### PR TITLE
Support batch processing aync inference

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -67,7 +67,7 @@ class GenerateSolutionsConfig:
     max_samples: int = -1  # If > 0, will stop after generating this many samples. Useful for debugging
     skip_filled: bool = False  # If True, will skip the generations that are already in the output file
 
-    max_concurrent_requests: int = 128  # Maximum number of concurrent requests to the server for the async loop
+    max_concurrent_requests: int = 1024  # Maximum number of concurrent requests to the server for the async loop
     # chunk the dataset into equal sized parts and index into them
     num_chunks: int | None = None  # if specified, will split the data into chunks and only generate for one chunk
     chunk_id: int | None = None  # if specified, will index the specified chunk only

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -29,6 +29,7 @@ from nemo_skills.code_execution.sandbox import get_sandbox, sandbox_params
 from nemo_skills.inference.server.code_execution_model import get_code_execution_model, get_model, server_params
 from nemo_skills.prompt.utils import get_prompt
 from nemo_skills.utils import chunk_data, get_fields_docstring, get_help_message, nested_dataclass, setup_logging
+from collections import deque
 
 LOG = logging.getLogger(__file__)
 
@@ -306,6 +307,8 @@ def async_loop(cfg, data, llm, prompt, extra_stop_phrases, extra_generate_params
                         
                     # Prepare the result for writing
                     gen_dict[cfg.generation_key] = gen_dict.pop("generation")
+                    for key in gen_dict:
+                        data[idx].pop(key, None)
                     gen_dict.update(data[idx])
                     
                     # Insert the async position to preserve the original order

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -286,7 +286,7 @@ def async_loop(cfg, data, llm, prompt, extra_stop_phrases, extra_generate_params
         )
 
         # Store the request IDs returned by LLM
-        for i, idx in enumerate(batch_indices):
+        for idx in batch_indices:
             in_progress[idx] = batch_ids[i]
 
         # **Step 3: Monitor and refill requests dynamically**

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -287,7 +287,7 @@ def async_loop(cfg, data, llm, prompt, extra_stop_phrases, extra_generate_params
 
         # Store the request IDs returned by LLM
         for idx in batch_indices:
-            in_progress[idx] = batch_ids[i]
+            in_progress[idx] = idx
 
         # **Step 3: Monitor and refill requests dynamically**
         while in_progress or request_queue:  # Continue until all tasks are complete

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -258,9 +258,8 @@ def async_loop(cfg, data, llm, prompt, extra_stop_phrases, extra_generate_params
     if len(data) == 0:  # we might not have any examples if skip_filled=True
         return
 
-    LOG.warning("Maintaining 1000 concurrent requests throughout execution.")
+    LOG.warning(f"Async loop is maintaining {cfg.max_concurrent_requests} concurrent requests throughout execution -- batch_size parameter is ignored!.")
 
-    
     
     request_queue = list(range(len(data)))  # Queue of unsubmitted task indices
     in_progress = {}  # Track ongoing requests {index: generation_id}
@@ -270,12 +269,12 @@ def async_loop(cfg, data, llm, prompt, extra_stop_phrases, extra_generate_params
     with open(cfg.output_file + "-async", "at" if cfg.skip_filled else "wt", encoding="utf-8", buffering=1) as fout:
         pbar = tqdm(total=len(data), desc="Processing requests")
 
-        # **Step 1: Pre-fill `in_progress` with the first 2000 tasks**
+        # **Step 1: Pre-fill `in_progress` with the first max_concurrent_requests request**
         while len(in_progress) < cfg.max_concurrent_requests and request_queue:
             idx = request_queue.pop(0)
             in_progress[idx] = None  # Placeholder for reservation
 
-        # **Step 2: Submit first 1000 requests as a batch**
+        # **Step 2: Submit first max_concurrent_requests requests as a batch**
         batch_indices = list(in_progress.keys())  # Get reserved indices
         batch_prompts = [prompt.fill(data[idx]) for idx in batch_indices]  # Prepare prompts
 

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -326,7 +326,7 @@ def async_loop(cfg, data, llm, prompt, extra_stop_phrases, extra_generate_params
                 del in_progress[idx]
 
             
-            # **Step 4: Refill requests to maintain exactly 1000 concurrent tasks**
+            # **Step 4: Refill requests to maintain exactly N concurrent tasks**
             num_to_submit = cfg.max_concurrent_requests - len(in_progress)
             batch_indices = [request_queue.pop(0) for _ in range(min(num_to_submit, len(request_queue)))]
             batch_prompts = [prompt.fill(data[idx]) for idx in batch_indices]

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -298,8 +298,7 @@ def async_loop(cfg, data, llm, prompt, extra_stop_phrases, extra_generate_params
             
             for (idx, gen_id), gen_dict in zip(remaining_ids.items(), generations):
                 if gen_dict['generation'] is not None:
-                    # Mark task as completed
-                    completed_tasks.append(idx)
+                    # remove the completed task from in_progress
                     del in_progress[idx]
                                             
                     # Prepare the result for writing

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -260,7 +260,7 @@ def async_loop(cfg, data, llm, prompt, extra_stop_phrases, extra_generate_params
         return
 
     LOG.warning(f"Async loop is maintaining {cfg.max_concurrent_requests} concurrent requests throughout execution -- batch_size parameter is ignored!.")
-
+    LOG.warning("Users can set '++max_concurrent_requests' to control the number of concurrent requests.")
     
     request_queue = deque(range(len(data)))  # Queue of unsubmitted task indices
     in_progress = {}  # Track ongoing requests {index: generation_id}

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -149,22 +149,16 @@ class BaseModel(abc.ABC):
             if not is_list:
                 kwargs[key] = [value for _ in range(len(prompts))]
 
-        futures = []
+        gen_ids = []
         for request_idx in range(len(prompts)):
+            # Prepare request
             request = {key: value[request_idx] for key, value in kwargs.items()}
             request['prompt'] = prompts[request_idx]
             self.preprocess_request(request)
-            futures.append(self.executor.submit(self._generate_single, **request))
-        
-        gen_ids = []
 
-        new_gen_id_to_params = {}  # Stores generation parameters for the current batch
-
-        # Generate unique IDs for each future and store them
-        for future in futures:
             gen_id = str(uuid.uuid4())  # Generate a unique generation ID
             gen_ids.append(gen_id)
-            self.gen_id_to_future[gen_id] = future  # Store the future in the dictionary
+            self.gen_id_to_future[gen_id] = self.executor.submit(self._generate_single, **request)
 
         # Construct new_gen_id_to_params mapping gen_id to stop_phrases and remove_stop_phrases
         new_gen_id_to_params = {
@@ -174,15 +168,9 @@ class BaseModel(abc.ABC):
 
         # Update global dictionaries to retain existing data while adding new entries
         self.gen_id_to_params.update(new_gen_id_to_params)
-        
-        
         return gen_ids
 
-    def get_generations(
-        self,
-        generation_ids: list[str],
-    ) -> list[dict]:
-
+    def get_generations(self, generation_ids: list[str]) -> list[dict]:
         generations = []
         for generation_id in generation_ids:
             if generation_id not in self.gen_id_to_future:
@@ -381,22 +369,17 @@ class TRTLLMModel(BaseModel):
                 self.preprocess_request(request)
                 futures.append(executor.submit(self._generate_single_async, **request))
         outputs = [future.result() for future in futures]
-        
-        
+
         new_gen_id_to_params = {
             gen_id: (req_stop_phrases, remove_stop_phrases)
             for gen_id, req_stop_phrases in zip(outputs, kwargs["stop_phrases"])
         }
-        
+
         self.gen_id_to_params.update(new_gen_id_to_params)
 
         return outputs
 
-    def cancel_generations(
-        self,
-        generation_ids: list[str],
-    ) -> list[str]:
-
+    def cancel_generations(self, generation_ids: list[str]) -> list[str]:
         statuses = []
         for generation_id in generation_ids:
             request = {
@@ -411,11 +394,7 @@ class TRTLLMModel(BaseModel):
 
         return statuses
 
-    def get_generations(
-        self,
-        generation_ids: list[str],
-    ) -> list[dict]:
-
+    def get_generations(self, generation_ids: list[str]) -> list[dict]:
         generations = []
         for generation_id in generation_ids:
             request = {

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -157,14 +157,14 @@ class BaseModel(abc.ABC):
             futures.append(self.executor.submit(self._generate_single, **request))
         
         gen_ids = []
-        new_gen_id_to_future = {}  # Stores futures for the current batch
+
         new_gen_id_to_params = {}  # Stores generation parameters for the current batch
 
         # Generate unique IDs for each future and store them
         for future in futures:
             gen_id = str(uuid.uuid4())  # Generate a unique generation ID
             gen_ids.append(gen_id)
-            new_gen_id_to_future[gen_id] = future  # Store the future in the dictionary
+            self.gen_id_to_future[gen_id] = future  # Store the future in the dictionary
 
         # Construct new_gen_id_to_params mapping gen_id to stop_phrases and remove_stop_phrases
         new_gen_id_to_params = {
@@ -173,7 +173,6 @@ class BaseModel(abc.ABC):
         }
 
         # Update global dictionaries to retain existing data while adding new entries
-        self.gen_id_to_future.update(new_gen_id_to_future)
         self.gen_id_to_params.update(new_gen_id_to_params)
         
         

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -156,18 +156,14 @@ class BaseModel(abc.ABC):
             request['prompt'] = prompts[request_idx]
             self.preprocess_request(request)
 
-            gen_id = str(uuid.uuid4())  # Generate a unique generation ID
+            # Generate a unique generation ID
+            gen_id = str(uuid.uuid4())
             gen_ids.append(gen_id)
+
+            # Update global dictionaries tracking the progress of generations
             self.gen_id_to_future[gen_id] = self.executor.submit(self._generate_single, **request)
+            self.gen_id_to_params[gen_id] = (kwargs["stop_phrases"][request_idx], remove_stop_phrases)
 
-        # Construct new_gen_id_to_params mapping gen_id to stop_phrases and remove_stop_phrases
-        new_gen_id_to_params = {
-            gen_id: (req_stop_phrases, remove_stop_phrases)
-            for gen_id, req_stop_phrases in zip(gen_ids, kwargs["stop_phrases"])
-        }
-
-        # Update global dictionaries to retain existing data while adding new entries
-        self.gen_id_to_params.update(new_gen_id_to_params)
         return gen_ids
 
     def get_generations(self, generation_ids: list[str]) -> list[dict]:


### PR DESCRIPTION
Currently, the async inference loop encounters the following error when processing large-scale datasets:

RuntimeError: can't start new thread

To address this issue and support large-scale datasets, I have updated the async loop logic to submit requests in batches. For example, we initially submit 1,000 requests, and as soon as some requests complete, we continue adding new ones to maintain a steady count of 1,000 active requests in the inference engine. This ensures efficient resource utilization without exceeding thread limitations.