### PR TITLE
wrap_arguments split on specifically space instead of all whitespace

### DIFF
--- a/nemo_skills/pipeline/app.py
+++ b/nemo_skills/pipeline/app.py
@@ -36,7 +36,7 @@ def wrap_arguments(arguments: str):
             self.obj = None
 
     # first one is the cli name
-    return MockContext(args=arguments.split())
+    return MockContext(args=arguments.split(" "))
 
 
 def typer_unpacker(f: Callable):


### PR DESCRIPTION
changed wrap_arguments() to split on spaces instead of generic whitespace