### PR TITLE
Automatically reusing previously submitted experiment

### DIFF
--- a/docs/openmathinstruct2/dataset.md
+++ b/docs/openmathinstruct2/dataset.md
@@ -113,9 +113,8 @@ from nemo_skills.pipeline.cli import generate
 
 # we generated 80 new problems from each original seed problem, so we have a loop
 # to now generate 32 solutions for each of those 80 new data files
-exp = None
 for i in range(80):
-    exp = generate(
+    generate(
         cluster="slurm",
         server_type="trtllm",
         model="/trt_models/llama-3.1-405b-instruct",
@@ -129,7 +128,6 @@ for i in range(80):
             f"++examples_type=math_text_detailed "
             f"++prompt_template=llama3-base "
         ),
-        reuse_code_exp=exp,
     )
 ```
 
@@ -141,7 +139,6 @@ from nemo_skills.pipeline.cli import generate
 
 # we generated 10 new problems from each original seed problem, so we have a loop
 # to now generate 32 solutions for each of those 10 new data files
-exp = None
 for i in range(10):
     generate(
         cluster="slurm",
@@ -157,7 +154,6 @@ for i in range(10):
             f"++examples_type=gsm8k_text_detailed "
             f"++prompt_template=llama3-base "
         ),
-        reuse_code_exp=exp,
     )
 ```
 
@@ -173,7 +169,6 @@ from nemo_skills.pipeline.cli import run_cmd
 
 # for MATH
 data_folder = "/workspace/new-problems-solution-augmentation/math"
-exp = None
 # if you want to avoid scheduling many jobs, you can instead
 # create one big cmd and run it directly to handle all files
 # or you can create a new script and reference it with
@@ -183,10 +178,9 @@ for i in range(80):
         f'python -m nemo_skills.evaluation.fill_majority_answer '
         f'    ++input_files="{data_folder}/problem-set{i}/generation/output-rs*.jsonl" '
     )
-    exp = run_cmd(
+    run_cmd(
         cluster="slurm",
         ctx=wrap_arguments(cmd),
-        reuse_code_exp=exp,
         log_dir=f'{data_folder}/problem-set{i}/fill-majority-logs'
         # if cluster has a cpu partition you can specify it with a `partition` parameter
     )
@@ -198,10 +192,9 @@ for i in range(10):
         f'python -m nemo_skills.evaluation.fill_majority_answer '
         f'    ++input_files="{data_folder}/problem-set{i}/generation/output-rs*.jsonl" '
     )
