### PR TITLE
Randomize wandb run-id in order to prevent hangs

### DIFF
--- a/nemo_skills/pipeline/openrlhf/ppo.py
+++ b/nemo_skills/pipeline/openrlhf/ppo.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import os
+import random
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
@@ -145,7 +146,7 @@ class PPOOpenRLHFTask:
                 f" --use_wandb $WANDB_API_KEY "
                 f" --wandb_project {wandb_project} "
                 f" --wandb_run_name {expname} "
-                f" --wandb_id {expname} "
+                f" --wandb_id {expname}_{str(random.randint(0, 2 ** 32))} "
                 f" --wandb_resume auto"
             )
         else:

--- a/nemo_skills/pipeline/openrlhf/sft.py
+++ b/nemo_skills/pipeline/openrlhf/sft.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import random
 from dataclasses import dataclass
 from typing import List
 
@@ -129,7 +130,7 @@ def format_wandb_args(cluster_config, disable_wandb, wandb_project, expname):
             f" --use_wandb $WANDB_API_KEY "
             f" --wandb_project {wandb_project} "
             f" --wandb_run_name {expname} "
-            f" --wandb_id {expname} "
+            f" --wandb_id {expname}_{str(random.randint(0, 2 ** 32))} "
             f" --wandb_resume auto"
         )
     else:


### PR DESCRIPTION
- Changes the wandb-id with a random value in order to prevent crashes from repeating wandb job with exact same id that was already deleted