### PR TITLE
Update app.py

### DIFF
--- a/nemo_skills/pipeline/app.py
+++ b/nemo_skills/pipeline/app.py
@@ -36,7 +36,7 @@ def wrap_arguments(arguments: str):
             self.obj = None
 
     # first one is the cli name
-    return MockContext(args=arguments.split())
+    return MockContext(args=arguments.split(" "))
 
 
 def typer_unpacker(f: Callable):


### PR DESCRIPTION
split on spaces instead of arbitrary whitespace, fixes issue with extra_stop_phrases receiving incorrect stop phrases when newline is included in override arguments