### PR TITLE
Dh/fp8 v01

### DIFF
--- a/nemo_skills/conversion/hf_to_trtllm_quantize.py
+++ b/nemo_skills/conversion/hf_to_trtllm_quantize.py
@@ -1,3 +1,22 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copied from NVIDIA's TensorRT-LLM project:
+# https://github.com/NVIDIA/TensorRT-LLM/blob/main/examples/quantization/quantize.py
+# Original commit: 5aec7af45fc0abd876fa68a9ae8c8cae084f3af3
+# Original version: v0.18
+
 import argparse
 
 import torch.multiprocessing as mp

--- a/nemo_skills/conversion/hf_to_trtllm_quantize.py
+++ b/nemo_skills/conversion/hf_to_trtllm_quantize.py
@@ -1,0 +1,204 @@
+import argparse
+
+import torch.multiprocessing as mp
+
+from tensorrt_llm.quantization import (quantize_and_export,
+                                       quantize_nemo_and_export)
+
+mp.set_start_method("spawn", force=True)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_dir",
+                        help="Specify where the HuggingFace model is",
+                        default=None)
+    parser.add_argument('--nemo_ckpt_path',
+                        help="Specify where the NeMo checkpoint is",
+                        default=None)
+    parser.add_argument(
+        '--decoder_type',
+        type=str,
+        default='gptnext',
+        choices=['gptnext', 'llama'],
+        help="Decoder type; effective for NeMo checkpoint only.")
+    parser.add_argument(
+        '--device',
+        help=
+        "The device to run calibration; effective for HuggingFace model only.",
+        default='cuda',
+        choices=['cuda', 'cpu'])
+    parser.add_argument(
+        "--device_map",
+        help="How to map the model on the devices",
+        default="auto",
+        choices=["auto", "sequential", "cpu", "gpu"],
+    )
+    parser.add_argument(
+        '--calib_dataset',
+        type=str,
+        default='cnn_dailymail',
+        help=
+        "The huggingface dataset name or the local directory of the dataset for calibration."
+    )
+    parser.add_argument(
+        '--calib_tp_size',
+        type=int,
+        default=1,
+        help=
+        "Tensor parallel size for calibration; effective for NeMo checkpoint only."
+    )
+    parser.add_argument(
+        '--calib_pp_size',
+        type=int,
+        default=1,
+        help=
+        "Pipeline parallel size for calibration; effective for NeMo checkpoint only."
+    )
+
+    parser.add_argument(
+        '--dtype',
+        type=str,
+        default='auto',
+        choices=['auto', 'float16', 'bfloat16', 'float32'],
+        help=
+        "The data type for the model weights and activations of the non-quantized part, e.g., embedding and lm_head. "
+        "If 'auto', the data type is automatically inferred from the source model; "
+        "however, if the source dtype is float32, it is converted to float16.")
+    parser.add_argument(
+        "--qformat",
+        help="Quantization format.",
+        default="full_prec",
+        choices=[
+            "nvfp4",
+            "fp8",
+            "int8_sq",
+            "int4_awq",
+            "w4a8_awq",
+            "int8_wo",
+            "int4_wo",
+            "full_prec",
+        ],
+    )
+    parser.add_argument(
+        "--seed",
+        help="Seed the generate random numbers, the value will be used to call"
+        "random.seed(value) and numpy.random.seed(value)",
+        type=int,
+        default=1234)
+    parser.add_argument("--tokenizer_max_seq_length",
+                        help="Max sequence length to init the tokenizers",
+                        type=int,
+                        default=2048)
+
+    parser.add_argument("--batch_size",
+                        help="Batch size for calibration.",
+                        type=int,
+                        default=1)
+    parser.add_argument("--calib_size",
+                        help="Number of samples for calibration.",
+                        type=int,
+                        default=512)
+    parser.add_argument("--calib_max_seq_length",
+                        help="Max sequence length for calibration",
+                        type=int,
+                        default=512)
+    parser.add_argument("--output_dir", default="exported_model")
+    parser.add_argument("--tp_size", type=int, default=1)
+    parser.add_argument("--pp_size", type=int, default=1)
+    parser.add_argument("--cp_size", type=int, default=1)
+    parser.add_argument("--awq_block_size", type=int, default=128)
+    parser.add_argument("--kv_cache_dtype",
+                        help="KV Cache dtype.",
+                        default=None,
+                        choices=["int8", "fp8", None])
+    # Medusa
+    parser.add_argument('--num_medusa_heads', type=int, default=4)
+    parser.add_argument('--num_medusa_layers', type=int, default=1)
+    parser.add_argument('--max_draft_len', type=int, default=63)
+    parser.add_argument('--medusa_hidden_act', type=str, default="silu")
+    parser.add_argument('--medusa_model_dir', type=str, default=None)
+    parser.add_argument('--quant_medusa_head',
+                        default=False,
+                        action='store_true',
+                        help="whether to quantize the weights of medusa heads")
+
+    # auto quantization
+    parser.add_argument(
+        '--autoq_format',
+        default=None,
+        type=str,
+        help=
+        "Specific quantization algorithms will be searched in auto quantization."
+        "The algorithm must in ['fp8', 'int4_awq', 'w4a8_awq', 'int8_sq']."
+        "You can use ',' to separate more than one quantization algorithms(e.g. --autoq_format fp8,int4_awq,w4a8_awq)."
+        "Notice: fp8 and int8_sq can't be used at the same time.")
+    parser.add_argument(
+        '--auto_quantize_bits',
+        type=float,
+        default=None,
+        help="Effective bits constraint for auto quantization. If not set, "
+        "regular quantization without auto quantization search will be applied."
+        "You can't set it lower than the num_bits of most aggressive quantization format."
+        "For example, if 'int4_awq' is in autoq_format, it can't be lower than 4.0."
+    )
+
+    args = parser.parse_args()
+
+    # auto_quantize_bits check
+    if args.autoq_format:
+        lower_bound, upper_bound = 4 if '4' in args.autoq_format else 8, 16
+        if args.auto_quantize_bits is None or args.auto_quantize_bits < lower_bound or args.auto_quantize_bits > upper_bound:
+            print(
+                f"invalid auto_quantize_bits value, will be set to {lower_bound}"
+            )
+            args.auto_quantize_bits = lower_bound
+
+    if args.model_dir is not None:
+        quantize_and_export(
+            model_dir=args.model_dir,
+            device=args.device,
+            calib_dataset=args.calib_dataset,
+            dtype=args.dtype,
+            qformat=args.qformat
+            if args.auto_quantize_bits is None else args.autoq_format,
+            kv_cache_dtype=args.kv_cache_dtype,
+            calib_size=args.calib_size,
+            batch_size=args.batch_size,
+            calib_max_seq_length=args.calib_max_seq_length,
+            awq_block_size=args.awq_block_size,
+            output_dir=args.output_dir,
+            tp_size=args.tp_size,
+            pp_size=args.pp_size,
+            cp_size=args.cp_size,
+            seed=args.seed,
+            tokenizer_max_seq_length=args.tokenizer_max_seq_length,
+            num_medusa_heads=args.num_medusa_heads,
+            num_medusa_layers=args.num_medusa_layers,
+            max_draft_len=args.max_draft_len,
+            medusa_hidden_act=args.medusa_hidden_act,
+            medusa_model_dir=args.medusa_model_dir,
+            quant_medusa_head=args.quant_medusa_head,
+            auto_quantize_bits=args.auto_quantize_bits,
+            device_map=args.device_map)
+    elif args.nemo_ckpt_path is not None:
+        quantize_nemo_and_export(nemo_ckpt_path=args.nemo_ckpt_path,
+                                 decoder_type=args.decoder_type,
+                                 calib_dataset=args.calib_dataset,
+                                 calib_tp_size=args.calib_tp_size,
+                                 calib_pp_size=args.calib_pp_size,
+                                 dtype=args.dtype,
+                                 qformat=args.qformat,
+                                 kv_cache_dtype=args.kv_cache_dtype,
+                                 calib_size=args.calib_size,
+                                 batch_size=args.batch_size,
+                                 calib_max_seq_length=args.calib_max_seq_length,
+                                 awq_block_size=args.awq_block_size,
+                                 output_dir=args.output_dir,
+                                 tp_size=args.tp_size,
+                                 pp_size=args.pp_size,
+                                 cp_size=args.cp_size,
+                                 seed=args.seed)
+    else:
+        raise ValueError(
+            "One of source checkpoint (model_dir, nemo_ckpt_path) must be specified"
+        )

