### PR TITLE
FEAT allow disable eval_data

### DIFF
--- a/nemo_skills/pipeline/verl/ppo.py
+++ b/nemo_skills/pipeline/verl/ppo.py
@@ -95,7 +95,11 @@ class PPOVerlTask:
         return cmd
 
     def format_data_args(self):
-        cmd = f"   data.train_files='{self.prompt_data}' " f"   data.val_files='{self.eval_data}' "
+        cmd = f"   data.train_files='{self.prompt_data}' "
+        if self.eval_data:
+            cmd = f"{cmd} data.val_files='{self.eval_data}' "
+        else:
+            cmd = f"{cmd} +trainer.run_validation=False "
 
         return cmd
 


### PR DESCRIPTION
Automatically disables validation if no eval_data is supplied. Needs https://github.com/titu1994/verl/pull/3