### PR TITLE
Genselect updates

### DIFF
--- a/nemo_skills/inference/genselect.py
+++ b/nemo_skills/inference/genselect.py
@@ -171,7 +171,11 @@ class GenSelectTask(GenerationTask):
                     judgment = random.randint(0, instance["max_idx"])
 
                 output_instance["predicted_answer"] = instance[f'predicted_answer_{judgment}']
-                output_instance["is_correct"] = instance[f'is_correct_{judgment}']
+
+                if f"is_correct_{judgment}" in instance:
+                    output_instance["is_correct"] = instance[f'is_correct_{judgment}']
+                if f"judgement_{judgment}" in instance:
+                    output_instance["judgement"] = instance[f'judgement_{judgment}']
 
                 fout.write(json.dumps(output_instance) + '\n')
 

--- a/nemo_skills/inference/genselect_preprocess.py
+++ b/nemo_skills/inference/genselect_preprocess.py
@@ -159,11 +159,9 @@ def create_comparison_instance(clustered_instances, problem, max_soln_samples=8,
     for i, instance in enumerate(sampled_instances):
         comparison_instance[f"predicted_answer_{i}"] = instance["predicted_answer"]
         if "judgement" in instance:
-            comparison_instance[f"is_correct_{i}"] = is_correct_judgement(instance["judgement"])
-        elif "is_correct" in instance:
+            comparison_instance[f"judgement_{i}"] = instance["judgement"]
+        if "is_correct" in instance:
             comparison_instance[f"is_correct_{i}"] = instance["is_correct"]
-        else:
-            comparison_instance[f"is_correct_{i}"] = instance["predicted_answer"] == instance["expected_answer"]
 
     comparison_instance["expected_answer"] = clustered_instances[0][1][0]["expected_answer"]
 

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -621,7 +621,7 @@ def generate(
     with get_exp(expname, cluster_config) as exp:
         if generation_type == GenerationType.genselect:
             # Add the preprocessing command for genselect
-            genselect_args = f" ++num_random_seeds={len(random_seeds)} ++output_dir={output_dir} " + genselect_args
+            genselect_args = f" ++num_random_seeds={len(random_seeds)} ++output_dir={output_dir} " + (genselect_args if genselect_args is not None else "")
             preprocess_cmd = f"python -m nemo_skills.inference.genselect_preprocess {genselect_args}"
 
             preprocess_task = add_task(


### PR DESCRIPTION
The `output_instance` in genselect copies the original instance before updating the evaluation keys based on the selected solution. We currently just update the `is_correct` based on the selected solution. This leads to `summarize_results` reporting a non-sensical `judge_correct` score. In this PR, we keep both the symbolic and judgement key around from the original solutions. The selected solution's judgement key is copied into the `output_instance`.  