--- a/nemo_skills/pipeline/convert.py
+++ b/nemo_skills/pipeline/convert.py
@@ -251,6 +251,13 @@ def convert(
     # Validate dtype-related requirements
     if dtype == "fp8" and not calib_dataset:
         raise ValueError("--calib_dataset is required when dtype is 'fp8'")
+
+    # Validate dtype-related requirements
+    if dtype == "fp8":
+        if not calib_dataset:
+            raise ValueError("--calib_dataset is required when dtype is 'fp8'")
+        if convert_to != "trtllm":
+            raise ValueError("FP8 dtype is only supported when converting to TensorRT LLM (convert_to='trtllm')")
         
     # TODO: add support for conversion from NeMo to trtllm using nemo.export (need to test thoroughly)
     if convert_from == "nemo" and convert_to == "trtllm":

--- a/nemo_skills/pipeline/convert.py
+++ b/nemo_skills/pipeline/convert.py
@@ -51,6 +51,8 @@ def get_hf_to_trtllm_cmd(
     dtype,
     num_gpus,
     num_nodes,
+    calib_dataset,
+    calib_size,
     extra_arguments,
     trt_prepare_args,
     trt_reuse_tmp_engine,
@@ -59,36 +61,64 @@ def get_hf_to_trtllm_cmd(
         "bf16": "bfloat16",
         "fp16": "float16",
         "fp32": "float32",
+        "fp8": "fp8",
     }[dtype]
 
     tmp_engine_dir = f"{output_model}-tmp"
 
     setup_cmd = f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && cd /nemo_run/code && "
 
-    hf_to_trtllm_cmd = (
-        f"python -m nemo_skills.conversion.hf_to_trtllm_{model_type} "
-        f"    --model_dir {input_model} "
-        f"    --output_dir {tmp_engine_dir} "
-        f"    --dtype {dtype} "
-        f"    --tp_size {num_gpus} "
-        f"    --pp_size {num_nodes} "
-        f"    --workers 16 "
-        f"    {trt_prepare_args} "
-    )
-
-    trtllm_build_cmd = (
-        f"trtllm-build "
-        f"    --checkpoint_dir {tmp_engine_dir} "
-        f"    --output_dir {output_model} "
-        f"    --gpt_attention_plugin {dtype} "
-        f"    --use_paged_context_fmha enable "
-        f"    --max_batch_size 512 "
-        f"    --max_input_len 4096 "
-        f"    --max_seq_len 8192 "
-        f"    --max_num_tokens 8192 "
-        f"    {extra_arguments} && "
-        f"cp {input_model}/tokenizer* {output_model} "
-    )
+    if dtype == "fp8":
+        hf_to_trtllm_cmd = (
+            f"python -m nemo_skills.conversion.hf_to_trtllm_quantize "
+            f"    --model_dir {input_model} "
+            f"    --dtype float16 "
+            f"    --qformat {dtype} "
+            f"    --output_dir {tmp_engine_dir} "
+            f"    --calib_size {calib_size} "
+            f"    --calib_dataset {calib_dataset} "
+            f"    --batch_size 4 "
+            f"    --tp_size {num_gpus} "
+            f"    --pp_size {num_nodes} "
+            f"    {trt_prepare_args} "
+        )
+        trtllm_build_cmd = (
+            f"trtllm-build "
+            f"    --checkpoint_dir {tmp_engine_dir} "
+            f"    --output_dir {output_model} "
+            f"    --gemm_plugin auto "
+            f"    --use_paged_context_fmha enable "
+            f"    --max_batch_size 512 "
+            f"    --max_input_len 4096 "
+            f"    --max_seq_len 8192 "
+            f"    --max_num_tokens 8192 "
+            f"    {extra_arguments} && "
+            f"cp {input_model}/tokenizer* {output_model} "
+        )
+    else:    
+        hf_to_trtllm_cmd = (
+            f"python -m nemo_skills.conversion.hf_to_trtllm_{model_type} "
+            f"    --model_dir {input_model} "
+            f"    --output_dir {tmp_engine_dir} "
+            f"    --dtype {dtype} "
+            f"    --tp_size {num_gpus} "
+            f"    --pp_size {num_nodes} "
+            f"    --workers 16 "
+            f"    {trt_prepare_args} "
+        )
+        trtllm_build_cmd = (
+            f"trtllm-build "
+            f"    --checkpoint_dir {tmp_engine_dir} "
+            f"    --output_dir {output_model} "
+            f"    --gpt_attention_plugin {dtype} "
+            f"    --use_paged_context_fmha enable "
+            f"    --max_batch_size 512 "
+            f"    --max_input_len 4096 "
+            f"    --max_seq_len 8192 "
+            f"    --max_num_tokens 8192 "
+            f"    {extra_arguments} && "
+            f"cp {input_model}/tokenizer* {output_model} "
+        )
 
     if trt_reuse_tmp_engine:
         cmd = (
@@ -140,6 +170,7 @@ class SupportedDtypes(str, Enum):
     bf16 = "bf16"
     fp16 = "fp16"
     fp32 = "fp32"
+    fp8 = "fp8"
 
 
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
@@ -162,6 +193,14 @@ def convert(
     trt_reuse_tmp_engine: bool = typer.Option(True, help="Whether to reuse the tmp engine for the final conversion"),
     hf_model_name: str = typer.Option(None, help="Name of the model on Hugging Face Hub to convert to/from"),
     dtype: SupportedDtypes = typer.Option("bf16", help="Data type"),
+    calib_dataset: str = typer.Option(
+        None,
+        help="(Required for dtype=fp8) HuggingFace dataset to use for FP8 calibration",
+    ),
+    calib_size: int = typer.Option(
+        4096,
+        help="Optional number of samples to use from the calibration dataset (if dtype=fp8)",
+    ),
     expname: str = typer.Option("conversion", help="NeMo-Run experiment name"),
     num_nodes: int = typer.Option(1),
     num_gpus: int = typer.Option(...),
@@ -209,6 +248,10 @@ def convert(
     except AttributeError:
         pass
 
+    # Validate dtype-related requirements
+    if dtype == "fp8" and not calib_dataset:
+        raise ValueError("--calib_dataset is required when dtype is 'fp8'")
+        
     # TODO: add support for conversion from NeMo to trtllm using nemo.export (need to test thoroughly)
     if convert_from == "nemo" and convert_to == "trtllm":
         raise ValueError("Conversion from NeMo to TensorRT LLM is not supported directly. Convert to HF first.")
@@ -249,6 +292,8 @@ def convert(
         dtype=dtype,
         num_gpus=num_gpus,
         num_nodes=num_nodes,
+        calib_dataset=calib_dataset,
+        calib_size=calib_size,
         extra_arguments=extra_arguments,
     )
     with get_exp(expname, cluster_config) as exp:
@@ -279,3 +324,4 @@ if __name__ == "__main__":
     # workaround for https://github.com/fastapi/typer/issues/341
     typer.main.get_command_name = lambda name: name
     app()
+

--- a/nemo_skills/pipeline/convert.py
+++ b/nemo_skills/pipeline/convert.py
@@ -72,7 +72,7 @@ def get_hf_to_trtllm_cmd(
         hf_to_trtllm_cmd = (
             f"python -m nemo_skills.conversion.hf_to_trtllm_quantize "
             f"    --model_dir {input_model} "
-            f"    --dtype float16 "
+            f"    --dtype auto "
             f"    --qformat {dtype} "
             f"    --output_dir {tmp_engine_dir} "
             f"    --calib_size {calib_size} "

--- a/nemo_skills/pipeline/convert.py
+++ b/nemo_skills/pipeline/convert.py
@@ -249,10 +249,6 @@ def convert(
         pass
 
     # Validate dtype-related requirements
-    if dtype == "fp8" and not calib_dataset:
-        raise ValueError("--calib_dataset is required when dtype is 'fp8'")
-
-    # Validate dtype-related requirements
     if dtype == "fp8":
         if not calib_dataset:
             raise ValueError("--calib_dataset is required when dtype is 'fp8'")


### PR DESCRIPTION
- Allow fp8 quantization.
- Providing calibration dataset with `text` field is mandatory as input. 
- File `nemo_skills/conversion/hf_to_trtllm_quantize.py` is copied directly from `TensorRT-LLM/examples/quantization/quantize.py`

Usage,
```
ns convert --input_model OpenMath-Nemotron-1.5B \
           --output_model OpenMath-Nemotron-1.5B-Kaggle-fp8-trtllm \
           --convert_from hf \
           --convert_to trtllm \
           --num_gpus 2 \
           --dtype fp8 \
           --hf_model_name nvidia/OpenMath-Nemotron-1.5B \
           --model_type qwen \
           --calib_dataset calibrate_openmathreasoning
```