-    exp = run_cmd(
+    run_cmd(
         cluster="slurm",
         ctx=wrap_arguments(cmd),
-        reuse_code_exp=exp,
         log_dir=f'{data_folder}/problem-set{i}/fill-majority-logs'
         # if cluster has a cpu partition you can specify it with a `partition` parameter
     )

--- a/docs/pipelines/training.md
+++ b/docs/pipelines/training.md
@@ -117,9 +117,8 @@ from nemo_skills.pipeline.cli import train, convert, eval
 expname = "my-training-job"
 cluster = "slurm"
 output_dir = f"/workspace/{expname}/checkpoints"
-exp = None
 
-exp = train(
+train(
     ctx=wrap_arguments(""),
     cluster=cluster,
     expname=expname,
@@ -129,10 +128,9 @@ exp = train(
     num_gpus=8,
     num_training_jobs=4,
     training_data="/data/sft-data.jsonl",
-    reuse_code_exp=exp,
 )
 
-exp = convert(
+convert(
     ctx=wrap_arguments(""),
     cluster=cluster,
     input_model=f"{output_dir}/model-averaged-nemo",
@@ -144,10 +142,9 @@ exp = convert(
     model_type="llama",
     num_gpus=8,
     hf_model_name="meta-llama/Meta-Llama-3.1-8B",
-    reuse_code_exp=exp,
 )
 
-exp = convert(
+convert(
     ctx=wrap_arguments(""),
     cluster=cluster,
     input_model=f"{output_dir}/model-averaged-hf",
@@ -158,10 +155,9 @@ exp = convert(
     convert_to="trtllm",
     model_type="llama",
     num_gpus=8,
-    reuse_code_exp=exp,
 )
 
-exp = eval(
+eval(
     ctx=wrap_arguments("++prompt_template=llama3-instruct ++batch_size=512"),
     cluster=cluster,
     model=f"{output_dir}/model-averaged-trtllm",
@@ -170,6 +166,5 @@ exp = eval(
     benchmarks="gsm8k:0,math:0",
     server_gpus=8,
     run_after=f"{expname}-to-trtllm",
-    reuse_code_exp=exp,
 )
 ```

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -944,7 +944,7 @@ def run_exp(exp, cluster_config, sequential=None):
     else:
         exp.run(detach=True, sequential=False if sequential is None else sequential)
 
-    # caching the experiment code for reuse
-    ssh_hash = tunnel_hash(get_tunnel(cluster_config))
-    if ssh_hash not in REUSE_CODE_EXP:
-        REUSE_CODE_EXP[ssh_hash] = exp
+        # caching the experiment code for reuse
+        ssh_hash = tunnel_hash(get_tunnel(cluster_config))
+        if ssh_hash not in REUSE_CODE_EXP:
+            REUSE_CODE_EXP[ssh_hash] = exp

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -901,8 +901,8 @@ def add_task(
             )
             executors.append(sandbox_executor)
 
-    tunnel = get_tunnel(cluster_config)
     if cluster_config["executor"] != "local":
+        tunnel = get_tunnel(cluster_config)
         if reuse_code:
             reuse_code_exp = reuse_code_exp or REUSE_CODE_EXP.get(tunnel_hash(tunnel))
             if reuse_code_exp is not None:

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -36,6 +36,12 @@ from torchx.specs.api import AppState
 LOG = logging.getLogger(__file__)
 
 
+# keeping a global variable for first submitted experiment (per cluster) and reusing it by default
+# we are using ssh tunnel as a proxy for cluster identity, since even if other parameters are different
+# we can still reuse code as long as ssh matches
+REUSE_CODE_EXP = {}
+
+
 def check_if_mounted(cluster_config, path_to_check):
     """Will check that path_to_check is referenced inside one of the mounts."""
     for mount in get_mounts_from_config(cluster_config) + ['/nemo_run/code:/nemo_run/code']:
@@ -364,6 +370,10 @@ def _get_tunnel_cached(
     )
 
 
+def tunnel_hash(tunnel):
+    return f"{tunnel.job_dir}:{tunnel.host}:{tunnel.user}:{tunnel.identity}:{tunnel.shell}:{tunnel.pre_command}"
+
+
 def get_tunnel(cluster_config):
     return _get_tunnel_cached(**cluster_config["ssh_tunnel"])
 
@@ -479,7 +489,6 @@ def cluster_upload(tunnel: SSHTunnel, local_file: str, remote_dir: str, verbose:
     print(f"\nTransfer complete")
 
 
-@lru_cache
 def get_packager(extra_package_dirs: tuple[str] | None = None):
     """Will check if we are running from a git repo and use git packager or default packager otherwise."""
     nemo_skills_dir = Path(__file__).absolute().parents[1]
@@ -591,7 +600,7 @@ def get_env_variables(cluster_config):
     return env_vars
 
 
-def get_mounts_from_config(cluster_config: dict, env_vars: dict = None):
+def get_mounts_from_config(cluster_config: dict):
     """
     Determines if there are mount paths that are being passed via environment variables.
     Selects the key in the cluster config called `mounts` which is a list of strings.
@@ -600,7 +609,6 @@ def get_mounts_from_config(cluster_config: dict, env_vars: dict = None):
 
     Args:
         cluster_config (dict): cluster config dictionary
-        env_vars (dict): dictionary of environment variables
 
     Returns:
         list: updated list of mounts
@@ -662,7 +670,7 @@ def get_executor(
     slurm_kwargs: dict | None = None,
 ):
     env_vars = get_env_variables(cluster_config)
-    config_mounts = get_mounts_from_config(cluster_config, env_vars)
+    config_mounts = get_mounts_from_config(cluster_config)
 
     mounts = mounts or config_mounts
     if extra_package_dirs is not None:
@@ -769,6 +777,7 @@ def add_task(
     sandbox_port: int | None = None,
     server_config=None,
     reuse_code_exp: str | run.Experiment | None = None,
+    reuse_code: bool = True,
     task_dependencies: list[str] = None,
     run_after: str | list[str] | None = None,
     get_server_command=get_server_command,
@@ -792,6 +801,9 @@ def add_task(
     You can use `reuse_code_exp` to reuse the code from another experiment
     (and thus avoid costly packaging/ssh uploading). You can provide either experiment
     name or the experiment object itself.
+
+    By default we will reuse the code of the first submitted experiment.
+    If you want to avoid this, set `reuse_code=False`.
     """
     if run_after is not None and cluster_config["executor"] == "slurm":
         if isinstance(run_after, str):
@@ -889,17 +901,21 @@ def add_task(
             )
             executors.append(sandbox_executor)
 
-    if reuse_code_exp is not None:
-        tunnel = get_tunnel(cluster_config)
-        if isinstance(reuse_code_exp, run.Experiment):
-            LOG.info("Reusing code from experiment %s", reuse_code_exp._title)
-            reuse_dir = reuse_code_exp.tunnels[tunnel.key].packaging_jobs['nemo-run'].dst_path
-        else:
-            with run.Experiment.from_title(reuse_code_exp) as reuse_exp:
-                LOG.info("Reusing code from experiment %s", reuse_code_exp)
-                reuse_dir = reuse_exp.tunnels[tunnel.key].packaging_jobs['nemo-run'].dst_path
-        for executor in executors:
-            executor.packager.symlink_from_remote_dir = reuse_dir
+    tunnel = get_tunnel(cluster_config)
+    if reuse_code:
+        reuse_code_exp = reuse_code_exp or REUSE_CODE_EXP.get(tunnel_hash(tunnel))
+        if reuse_code_exp is not None:
+            if isinstance(reuse_code_exp, run.Experiment):
+                LOG.info("Reusing code from experiment %s", reuse_code_exp._title)
+                reuse_dir = reuse_code_exp.tunnels[tunnel.key].packaging_jobs['nemo-run'].dst_path
+            else:
+                with run.Experiment.from_title(reuse_code_exp) as reuse_exp:
+                    LOG.info("Reusing code from experiment %s", reuse_code_exp)
+                    reuse_dir = reuse_exp.tunnels[tunnel.key].packaging_jobs['nemo-run'].dst_path
+            for executor in executors:
+                executor.packager.symlink_from_remote_dir = reuse_dir
+    else:  # if current is not reused, we are refreshing the cache as there is a reason to believe it's outdated
+        REUSE_CODE_EXP.pop(tunnel_hash(tunnel), None)
 
     if len(commands) == 1:
         # to keep sbatch script simpler, we don't wrap in a list in this case
@@ -927,3 +943,8 @@ def run_exp(exp, cluster_config, sequential=None):
         exp.run(detach=False, tail_logs=True, sequential=True if sequential is None else sequential)
     else:
         exp.run(detach=True, sequential=False if sequential is None else sequential)
+
+    # caching the experiment code for reuse
+    ssh_hash = tunnel_hash(get_tunnel(cluster_config))
+    if ssh_hash not in REUSE_CODE_EXP:
+        REUSE_CODE_EXP[ssh_hash] = exp


### PR DESCRIPTION
If multiple experiments are submitted from the same python script, we automatically reuse the code to avoid re-uploading, since it's very unlikely to change (and there is an opt-out for edge cases)