### PR TITLE
MAINT revert some changes leading to job instability

### DIFF
--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -664,6 +664,18 @@ def get_executor(
     else:
         timeout = cluster_config["timeouts"][partition]
 
+    srun_args = [
+        "--no-container-mount-home",
+        "--overlap",
+        "--mpi=pmix",
+        '--wait=10',
+        # we need to be explicit about this in srun as commands might need to run in parallel
+        f"--ntasks={tasks_per_node * num_nodes}",
+        f"--nodes={num_nodes}",
+    ]
+    if not cluster_config.get("disable_gpus_per_node", False):
+        srun_args.append(f"--gpus-per-node={gpus_per_node}")
+
     return run.SlurmExecutor(
         account=cluster_config["account"],
         partition=partition,
@@ -677,16 +689,7 @@ def get_executor(
         exclusive=True,
         packager=packager,
         gpus_per_node=gpus_per_node if not cluster_config.get("disable_gpus_per_node", False) else None,
-        srun_args=[
-            "--no-container-mount-home",
-            "--overlap",
-            "--mpi=pmix",
-            '--wait=10',
-            # we need to be explicit about this in srun as commands might need to run in parallel
-            f"--ntasks={tasks_per_node * num_nodes}",
-            f"--nodes={num_nodes}",
-            f"--gpus-per-node={gpus_per_node}",
-        ],
+        srun_args=srun_args,
         job_details=CustomJobDetails(
             job_name=cluster_config.get("job_name_prefix", "") + job_name,
             folder=get_unmounted_path(cluster_config, log_dir),

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -674,6 +674,7 @@ def get_executor(
         container_mounts=mounts,
         time=timeout,
         additional_parameters={'time_min': time_min} if time_min is not None else {},
+        exclusive=True,
         packager=packager,
         gpus_per_node=gpus_per_node if not cluster_config.get("disable_gpus_per_node", False) else None,
         srun_args=[
@@ -684,6 +685,7 @@ def get_executor(
             # we need to be explicit about this in srun as commands might need to run in parallel
             f"--ntasks={tasks_per_node * num_nodes}",
             f"--nodes={num_nodes}",
+            f"--gpus-per-node={gpus_per_node}",
         ],
         job_details=CustomJobDetails(
             job_name=cluster_config.get("job_name_prefix", "") + job_name,


### PR DESCRIPTION
* adds back exclusive flag until a fix for overlapping jobs can be patched in
* adds gpus per node flag, assuming we generally care that allocated GPUs are on the same node. If not set, GPUs can be given from across multiple nodes.