### PR TITLE
Allow few-shot type to come from data file

### DIFF
--- a/nemo_skills/prompt/utils.py
+++ b/nemo_skills/prompt/utils.py
@@ -153,7 +153,7 @@ class Prompt:
 
     def build_examples_dict(self, input_dict):
         if self.config.few_shot_examples.examples_type:
-            return examples_map[self.config.few_shot_examples.examples_type]
+            return examples_map[self.config.few_shot_examples.examples_type.format(**input_dict)]
 
         if self.config.few_shot_examples.retriever is None:
             return []


### PR DESCRIPTION
In the config we'd need to set `examples_type: "{examples_type}"` and then use it like this

```python
from nemo_skills.prompt.utils import get_prompt
prompt = get_prompt('generic/math', 'qwen-instruct')
prompt.fill({'problem': '2x2?', 'examples_type': 'gsm8k_text_detailed'})
```