### PR TITLE
Packages needed for local execution

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -28,8 +28,12 @@ requests
 scikit-learn
 sdp @ git+https://github.com/NVIDIA/NeMo-speech-data-processor@29b9b1ec0ceaf3ffa441c1d01297371b3f8e11d2
 sympy
+ipython
 tqdm
 transformers
 typer >= 0.13
 fire
 wandb
+
+# needed local code execution server for persistent sessions
+flask


### PR DESCRIPTION
For local execution with sandbox we miss these two packages, `ipython` & `flask`.  
`ipython` will silently fail.
We can either add this to the main requirements so it installs with `pip install git+https://github.com/NVIDIA/NeMo-Skills.git`  or alternatively instruct the user to install separately.  