### PR TITLE
Fix chunks end-of-work condition

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -283,6 +283,12 @@ class GenerationTask:
             return data
 
         starting_idx = 0
+        if self.cfg.num_chunks:
+            chunk_index = self.cfg.output_file.rfind("_chunk")
+            base_output_file = self.cfg.output_file[:chunk_index] + ".jsonl"
+            if Path(base_output_file).exists():
+                LOG.warning(f"File `{base_output_file}` exists, skipping generation")
+                return []
         try:
             with open(self.cfg.output_file, "rt", encoding="utf-8") as fin:
                 starting_idx = len(fin.readlines())
@@ -303,6 +309,12 @@ class GenerationTask:
 
         filled_positions = set()
         if self.cfg.skip_filled:
+            if self.cfg.num_chunks:
+                chunk_index = self.cfg.output_file.rfind("_chunk")
+                base_output_file = self.cfg.output_file[:chunk_index] + ".jsonl"
+                if Path(base_output_file).exists():
+                    LOG.warning(f"File `{base_output_file}` exists, skipping generation")
+                    return []
             try:
                 with open(self.cfg.output_file + '-async', "rt", encoding="utf-8") as fin:
                     for line in fin:


### PR DESCRIPTION
Chunks stop of work signal is the existence and fullness of the chunk file. Therefore, if all the chunks are already combined and separate files removed the work of the specific chunk will be resumed

Fix: Add the logic to stop the work when the combined file exists