### PR TITLE
Port passthrough for generation servers

### DIFF
--- a/nemo_skills/inference/llm_math_judge.py
+++ b/nemo_skills/inference/llm_math_judge.py
@@ -142,6 +142,9 @@ def llm_math_judge(cfg: LlmMathJudgeConfig):
     # additionally, skipping whatever is pre-filled, assuming offset didn't change
     data = data[starting_idx:]
 
+    if len(data) == 0:  # we might not have any examples if skip_filled=True
+        return
+
     prompt = get_prompt(cfg.prompt_config, cfg.prompt_template, examples_type=cfg.examples_type)
     LOG.info("Prompt used: %s", prompt)
     LOG.info("Example prompt:\nData dictionary: %s\nPrompt: %s", data[0], prompt.fill(data[0]))

--- a/nemo_skills/inference/server/serve_nemo_reward_model.py
+++ b/nemo_skills/inference/server/serve_nemo_reward_model.py
@@ -57,7 +57,7 @@ def proxy_rm(cfg: RewardModelGenerationConfig) -> None:
 
         @app.route('/score', methods=['POST'])
         def infer():
-            client.wait_for_model()
+            client.wait_for_model(3600)
             data = request.json
             input_data = np.array([[obj.encode('utf-8')] for obj in data['prompts']], dtype=np.bytes_)
 

--- a/nemo_skills/inference/server/serve_nemo_reward_model.py
+++ b/nemo_skills/inference/server/serve_nemo_reward_model.py
@@ -54,17 +54,10 @@ def proxy_rm(cfg: RewardModelGenerationConfig) -> None:
 
         client = ModelClient(cfg.triton_server_address, "reward_model")
 
-        @app.before_request
-        def simulate_connection_failure_until_triton_healthy():
-            if not client.is_healthy():
-                abort(503)
-
-        @app.route('/', methods=['PUT'])
-        def health():
-            return jsonify({'status': 'ok'})
 
         @app.route('/score', methods=['POST'])
         def infer():
+            client.wait_for_model()
             data = request.json
             input_data = np.array([[obj.encode('utf-8')] for obj in data['prompts']], dtype=np.bytes_)
 

--- a/nemo_skills/pipeline/check_contamination.py
+++ b/nemo_skills/pipeline/check_contamination.py
@@ -21,6 +21,7 @@ import typer
 from nemo_skills.pipeline import add_task, check_if_mounted, get_cluster_config, get_generation_command, run_exp
 from nemo_skills.pipeline.app import app, typer_unpacker
 from nemo_skills.pipeline.generate import wrap_cmd
+from nemo_skills.pipeline.utils import get_free_port
 from nemo_skills.utils import setup_logging
 
 
