### PR TITLE
Error handling

### DIFF
--- a/nemo_skills/inference/server/reward_model.py
+++ b/nemo_skills/inference/server/reward_model.py
@@ -132,7 +132,7 @@ class VLLMRewardModel(BaseModel):
             print(f"Tokenization error: {ve}")
         except KeyError as ke:
             # Returned output is not adhering to the expected output format
-            print("Output fmt error: {ke}")
+            print(f"Output fmt error: {ke}")
             print(output)
 
         if per_token_scores is None:

--- a/nemo_skills/inference/server/reward_model.py
+++ b/nemo_skills/inference/server/reward_model.py
@@ -19,10 +19,9 @@ import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from enum import Enum
 
-import httpx
 import openai
 import requests
-from openai import BadRequestError, DefaultHttpxClient, OpenAI
+from openai import BadRequestError, OpenAI
 
 LOG = logging.getLogger(__file__)
 
@@ -98,16 +97,10 @@ class VLLMRewardModel(BaseModel):
         if self.ssh_server and self.ssh_key_path:
             raise NotImplementedError("SSH tunnelling is not implemented for vLLM model.")
 
-        http_client = DefaultHttpxClient(
-            limits=httpx.Limits(max_keepalive_connections=1500, max_connections=1500),
-            transport=httpx.HTTPTransport(retries=3),
-        )
-
         self.oai_client = openai.OpenAI(
             api_key="EMPTY",
             base_url=f"http://{self.server_host}:{self.server_port}/v1",
             timeout=None,
-            http_client=http_client,
         )
 
         # Reward models are accessed via the "pooling" interface
@@ -121,23 +114,26 @@ class VLLMRewardModel(BaseModel):
         """Score a single prompt"""
 
         per_token_scores = None
+        inference_error = ""
         try:
             response = requests.post(self.request_url, json={"input": prompt, "model": self.model})
             output = response.json()
             per_token_scores = output['data'][0]['data']
         except requests.exceptions.HTTPError as err:
-            print(f"Request failed: {err}")
+            inference_error = f"Request failed: {err}"
         except ValueError as ve:
             # Could be that the sequence exceeds the maximum context length
-            print(f"Tokenization error: {ve}")
+            inference_error = f"Tokenization error: {ve}"
         except KeyError as ke:
             # Returned output is not adhering to the expected output format
-            print(f"Output fmt error: {ke}")
-            print(output)
+            inference_error = f"Output fmt error: {ke}\n{output}"
+
+        if inference_error:
+            LOG.warning(inference_error)
 
         if per_token_scores is None:
             # Return a trivial reward model score
-            return {"reward_model_score": 0.0}
+            return {"reward_model_score": 0.0, "inference_error": inference_error}
 
         last_token_score = per_token_scores[-1]
         score = None

--- a/nemo_skills/pipeline/check_contamination.py
+++ b/nemo_skills/pipeline/check_contamination.py
@@ -95,7 +95,6 @@ def check_contamination(
     exclusive: bool = typer.Option(
         True,
         "--not_exclusive",
-        is_flag=True,
         help="If --not_exclusive is used, will NOT use --exclusive flag for slurm",
     ),
 ):

--- a/nemo_skills/pipeline/convert.py
+++ b/nemo_skills/pipeline/convert.py
@@ -191,7 +191,6 @@ def convert(
     exclusive: bool = typer.Option(
         True,
         "--not_exclusive",
-        is_flag=True,
         help="If --not_exclusive is used, will NOT use --exclusive flag for slurm",
     ),
 ):

--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -164,7 +164,11 @@ def eval(
         help="Path to a custom dataset folder that will be searched in addition to the main one. "
         "Can also specify through NEMO_SKILLS_EXTRA_DATASETS.",
     ),
-    exclusive: bool = typer.Option(False, help="If True, will use --exclusive flag for slurm"),
+    exclusive: bool = typer.Option(
+        True,
+        "--not_exclusive",
+        help="If --not_exclusive is used, will NOT use --exclusive flag for slurm",
+    ),
 ):
     """Evaluate a model on specified benchmarks.
 

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -228,7 +228,6 @@ def generate(
     exclusive: bool = typer.Option(
         True,
         "--not_exclusive",
-        is_flag=True,
         help="If --not_exclusive is used, will NOT use --exclusive flag for slurm",
     ),
 ):

--- a/nemo_skills/pipeline/run_cmd.py
+++ b/nemo_skills/pipeline/run_cmd.py
@@ -74,7 +74,6 @@ def run_cmd(
     exclusive: bool = typer.Option(
         True,
         "--not_exclusive",
-        is_flag=True,
         help="If --not_exclusive is used, will NOT use --exclusive flag for slurm",
     ),
 ):

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -56,7 +56,6 @@ def start_server(
     exclusive: bool = typer.Option(
         True,
         "--not_exclusive",
-        is_flag=True,
         help="If --not_exclusive is used, will NOT use --exclusive flag for slurm",
     ),
     get_random_port: bool = typer.Option(False, help="If True, will get a random port for the server"),

--- a/nemo_skills/pipeline/train.py
+++ b/nemo_skills/pipeline/train.py
@@ -250,7 +250,6 @@ def train(
     exclusive: bool = typer.Option(
         True,
         "--not_exclusive",
-        is_flag=True,
         help="If --not_exclusive is used, will NOT use --exclusive flag for slurm",
     ),
 ):


### PR DESCRIPTION
Reward model calls can fail for a variety of reasons, such as the input sequence going beyond the model's max length. This PR adds error handling which was missing. 