### PR TITLE
Averaged pass at k generations (as in R1 paper)

### DIFF
--- a/nemo_skills/evaluation/metrics/math_metrics.py
+++ b/nemo_skills/evaluation/metrics/math_metrics.py
@@ -63,7 +63,7 @@ class MathMetrics(BaseMetrics):
             perf_dict["both_correct"] += int(current_correct_sympy and current_correct_judge)
             perf_dict["any_correct"] += int(current_correct_sympy or current_correct_judge)
 
-    def update_comb_metric_expected(self, perf_dict, current_correct_sympy, current_correct_judge, no_answer):
+    def update_comb_metric_averaged(self, perf_dict, current_correct_sympy, current_correct_judge, no_answer):
         perf_dict["correct_sympy"] += current_correct_sympy
         perf_dict["correct_judge"] += current_correct_judge
         perf_dict["no_answer"] += no_answer
@@ -139,7 +139,7 @@ class MathMetrics(BaseMetrics):
                         current_correct_judge,
                         no_answer,
                     )
-                    self.update_comb_metric_expected(
+                    self.update_comb_metric_averaged(
                         self.agg_mode_dict[f"pass@1[{k}]"],
                         current_correct_sympy,
                         current_correct_judge,
@@ -315,5 +315,5 @@ class MathMetrics(BaseMetrics):
 
     def max_aggregations_to_print(self):
         """We will log all majority/rm/pass/pass@1[k] up to k, but only report the kth one."""
-        # majority + pass + 2xRM
-        return 2 + 2 * self.has_reward + 1
+        # majority + pass + 2xRM + pass@1[k]
+        return 1 + 1 + 2 * self.has_reward + 1

--- a/nemo_skills/evaluation/metrics/math_metrics.py
+++ b/nemo_skills/evaluation/metrics/math_metrics.py
@@ -67,6 +67,9 @@ class MathMetrics(BaseMetrics):
         perf_dict["correct_sympy"] += current_correct_sympy
         perf_dict["correct_judge"] += current_correct_judge
         perf_dict["no_answer"] += no_answer
+        if self.has_sympy and self.has_judge:
+            perf_dict["both_correct"] += current_correct_sympy and current_correct_judge
+            perf_dict["any_correct"] += current_correct_sympy or current_correct_judge
 
 
     def update(self, predictions):
@@ -283,6 +286,8 @@ class MathMetrics(BaseMetrics):
                 current_correct_sympy, current_correct_judge, no_answer = False, False, False
                 if self.has_sympy:
                     current_correct_sympy = sum([elem['is_correct'] for elem in predictions[:k]]) / k
+                if self.has_judge:
+                    current_correct_judge = sum([is_correct_judgement(elem['judgement']) for elem in predictions[:k]]) / k
                 if all([elem['predicted_answer'] is None for elem in predictions[:k]]):
                     no_answer = True
 

--- a/nemo_skills/evaluation/metrics/math_metrics.py
+++ b/nemo_skills/evaluation/metrics/math_metrics.py
@@ -286,7 +286,7 @@ class MathMetrics(BaseMetrics):
                 if all([elem['predicted_answer'] is None for elem in predictions[:k]]):
                     no_answer = True
 
-                self.update_comb_metric_expected(
+                self.update_comb_metric_averaged(
                     self.agg_mode_dict[f"pass@1[{k}]"], current_correct_sympy, current_correct_judge, no_answer
                 )
 


### PR DESCRIPTION
Added pass@1[k] (averaged pass@1 on k samples) implementation as described in [R1 paper, p.12](https://arxiv.org/pdf/2501.12948)


![Screenshot 2025-03-25 at 13 08 36](https://github.com/user-attachments/assets/6a72b7ca-713c-4b40-9e26-a3ca5999fac0)
