### PR TITLE
Adding the option of including generation in generate.py

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -56,6 +56,8 @@ class GenerateSolutionsConfig:
     # Prompt configuration - path to yaml files
     prompt_template: str | None = None  # not required for OpenAI server
     prompt_config: str | None = None  # we will fetch it from dataset dir if not provided
+    include_generation: bool = False  # whether to include "generation" key while building prompt or not
+
     examples_type: str | None = None  # to be able to customize few-shot examples
     inference: InferenceConfig = field(default_factory=InferenceConfig)  # LLM call parameters
 
@@ -176,7 +178,7 @@ def sync_loop(cfg, data, llm, prompt, extra_stop_phrases, extra_generate_params)
             if len(data_points) == cfg.batch_size or idx == len(data) - 1:
                 if cfg.multi_turn_key is None:
                     outputs = llm.generate(
-                        prompts=[prompt.fill(dp) for dp in data_points],
+                        prompts=[prompt.fill(dp, include_generation=cfg.include_generation) for dp in data_points],
                         stop_phrases=combine_stop_phrases(prompt.stop_phrases, extra_stop_phrases),
                         **asdict(cfg.inference),
                         **extra_generate_params,
@@ -204,7 +206,7 @@ def sync_loop(cfg, data, llm, prompt, extra_stop_phrases, extra_generate_params)
                         # getting a new set of generations
                         turn_outputs = llm.generate(
                             prompts=[
-                                prompt.fill(turn_data_points[dp_index], multi_turn_key=cfg.multi_turn_key)
+                                prompt.fill(turn_data_points[dp_index], multi_turn_key=cfg.multi_turn_key, include_generation=cfg.include_generation)
                                 for dp_index in dp_indices
                             ],
                             stop_phrases=combine_stop_phrases(prompt.stop_phrases, extra_stop_phrases),
@@ -274,7 +276,7 @@ def async_loop(cfg, data, llm, prompt, extra_stop_phrases, extra_generate_params
             # Dynamic sending requests to maintain cfg.max_concurrent_requests running requests
             num_to_submit = min(cfg.max_concurrent_requests - len(in_progress), len(request_queue))
             batch_indices = [request_queue.popleft() for _ in range(num_to_submit)]
-            batch_prompts = [prompt.fill(data[idx]) for idx in batch_indices]
+            batch_prompts = [prompt.fill(data[idx], include_generation=cfg.include_generation) for idx in batch_indices]
 
             if len(batch_prompts) > 0:
                 generation_ids = llm.generate_async(


### PR DESCRIPTION
There are cases like gen-rm, generation summarization where we want to include the "generation" key while building the prompt. This PR adds support for such use cases. 