### PR TITLE
Handle dependencies for tasks that are finished 

### DIFF
--- a/nemo_skills/pipeline/run_cmd.py
+++ b/nemo_skills/pipeline/run_cmd.py
@@ -56,6 +56,7 @@ def run_cmd(
         help="Can specify a custom location for slurm logs. "
         "If not specified, will be inside `ssh_tunnel.job_dir` part of your cluster config.",
     ),
+    exclusive: bool = typer.Option(False, help="If True, will use --exclusive flag for slurm"),
 ):
     """Run a pre-defined module or script in the NeMo-Skills container."""
     setup_logging(disable_hydra_logs=False)
@@ -77,6 +78,7 @@ def run_cmd(
             time_min=time_min,
             run_after=run_after,
             num_gpus=num_gpus,
+            slurm_kwargs={"exclusive": exclusive} if exclusive else None,
         )
         run_exp(exp, cluster_config)
 

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -660,7 +660,6 @@ def get_executor(
             f"--ntasks={tasks_per_node * num_nodes}",
             f"--nodes={num_nodes}",
         ],
-        mem=0,
         job_details=CustomJobDetails(
             job_name=cluster_config.get("job_name_prefix", "") + job_name,
             folder=get_unmounted_path(cluster_config, log_dir),
@@ -719,11 +718,6 @@ def add_task(
     if num_gpus is None and cluster_config['executor'] == "slurm":
         if not 'cpu' in (partition or cluster_config.get("partition", "")):
             num_gpus = 1
-        # for cpu tasks always ask for the full node
-        # TODO: should we not do that? Is there any good way to figure out number of cores?
-        else:
-            slurm_kwargs = slurm_kwargs or {}
-            slurm_kwargs['exclusive'] = True
 
     commands = []
     executors = []

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -32,6 +32,7 @@ from nemo_run.core.execution.docker import DockerExecutor
 from nemo_run.core.execution.slurm import SlurmJobDetails
 from nemo_run.core.serialization.zlib_json import ZlibJSONSerializer
 from nemo_run.core.tunnel import SSHTunnel
+from torchx.specs.api import AppState
 
 LOG = logging.getLogger(__file__)
 
@@ -63,29 +64,28 @@ def _get_latest_dir(path, expname, job_id) -> str:
     return os.path.join(path, latest_dir)
 
 
-def get_exp_handles(expname):
-    # TODO: remove this after we can properly use .from_title api
-    job_id = None
-    if "_" in expname and expname.split("_")[-1].isdigit():
-        job_id = int(expname.split("_")[-1])
-        expname = expname[: expname.rfind("_")]
+def get_exp_handles(expname: str, ignore_finished=True) -> list[str]:
+    """Will return the handles of the tasks in the experiment.
 
-    parent_dir = os.path.join(NEMORUN_HOME, "experiments", expname)
-    exp_dir = _get_latest_dir(parent_dir, expname, job_id)
+    If ignore_finished=True, will only return handles for the tasks
+    that are not yet finished. Useful for filtering handles to set dependencies on.
+    """
+    try:
+        exp = run.Experiment.from_title(expname)
+    except FileNotFoundError:
+        try:
+            exp = run.Experiment.from_id(expname)
+        except FileNotFoundError:
+            raise ValueError(f"Experiment {expname} not found.")
 
-    with open(os.path.join(exp_dir, '_TASKS')) as f:
-        serialized_jobs = json.load(f)
-
-    serializer = ZlibJSONSerializer()
     handles = []
-    for job in serialized_jobs:
-        obj = serializer.deserialize(job[0])
-        if hasattr(obj, 'handle'):
-            handles.append(obj.handle)
-        elif hasattr(obj, 'handles'):
-            handles.extend(obj.handles)
-        else:
-            raise ValueError(f"Object {obj} does not have a handle or handles attribute.")
+    for job in exp.jobs:
+        if not ignore_finished or (
+            job.status(exp._runner) in [AppState.RUNNING, AppState.PENDING, AppState.SUBMITTED]
+        ):
+            handles.append(job.handle.split("/")[-1])
+            continue
+
     return handles
 
 
@@ -711,7 +711,14 @@ def add_task(
     if run_after is not None and cluster_config["executor"] == "slurm":
         if isinstance(run_after, str):
             run_after = [run_after]
-        dependencies = tuple([handle for exp_name in run_after for handle in get_exp_handles(exp_name)])
+        dependencies = []
+        for expname in run_after:
+            exp_handles = get_exp_handles(expname)
+            if len(exp_handles) == 0:
+                LOG.warning(f"No pending or running tasks found for experiment {expname}, cannot set dependencies.")
+            dependencies.extend(exp_handles)
+        if len(dependencies) == 0:
+            dependencies = None
     else:
         dependencies = None
 

--- a/nemo_skills/training/data_preparation_utils/filters.py
+++ b/nemo_skills/training/data_preparation_utils/filters.py
@@ -74,6 +74,7 @@ class BaseFilter(BaseParallelProcessor):
                 yield manifest_chunk
                 manifest_chunk = []
         if len(manifest_chunk) > 0:
+            LOG.info("Processing last chunk")
             yield manifest_chunk
 
 

--- a/nemo_skills/training/data_preparation_utils/filters.py
+++ b/nemo_skills/training/data_preparation_utils/filters.py
@@ -64,6 +64,18 @@ class BaseFilter(BaseParallelProcessor):
             num_modified_entries = sum(metric.get('num_modified', 0) for metric in metrics)
             LOG.info("Number of modified entries: %d", num_modified_entries)
 
+    def _chunk_manifest(self):
+        """Small modification of original function to print progress."""
+        manifest_chunk = []
+        for idx, data_entry in enumerate(self.read_manifest(), 1):
+            manifest_chunk.append(data_entry)
+            if idx % self.in_memory_chunksize == 0:
+                LOG.info("Processing chunk %d", idx)
+                yield manifest_chunk
+                manifest_chunk = []
+        if len(manifest_chunk) > 0:
+            yield manifest_chunk
+
 
 class DropMultiBoxed(BaseFilter):
     def __init__(self, solution_key: str = "generation", **kwargs):


### PR DESCRIPTION
Previously if you use run_after with some experiment that's already finished, job submission would fail. Now it would raise a warning instead, since it's very common for resuming long workflows to start from a middle task. This allows us to skip modifying code to remove run_after arguments for such cases