### PR TITLE
Various fixes

### DIFF
--- a/nemo_skills/pipeline/summarize_results.py
+++ b/nemo_skills/pipeline/summarize_results.py
@@ -242,13 +242,13 @@ def summarize_results(
                     k = int(k_match.group(1))
                     base_name = eval_mode.rsplit('@', 1)[0]
 
-                    # Store k and corresponding values for each metric
-                    for metric_key, metric_value in metrics.items():
-                        if metric_key != "num_entries":
-                            k_metrics[metric_key][base_name]["k"].append(k)
-                            k_metrics[metric_key][base_name]["value"].append(metric_value)
+                # Store k and corresponding values for each metric, but log everything
+                for metric_key, metric_value in metrics.items():
+                    if k_match and metric_key != "num_entries":
+                        k_metrics[metric_key][base_name]["k"].append(k)
+                        k_metrics[metric_key][base_name]["value"].append(metric_value)
 
-                        run.summary.update({f"{benchmark}/{eval_mode}/{metric_key}": metric_value})
+                    run.summary.update({f"{benchmark}/{eval_mode}/{metric_key}": metric_value})
 
             # Create combined plot per metric key (line series)
             for metric_key, eval_modes in k_metrics.items():

--- a/nemo_skills/training/data_preparation_utils/preprocessing.py
+++ b/nemo_skills/training/data_preparation_utils/preprocessing.py
@@ -267,12 +267,6 @@ class WriteFinalSftManifest(BaseProcessor):
         else:
             LOG.warning("Prompt details are missing! The processed data won't be formatted using any prompt.")
 
-        if self.chat_format and self.prompt is None:
-            error_str = ""
-            error_str += "prompt_config is missing! " if prompt_config is None else ""
-            error_str += "prompt_template is missing!" if prompt_template is None else ""
-            raise ValueError(f"chat_format requires prompt information: {error_str}")
-
     def process(self):
         samples_count = 0
         seen_predictions = defaultdict(set)
@@ -304,10 +298,15 @@ class WriteFinalSftManifest(BaseProcessor):
                         output_sample["output"] = generation + self.prompt.config.template.assistant_end
                     else:
                         output_sample["input"] = elem[self.input_key]
+                        output_sample["output"] = generation
 
                 elif self.chat_format.lower() == "nemotron":
                     output_sample['conversations'] = [
-                        {'value': self.prompt.config.user.format(**elem), 'from': 'User', 'canonical_form': ''},
+                        {
+                            'value': self.prompt.config.user.format(**elem) if self.prompt else elem[self.input_key],
+                            'from': 'User',
+                            'canonical_form': '',
+                        },
                         {'value': elem.pop(self.output_key), 'from': 'Assistant', 'canonical_form': ''},
                     ]
                     output_sample['system'] = self.prompt.config.system
@@ -315,7 +314,7 @@ class WriteFinalSftManifest(BaseProcessor):
                 elif self.chat_format.lower() == "llama":
                     output_sample['conversations'] = [
                         {
-                            'value': self.prompt.config.user.format(**elem),
+                            'value': self.prompt.config.user.format(**elem) if self.prompt else elem[self.input_key],
                             'from': '<|start_header_id|>user<|end_header_id|>',
                             'canonical_form': '',
                         },

--- a/nemo_skills/training/data_preparation_utils/preprocessing.py
+++ b/nemo_skills/training/data_preparation_utils/preprocessing.py
@@ -309,7 +309,7 @@ class WriteFinalSftManifest(BaseProcessor):
                         },
                         {'value': elem.pop(self.output_key), 'from': 'Assistant', 'canonical_form': ''},
                     ]
-                    output_sample['system'] = self.prompt.config.system
+                    output_sample['system'] = self.prompt.config.system if self.prompt else ''
                     output_sample['mask'] = 'User'
                 elif self.chat_format.lower() == "llama":
                     output_sample['conversations'] = [
@@ -324,7 +324,7 @@ class WriteFinalSftManifest(BaseProcessor):
                             'canonical_form': '',
                         },
                     ]
-                    output_sample['system'] = self.prompt.config.system
+                    output_sample['system'] = self.prompt.config.system if self.prompt else ''
                     output_sample['mask'] = '<|start_header_id|>user<|end_header_id|>'
                 else:
                     raise ValueError(f"Chat format {self.chat_format} is not supported")

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -60,6 +60,8 @@ def nested_dataclass(*args, **kwargs):
 
 
 def unroll_files(input_files):
+    if len(input_files) == 0:
+        raise ValueError("No files found with the given pattern.")
     for file_pattern in input_files:
         for file in sorted(glob.glob(file_pattern, recursive=True)):
             yield file

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -78,13 +78,13 @@ def test_eval_mtbench_api():
         f"ns eval "
         f"    --cluster test-local --config_dir {Path(__file__).absolute().parent / 'gpu-tests'} "
         f"    --server_type=openai "
-        f"    --model=meta/llama-3.1-405b-instruct "
+        f"    --model=meta/llama-3.1-8b-instruct "
         f"    --server_address=https://integrate.api.nvidia.com/v1 "
         f"    --benchmarks=mt-bench:0 "
         f"    --output_dir=/tmp/nemo-skills-tests/mtbench-api "
         f"    --extra_eval_args=\"++eval_config.use_batch_api=False "
         f"                        ++eval_config.base_url=https://integrate.api.nvidia.com/v1 "
-        f"                        ++eval_config.judge_model=meta/llama-3.1-405b-instruct\" "
+        f"                        ++eval_config.judge_model=meta/llama-3.1-8b-instruct\" "
         f"    ++max_samples=2 "
     )
     subprocess.run(cmd, shell=True, check=True)


### PR DESCRIPTION
1. Allow prepare sft data with chat format to not have config/template
2. Switch mtbench test to 8b model (still not working, but that's not the code problem)
3. Add a check in unroll files to raise an error if list is empty
4. Fix logging for non-@k metrics in summarize results to wandb