@@ -109,7 +110,8 @@ def check_contamination(
 
     if server_address is None:  # we need to host the model
         assert server_gpus is not None, "Need to specify server_gpus if hosting the model"
-        server_address = "localhost:5000"
+        server_port = get_free_port()
+        server_address = f"localhost:{server_port}"
 
         server_config = {
             "model_path": model,
@@ -117,6 +119,7 @@ def check_contamination(
             "num_gpus": server_gpus,
             "num_nodes": server_nodes,
             "server_args": server_args,
+            "server_port": server_port,
         }
         extra_arguments += f" ++server.server_type={server_type} "
     else:  # model is hosted elsewhere

--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -23,6 +23,7 @@ import typer
 from nemo_skills.dataset.utils import get_dataset_module
 from nemo_skills.pipeline import add_task, check_if_mounted, get_cluster_config, get_generation_command, run_exp
 from nemo_skills.pipeline.app import app, typer_unpacker
+from nemo_skills.pipeline.utils import get_free_port, get_server_command
 from nemo_skills.utils import setup_logging
 
 LOG = logging.getLogger(__file__)
@@ -147,7 +148,8 @@ def eval(
 
     if server_address is None:  # we need to host the model
         assert server_gpus is not None, "Need to specify server_gpus if hosting the model"
-        server_address = "localhost:5000"
+        server_port = get_free_port()
+        server_address = f"localhost:{server_port}"
 
         server_config = {
             "model_path": model,
@@ -155,6 +157,7 @@ def eval(
             "num_gpus": server_gpus,
             "num_nodes": server_nodes,
             "server_args": server_args,
+            "server_port": server_port,
         }
         extra_arguments += f" ++server.server_type={server_type} "
     else:  # model is hosted elsewhere
@@ -217,6 +220,7 @@ def eval(
                 with_sandbox=True,
                 run_after=run_after,
                 extra_package_dirs=[extra_datasets] if extra_datasets else None,
+                get_server_command=get_server_command,
             )
         run_exp(exp, cluster_config)
 

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -296,7 +296,7 @@ def generate(
                     with_sandbox=True,
                     run_after=run_after,
                     task_dependencies=prev_tasks,
-                    get_server_command=partial(get_server_command, inference_port=server_port),
+                    get_server_command=partial(get_server_command, server_port=server_port),
                 )
                 prev_tasks = [new_task]
         run_exp(exp, cluster_config)

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -14,7 +14,6 @@
 
 import logging
 from enum import Enum
-from functools import partial
 from typing import List
 
 import nemo_run as run
@@ -134,6 +133,7 @@ def configure_client(generation_type, server_gpus, server_type, server_address, 
             "num_gpus": server_gpus,
             "num_nodes": server_nodes,
             "server_args": server_args,
+            "server_port": server_port,
         }
         extra_arguments += f" ++server.server_type={server_type} "
     else:  # model is hosted elsewhere
@@ -255,7 +255,7 @@ def generate(
                         with_sandbox=True,
                         run_after=run_after,
                         task_dependencies=prev_tasks,
-                        get_server_command=partial(get_server_command, server_port=server_port),
+                        get_server_command=get_server_command,
                     )
                     prev_tasks = [new_task]
         else:
@@ -296,7 +296,7 @@ def generate(
                     with_sandbox=True,
                     run_after=run_after,
                     task_dependencies=prev_tasks,
-                    get_server_command=partial(get_server_command, server_port=server_port),
+                    get_server_command=get_server_command,
                 )
                 prev_tasks = [new_task]
         run_exp(exp, cluster_config)

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -117,14 +117,6 @@ def configure_client(generation_type, server_gpus, server_type, server_address, 
     if server_address is None:  # we need to host the model
         server_port = get_free_port()
         assert server_gpus is not None, "Need to specify server_gpus if hosting the model"
-        # Note: for nemo reward models, the port is hard-coded to 5000 in the
-        # get_reward_server_command function. Since RM has a proxy server on 5000
-        # and an actual GPU is being loaded on port 5001, we need to wait for 5001
-        # to come online before sending requests
-
-        # if generation_type == GenerationType.reward and server_type == SupportedServers.nemo:
-        #     server_address = "localhost:5001"
-        # else:
         server_address = f"localhost:{server_port}"
 
         server_config = {

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -14,6 +14,7 @@
 
 import logging
 from enum import Enum
+from functools import partial
 from typing import List
 
 import nemo_run as run
@@ -21,7 +22,7 @@ import typer
 
 from nemo_skills.pipeline import add_task, check_if_mounted, get_cluster_config, get_generation_command, run_exp
 from nemo_skills.pipeline.app import app, typer_unpacker
-from nemo_skills.pipeline.utils import get_reward_server_command, get_server_command
+from nemo_skills.pipeline.utils import get_reward_server_command, get_server_command, get_free_port
 from nemo_skills.utils import setup_logging
 
 LOG = logging.getLogger(__file__)
@@ -113,6 +114,35 @@ client_command_factories = {
     GenerationType.math_judge: get_math_judge_cmd,
 }
 
+def configure_client(generation_type, server_gpus, server_type, server_address, server_port, server_nodes, model, server_args, extra_arguments):
+    if server_address is None:  # we need to host the model
+        server_port = get_free_port()
+        assert server_gpus is not None, "Need to specify server_gpus if hosting the model"
+        # Note: for nemo reward models, the port is hard-coded to 5000 in the
+        # get_reward_server_command function. Since RM has a proxy server on 5000
+        # and an actual GPU is being loaded on port 5001, we need to wait for 5001
+        # to come online before sending requests
+
+        # if generation_type == GenerationType.reward and server_type == SupportedServers.nemo:
+        #     server_address = "localhost:5001"
+        # else:
+        server_address = f"localhost:{server_port}"
+
+        server_config = {
+            "model_path": model,
+            "server_type": server_type,
+            "num_gpus": server_gpus,
+            "num_nodes": server_nodes,
+            "server_args": server_args,
+        }
+        extra_arguments += f" ++server.server_type={server_type} "
+    else:  # model is hosted elsewhere
+        server_config = None
+        extra_arguments += (
+            f" ++server.server_type={server_type} ++server.base_url={server_address} ++server.model={model} "
+        )
+        server_port = None
+    return server_config, extra_arguments, server_address, server_port
 
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 @typer_unpacker
@@ -180,37 +210,25 @@ def generate(
     else:
         log_dir = f"{output_dir}/generation-logs"
 
-    if server_address is None:  # we need to host the model
-        assert server_gpus is not None, "Need to specify server_gpus if hosting the model"
-        # Note: for nemo reward models, the port is hard-coded to 5000 in the
-        # get_reward_server_command function. Since RM has a proxy server on 5000
-        # and an actual GPU is being loaded on port 5001, we need to wait for 5001
-        # to come online before sending requests
-        if generation_type == GenerationType.reward and server_type == SupportedServers.nemo:
-            server_address = "localhost:5001"
-        else:
-            server_address = "localhost:5000"
-
-        server_config = {
-            "model_path": model,
-            "server_type": server_type,
-            "num_gpus": server_gpus,
-            "num_nodes": server_nodes,
-            "server_args": server_args,
-        }
-        extra_arguments += f" ++server.server_type={server_type} "
-    else:  # model is hosted elsewhere
-        server_config = None
-        extra_arguments += (
-            f" ++server.server_type={server_type} ++server.base_url={server_address} ++server.model={model} "
-        )
-
     get_server_command = server_command_factories[generation_type]
     get_cmd = client_command_factories[generation_type]
 
     with run.Experiment(expname) as exp:
         if random_seeds:
             for seed in random_seeds:
+                server_port = get_free_port()
+                server_config, extra_arguments, server_address, server_port = configure_client(
+                    generation_type=generation_type,
+                    server_gpus=server_gpus,
+                    server_type=server_type,
+                    server_address=server_address,
+                    server_port=server_port,
+                    server_nodes=server_nodes,
+                    model=model,
+                    server_args=server_args,
+                    extra_arguments=extra_arguments,
+                )
+
                 cmd = get_cmd(
                     random_seed=seed,
                     output_dir=output_dir,
@@ -237,10 +255,22 @@ def generate(
                         with_sandbox=True,
                         run_after=run_after,
                         task_dependencies=prev_tasks,
-                        get_server_command=get_server_command,
+                        get_server_command=partial(get_server_command, inference_port=server_port),
                     )
                     prev_tasks = [new_task]
         else:
+            server_port = get_free_port()
+            server_config, extra_arguments, server_address, server_port = configure_client(
+                generation_type=generation_type,
+                server_gpus=server_gpus,
+                server_type=server_type,
+                server_address=server_address,
+                server_port=server_port,
+                server_nodes=server_nodes,
+                model=model,
+                server_args=server_args,
+                extra_arguments=extra_arguments,
+            )
             cmd = get_cmd(
                 random_seed=None,
                 output_dir=output_dir,
@@ -266,7 +296,7 @@ def generate(
                     with_sandbox=True,
                     run_after=run_after,
                     task_dependencies=prev_tasks,
-                    get_server_command=get_server_command,
+                    get_server_command=partial(get_server_command, inference_port=server_port),
                 )
                 prev_tasks = [new_task]
         run_exp(exp, cluster_config)

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -255,7 +255,7 @@ def generate(
                         with_sandbox=True,
                         run_after=run_after,
                         task_dependencies=prev_tasks,
-                        get_server_command=partial(get_server_command, inference_port=server_port),
+                        get_server_command=partial(get_server_command, server_port=server_port),
                     )
                     prev_tasks = [new_task]
         else:

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -18,6 +18,7 @@ import typer
 
 from nemo_skills.pipeline import add_task, check_if_mounted, get_cluster_config
 from nemo_skills.pipeline.app import app, typer_unpacker
+from nemo_skills.pipeline.utils import get_free_port
 from nemo_skills.utils import setup_logging
 
 
@@ -71,6 +72,7 @@ def start_server(
         "num_gpus": server_gpus,
         "num_nodes": server_nodes,
         "server_args": server_args,
+        "server_port": get_free_port(),
     }
 
     with run.Experiment("server") as exp:

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -776,7 +776,7 @@ def add_task(
     executors = []
     # assuming server always has the largest resources request, so it needs to go first
     if server_config is not None:
-        server_port = server_config.pop("server_port", 5000)
+        server_port = server_config["server_port"]
         server_cmd, num_server_tasks = get_server_command(**server_config, server_port=server_port, cluster_config=cluster_config)
         if 'container' not in server_config:
             server_container = cluster_config["containers"][server_config['server_type']]

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -189,7 +189,7 @@ def get_server_command(
     num_nodes: int,
     model_path: str,
     cluster_config: dict,
-    server_port: int = 5000,
+    server_port: int,
     server_args: str = "",
 ):
     num_tasks = num_gpus
@@ -776,8 +776,7 @@ def add_task(
     executors = []
     # assuming server always has the largest resources request, so it needs to go first
     if server_config is not None:
-        server_port = server_config["server_port"]
-        server_cmd, num_server_tasks = get_server_command(**server_config, server_port=server_port, cluster_config=cluster_config)
+        server_cmd, num_server_tasks = get_server_command(**server_config, cluster_config=cluster_config)
         if 'container' not in server_config:
             server_container = cluster_config["containers"][server_config['server_type']]
         server_executor = get_executor(

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -189,7 +189,7 @@ def get_server_command(
     num_nodes: int,
     model_path: str,
     cluster_config: dict,
-    server_port: int,
+    server_port: int = 5000,
     server_args: str = "",
 ):
     num_tasks = num_gpus
@@ -776,7 +776,8 @@ def add_task(
     executors = []
     # assuming server always has the largest resources request, so it needs to go first
     if server_config is not None:
-        server_cmd, num_server_tasks = get_server_command(**server_config, cluster_config=cluster_config)
+        server_port = server_config.pop("port", 5000)
+        server_cmd, num_server_tasks = get_server_command(**server_config, server_port=server_port, cluster_config=cluster_config)
         if 'container' not in server_config:
             server_container = cluster_config["containers"][server_config['server_type']]
         server_executor = get_executor(

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -776,7 +776,7 @@ def add_task(
     executors = []
     # assuming server always has the largest resources request, so it needs to go first
     if server_config is not None:
-        server_port = server_config.pop("port", 5000)
+        server_port = server_config.pop("server_port", 5000)
         server_cmd, num_server_tasks = get_server_command(**server_config, server_port=server_port, cluster_config=cluster_config)
         if 'container' not in server_config:
             server_container = cluster_config["containers"][server_config['server_type']]


### PR DESCRIPTION
This PR modifies server startups to take a passed port instead of hard-coded values. The `get_free_port` method will be updated in a future PR to change port configuration strategies from static to random to avoid collisions.