### PR TITLE
Nemo rl grpo

### DIFF
--- a/nemo_skills/pipeline/cli.py
+++ b/nemo_skills/pipeline/cli.py
@@ -26,6 +26,7 @@ from nemo_skills.pipeline.convert import convert
 from nemo_skills.pipeline.eval import eval
 from nemo_skills.pipeline.generate import generate
 from nemo_skills.pipeline.nemo_rl.sft import sft_nemo_rl
+from nemo_skills.pipeline.nemo_rl.grpo import grpo_nemo_rl
 from nemo_skills.pipeline.openrlhf.ppo import ppo_openrlhf
 from nemo_skills.pipeline.openrlhf.sft import sft_openrlhf
 from nemo_skills.pipeline.run_cmd import run_cmd

--- a/nemo_skills/pipeline/nemo_rl/grpo.py
+++ b/nemo_skills/pipeline/nemo_rl/grpo.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from dataclasses import dataclass
+from typing import List
+
+import typer
+
+from nemo_skills.pipeline.app import app, typer_unpacker
+from nemo_skills.pipeline.nemo_rl import nemo_rl_app
+from nemo_skills.pipeline.utils import (
+    add_task,
+    check_mounts,
+    get_cluster_config,
+    get_exp,
+    get_mounted_path,
+    get_timeout,
+    resolve_mount_paths,
+    run_exp,
+)
+from nemo_skills.utils import get_logger_name, setup_logging
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+
+@dataclass
+class NemoRLTask:
+    model: str
+    output_dir: str
+    prompt_data: str
+    eval_data: str
+    num_gpus: int
+    num_nodes: int
+    expname: str
+    disable_wandb: bool
+    wandb_project: str
+    wandb_group: str
+    timeout: str
+    log_dir: str
+    cache_dir: str
+    extra_arguments: str = ""
+
+    def format_train_args(self):
+        cmd = (
+            f"++policy.model_name={self.model} "
+            f"++cluster.gpus_per_node={self.num_gpus} "
+            f"++cluster.num_nodes={self.num_nodes} "
+            f"++logger.log_dir={self.log_dir} "
+            f"++checkpointing.checkpoint_dir={self.output_dir}/checkpoints "
+        )
+        return cmd
+
+    def format_data_args(self):
+        cmd = f"+data.train_data_path={self.prompt_data} " f"+data.val_data_path={self.eval_data} "
+        return cmd
+
+    def format_wandb_args(self):
+        wandb_id = self.expname + ("-" + self.wandb_group if self.wandb_group else "") + "-" + self.wandb_project
+        cmd = (
+            f"++logger.wandb_enabled={not self.disable_wandb} "
+            f"++logger.wandb.project={self.wandb_project} "
+            f"++logger.wandb.name={self.expname} "
+            f"++logger.wandb.id={wandb_id} "
+        )
+        if self.wandb_group:
+            cmd += f"++logger.wandb.group={self.wandb_group} "
+        return cmd
+
+    def get_cmd(self):
+        self.logging_params = self.format_wandb_args()
+
+        cmd = (
+            f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code:/opt/NeMo-RL && "
+            f"export NEMO_RL_VENV_DIR=/{self.cache_dir}/nemo_rl_venv && "
+            f"export UV_CACHE_DIR={self.cache_dir}/uv_cache && "
+            f"export UV_PROJECT=/opt/NeMo-RL && "
+            f"echo 'Starting training' && "
+            f"uv run --active python /nemo_run/code/nemo_skills/training/nemo_rl/start_grpo.py "
+            f"  {self.format_train_args()} "
+            f"  {self.format_data_args()} "
+            f"  {self.logging_params} "
+            f"  {self.extra_arguments} "
+        )
+        return cmd
+
+
+def get_training_cmd(
+    cluster_config,
+    partition,
+    hf_model,
+    output_dir,
+    prompt_data,
+    eval_data,
+    num_gpus,
+    num_nodes,
+    expname,
+    disable_wandb,
+    wandb_project,
+    wandb_group,
+    extra_arguments,
+    log_dir,
+    cache_dir,
+):
+    timeout = get_timeout(cluster_config, partition)
+
+    task = NemoRLTask(
+        model=hf_model,
+        output_dir=output_dir,
+        prompt_data=prompt_data,
+        eval_data=eval_data,
+        num_gpus=num_gpus,
+        num_nodes=num_nodes,
+        expname=expname,
+        disable_wandb=disable_wandb,
+        wandb_project=wandb_project,
+        wandb_group=wandb_group,
+        timeout=timeout,
+        extra_arguments=extra_arguments,
+        log_dir=log_dir,
+        cache_dir=cache_dir,
+    )
+
+    return task.get_cmd()
+
+
+def get_checkpoint_convert_cmd(output_dir, final_hf_path, cache_dir):
+    cmd = (
+        f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
+        f"export NEMO_RL_VENV_DIR=/{cache_dir}/nemo_rl_venv && "
+        f"export UV_CACHE_DIR={cache_dir}/uv_cache && "
+        f"export UV_PROJECT=/opt/NeMo-RL && "
+        f"cd /nemo_run/code && "
+        f"uv run --active python -m nemo_skills.training.nemo_rl.convert_dcp_to_hf "
+        f"    --training-folder={output_dir} "
+        f"    --hf-ckpt-path={final_hf_path} "
+    )
+    return cmd
+
+
+@nemo_rl_app.command(name='grpo', context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+@typer_unpacker
+def grpo_nemo_rl(
+    ctx: typer.Context,
+    cluster: str = typer.Option(
+        None,
+        help="One of the configs inside config_dir or NEMO_SKILLS_CONFIG_DIR or ./cluster_configs. "
+        "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
+    ),
+    output_dir: str = typer.Option(..., help="Where to put results"),
+    final_hf_path: str = typer.Option(
+        None,
+        help="If specified, will save the final HF model to this path. "
+        "If not specified, will save to output_dir/final_hf_model",
+    ),
+    expname: str = typer.Option("openrlhf-ppo", help="Nemo run experiment name"),
+    hf_model: str = typer.Option(..., help="Path to the HF model"),
+    training_data: str = typer.Option(None, help="Path to the training data"),
+    validation_data: str = typer.Option(None, help="Path to the validation data"),
+    num_nodes: int = typer.Option(1, help="Number of nodes"),
+    num_gpus: int = typer.Option(..., help="Number of GPUs"),
+    num_training_jobs: int = typer.Option(1, help="Number of training jobs"),
+    wandb_project: str = typer.Option("nemo-skills", help="Weights & Biases project name"),
+    wandb_group: str = typer.Option(None, help="Weights & Biases group name."),
+    disable_wandb: bool = typer.Option(False, help="Disable wandb logging"),
+    partition: str = typer.Option(
+        None, help="Can specify if need interactive jobs or a specific non-default partition"
+    ),
+    time_min: str = typer.Option(None, help="If specified, will use as a time-min slurm parameter"),
+    run_after: List[str] = typer.Option(
+        None, help="Can specify a list of expnames that need to be completed before this one starts"
+    ),
+    reuse_code: bool = typer.Option(
+        True,
+        help="If True, will reuse the code from the provided experiment. "
+        "If you use it from Python, by default the code will be re-used from "
+        "the last submitted experiment in the current Python session, so set to False to disable "
+        "(or provide reuse_code_exp to override).",
+    ),
+    reuse_code_exp: str = typer.Option(
+        None,
+        help="If specified, will reuse the code from this experiment. "
+        "Can provide an experiment name or an experiment object if running from code.",
+    ),
+    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
+    log_dir: str = typer.Option(
+        None,
+        help="Can specify a custom location for slurm logs. "
+        "If not specified, will be inside `ssh_tunnel.job_dir` part of your cluster config.",
+    ),
+    cache_dir: str = typer.Option(
+        ...,
+        help="Path to the directory where the NeMo-RL uv cache will be stored. This should be a mounted "
+        "path so the cache can be reused between jobs.",
+    ),
+    exclusive: bool = typer.Option(
+        True,
+        "--not_exclusive",
+        help="If --not_exclusive is used, will NOT use --exclusive flag for slurm",
+    ),
+    mount_paths: str = typer.Option(None, help="Comma separated list of paths to mount on the remote machine"),
+    check_mounted_paths: bool = typer.Option(False, help="Check if mounted paths are available on the remote machine"),
+):
+    """Runs NeMo-RL GRPO training.
+
+    All extra arguments are passed directly to the NeMo-RL GRPO script.
+    """
+    setup_logging(disable_hydra_logs=False, use_rich=True)
+    extra_arguments = f'{" ".join(ctx.args)}'
+    LOG.info("Starting training job")
+    LOG.info("Extra arguments that will be passed to the underlying script: %s", extra_arguments)
+
+    cluster_config = get_cluster_config(cluster, config_dir)
+    cluster_config = resolve_mount_paths(cluster_config, mount_paths)
+
+    if log_dir is None:
+        log_dir = output_dir
+
+    hf_model, output_dir, log_dir = check_mounts(
+        cluster_config,
+        log_dir=log_dir,
+        mount_map={hf_model: None, output_dir: None},
+        check_mounted_paths=check_mounted_paths,
+    )
+
+    if num_training_jobs > 0:
+        if training_data is None:
+            raise ValueError("training_data is required when num_training_jobs > 0")
+        if training_data.startswith("/"):  # could ask to download from HF
+            training_data = get_mounted_path(cluster_config, training_data)
+        if validation_data is None:
+            validation_data = training_data
+        else:
+            validation_data = get_mounted_path(cluster_config, validation_data)
+        cache_dir = get_mounted_path(cluster_config, cache_dir)
+
+    train_cmd = get_training_cmd(
+        cluster_config=cluster_config,
+        partition=partition,
+        hf_model=hf_model,
+        output_dir=output_dir,
+        prompt_data=training_data,
+        eval_data=validation_data,
+        num_gpus=num_gpus,
+        num_nodes=num_nodes,
+        expname=expname,
+        disable_wandb=disable_wandb,
+        wandb_project=wandb_project,
+        wandb_group=wandb_group,
+        extra_arguments=extra_arguments,
+        log_dir=f"{log_dir}/training-logs",
+        cache_dir=cache_dir,
+    )
+
+    server_config = None
+    with get_exp(expname, cluster_config) as exp:
+        prev_task = None
+        for job_id in range(num_training_jobs):
+            prev_task = add_task(
+                exp,
+                cmd=train_cmd,
+                task_name=f'{expname}-grpo-{job_id}',
+                log_dir=f"{log_dir}/training-logs",
+                container=cluster_config["containers"]["nemo-rl"],
+                num_gpus=num_gpus,
+                num_nodes=num_nodes,
+                cluster_config=cluster_config,
+                server_config=server_config,
+                partition=partition,
+                time_min=time_min,
+                run_after=run_after,
+                reuse_code=reuse_code,
+                reuse_code_exp=reuse_code_exp,
+                task_dependencies=[prev_task] if prev_task is not None else None,
+                slurm_kwargs={"exclusive": exclusive} if exclusive else None,
+                heterogeneous=True if server_config is not None else False,
+                with_sandbox=False,
+                with_ray=True,
+            )
+
+        add_task(
+            exp,
+            cmd=get_checkpoint_convert_cmd(
+                output_dir=output_dir,
+                final_hf_path=final_hf_path or f"{output_dir}/final_hf_model",
+                cache_dir=cache_dir,
+            ),
+            task_name=f"{expname}-convert-final-ckpt",
+            log_dir=f"{log_dir}/convert-final-ckpt",
+            container=cluster_config["containers"]['nemo-rl'],
+            cluster_config=cluster_config,
+            partition=partition,
+            time_min=time_min,
+            num_nodes=1,
+            num_tasks=1,
+            num_gpus=num_gpus,
+            run_after=run_after,
+            reuse_code=reuse_code,
+            reuse_code_exp=reuse_code_exp,
+            task_dependencies=[prev_task] if prev_task is not None else None,
+            slurm_kwargs={"exclusive": exclusive} if exclusive else None,
+        )
+
+        # explicitly setting sequential to False since we set dependencies directly
+        run_exp(exp, cluster_config, sequential=False)
+
+    return exp
+
+
+if __name__ == "__main__":
+    typer.main.get_command_name = lambda name: name
+    app()

--- a/nemo_skills/pipeline/nemo_rl/grpo.py
+++ b/nemo_skills/pipeline/nemo_rl/grpo.py
@@ -86,7 +86,7 @@ class NemoRLTask:
             f"export UV_CACHE_DIR={self.cache_dir}/uv_cache && "
             f"export UV_PROJECT=/opt/NeMo-RL && "
             f"echo 'Starting training' && "
-            f"uv run --active python /nemo_run/code/nemo_skills/training/nemo_rl/start_sft.py "
+            f"uv run --active python /nemo_run/code/nemo_skills/training/nemo_rl/start_grpo.py "
             f"  {self.format_train_args()} "
             f"  {self.format_data_args()} "
             f"  {self.logging_params} "
@@ -146,9 +146,9 @@ def get_checkpoint_convert_cmd(output_dir, final_hf_path, cache_dir):
     return cmd
 
 
-@nemo_rl_app.command(name='sft', context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+@nemo_rl_app.command(name='grpo', context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 @typer_unpacker
-def sft_nemo_rl(
+def grpo_nemo_rl(
     ctx: typer.Context,
     cluster: str = typer.Option(
         None,
@@ -208,9 +208,9 @@ def sft_nemo_rl(
     mount_paths: str = typer.Option(None, help="Comma separated list of paths to mount on the remote machine"),
     check_mounted_paths: bool = typer.Option(False, help="Check if mounted paths are available on the remote machine"),
 ):
-    """Runs NeMo-RL SFT training.
+    """Runs NeMo-RL GRPO training.
 
-    All extra arguments are passed directly to the NeMo-RL SFT script.
+    All extra arguments are passed directly to the NeMo-RL GRPO script.
     """
     setup_logging(disable_hydra_logs=False, use_rich=True)
     extra_arguments = f'{" ".join(ctx.args)}'
@@ -261,7 +261,7 @@ def sft_nemo_rl(
             prev_task = add_task(
                 exp,
                 cmd=train_cmd,
-                task_name=f'{expname}-sft-{job_id}',
+                task_name=f'{expname}-grpo-{job_id}',
                 log_dir=f"{log_dir}/training-logs",
                 container=cluster_config["containers"]["nemo-rl"],
                 num_gpus=num_gpus,

--- a/nemo_skills/training/nemo_rl/configs/grpo.yaml
+++ b/nemo_skills/training/nemo_rl/configs/grpo.yaml
@@ -1,0 +1,137 @@
+# copied and edited from https://github.com/NVIDIA/NeMo-RL/blob/ab1b638a499308caea022648daaf6994d390cbde/examples/configs/grpo_math_1B.yaml
+
+# GRPO Algorithm Configuration
+grpo:
+  num_prompts_per_step: 32
+  num_generations_per_prompt: 16
+  max_rollout_turns: 1 # for multi-turn rollouts. Math Environments just have 1 turn (answering the question)
+  max_num_steps: 1000000
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  val_period: 10
+  val_at_start: false
+  max_val_samples: 256
+  val_batch_size: 256
+
+loss_fn:
+  reference_policy_kl_penalty: 0.01
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  ratio_clip_c: null
+  # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
+  use_on_policy_kl_approximation: false
+  use_importance_sampling_correction: false
+  token_level_loss: true
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/grpo"
+  metric_name: "val_reward"
+  higher_is_better: true
+  keep_top_k: 3
+  save_period: 10
+
+policy:
+  model_name: ???
+  tokenizer:
+    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+  train_global_batch_size: 512
+  train_micro_batch_size: 4
+  generation_batch_size: 32 # Only used when generating using HF backend
+  logprob_batch_size: 4
+  max_total_sequence_length: 512
+  precision: "bfloat16"
+  fsdp_offload_enabled: false
+  activation_checkpointing_enabled: false
+  refit_buffer_size_gb: 4 # used for refitting inference engine, the unit is GB
+
+  dtensor_cfg:
+    enabled: true
+    cpu_offload: False
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    custom_parallel_plan: null
+
+  # dynamic_batching improves performance by ensuring logprob and training microbatches
+  # have a sufficent number of tokens to maximize GPU utilization. Specifically, variable length
+  # responses are sorted by sequence length and bucketed into microbatches with a total
+  # amount of tokens is approximately close to 'train_mb_tokens' and 'logprob_mb_tokens' for the
+  # training and logprob stages respectively.
+  dynamic_batching:
+    enabled: True
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    sequence_length_round: 64
+
+  # makes the training sequence length divisible by the tensor parallel size
+  # this is useful for sequence parallel training
+  make_sequence_length_divisible_by: ${policy.dtensor_cfg.tensor_parallel_size}
+  max_grad_norm: 1.0
+
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 5.0e-6
+      weight_decay: 0.01
+      betas: [0.9, 0.999]
+      eps: 1e-8
+      # when using Dtensor, we need to set foreach
+      # and fused to False
+      foreach: False
+      fused: False
+
+  scheduler:
+    - name: "torch.optim.lr_scheduler.LinearLR"
+      kwargs:
+        start_factor: 0.1
+        end_factor: 1.0
+        total_iters: 50
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: [50]
+
+  generation:
+    backend: "vllm"
+    max_new_tokens: ${policy.max_total_sequence_length}
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    vllm_cfg:
+      async_engine: false # Only for internal testing, will be enabled by https://github.com/NVIDIA/NeMo-RL/issues/447.
+      precision: ${policy.precision}
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.6
+      max_model_len: ${policy.max_total_sequence_length}
+
+data:
+  max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
+  prompt_file: "examples/prompts/cot.txt"
+  system_prompt_file: null
+  dataset_name: "OpenMathInstruct-2"
+
+env:
+  math:
+    num_workers: 8
+
+logger:
+  log_dir: "logs"  # Base directory for all logs
+  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
+  wandb_enabled: false
+  tensorboard_enabled: false
+  monitor_gpus: false  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  wandb:
+    project: "grpo-dev"
+    name: "grpo-dev-logger"
+  tensorboard: {}
+  gpu_monitoring:
+    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
+    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
+
+cluster:
+  gpus_per_node: 1
+  num_nodes: 1

--- a/nemo_skills/training/nemo_rl/configs/grpo.yaml
+++ b/nemo_skills/training/nemo_rl/configs/grpo.yaml
@@ -110,7 +110,7 @@ policy:
 
 data:
   max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
-  prompt_file: "examples/prompts/cot.txt"
+  prompt_file: "/nemo_run/code/nemo_skills/training/nemo_rl/prompts/cot.txt"
   system_prompt_file: null
   dataset_name: "OpenMathInstruct-2"
 

--- a/nemo_skills/training/nemo_rl/configs/grpo.yaml
+++ b/nemo_skills/training/nemo_rl/configs/grpo.yaml
@@ -110,7 +110,7 @@ policy:
 
 data:
   max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
-  prompt_file: "/nemo_run/code/nemo_skills/training/nemo_rl/prompts/cot.txt"
+  prompt_file: "/nemo_run/code/nemo_skills/training/nemo_rl/prompts/math.txt"
   system_prompt_file: null
   dataset_name: "OpenMathInstruct-2"
 

--- a/nemo_skills/training/nemo_rl/prompts/cot.txt
+++ b/nemo_skills/training/nemo_rl/prompts/cot.txt
@@ -1,0 +1,4 @@
+Think step-by-step to solve the following problem. Output your answer inside of \\boxed{{}} tags.:
+{}
+
+Let's think step-by-step

--- a/nemo_skills/training/nemo_rl/prompts/math.txt
+++ b/nemo_skills/training/nemo_rl/prompts/math.txt
@@ -1,0 +1,3 @@
+Solve the following math problem. Make sure to put the answer (and only answer) inside \\boxed{{}}.
+
+{}

--- a/nemo_skills/training/nemo_rl/start_grpo.py
+++ b/nemo_skills/training/nemo_rl/start_grpo.py
@@ -260,7 +260,7 @@ def main() -> None:
 
     if not args.config:
         args.config = os.path.join(
-            os.path.dirname(__file__), "configs", "grpo_math_1B.yaml"
+            os.path.dirname(__file__), "configs", "grpo.yaml"
         )
 
     config = load_config(args.config)

--- a/nemo_skills/training/nemo_rl/start_grpo.py
+++ b/nemo_skills/training/nemo_rl/start_grpo.py
@@ -101,7 +101,14 @@ def prepare_openinstructmath2_dataset(
     )
 
     # Load the original dataset
-    original_ds = load_dataset(dataset_path, split=split)
+    if not dataset_path.startswith('/'):
+        original_ds = load_dataset(dataset_path, split=split)
+    else:
+        import pandas as pd
+        from datasets import Dataset
+        df = pd.read_json(dataset_path, lines=True)
+        df = df[['problem', output_key]]
+        original_ds = Dataset.from_pandas(df)
 
     # Split into train and validation sets using HF's train_test_split
     split_ds = original_ds.train_test_split(test_size=test_size, seed=seed)

--- a/nemo_skills/training/nemo_rl/start_grpo.py
+++ b/nemo_skills/training/nemo_rl/start_grpo.py
@@ -1,0 +1,337 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# copied and edited from https://github.com/NVIDIA/NeMo-RL/blob/ab1b638a499308caea022648daaf6994d390cbde/examples/run_grpo_math.py
+
+import argparse
+import os
+import pprint
+from collections import defaultdict
+from typing import Any, Optional, cast
+
+import torch
+from omegaconf import OmegaConf
+from transformers import PreTrainedTokenizerBase
+
+from nemo_rl.algorithms.grpo import MasterConfig, grpo_train, setup
+from nemo_rl.algorithms.utils import get_tokenizer
+from nemo_rl.data import DataConfig
+from nemo_rl.data.datasets import AllTaskProcessedDataset
+from nemo_rl.data.hf_datasets.deepscaler import DeepScalerDataset
+from nemo_rl.data.hf_datasets.openmathinstruct2 import OpenMathInstruct2Dataset
+from nemo_rl.data.interfaces import (
+    DatumSpec,
+    LLMMessageLogType,
+    TaskDataProcessFnCallable,
+    TaskDataSpec,
+)
+from nemo_rl.distributed.ray_actor_environment_registry import (
+    get_actor_python_env,
+)
+from nemo_rl.distributed.virtual_cluster import init_ray
+from nemo_rl.environments.interfaces import EnvironmentInterface
+from nemo_rl.environments.math_environment import MathEnvironment
+from nemo_rl.models.generation import configure_generation_config
+from nemo_rl.utils.config import load_config, parse_hydra_overrides
+from nemo_rl.utils.logger import get_next_experiment_dir
+
+OmegaConf.register_new_resolver("mul", lambda a, b: a * b)
+
+
+def parse_args() -> tuple[argparse.Namespace, list[str]]:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Run GRPO training with configuration")
+    parser.add_argument(
+        "--config", type=str, default=None, help="Path to YAML config file"
+    )
+
+    # Parse known args for the script
+    args, overrides = parser.parse_known_args()
+
+    return args, overrides
+
+
+# ===============================================================================
+#                             Math Data Processor
+# ===============================================================================
+TokenizerType = PreTrainedTokenizerBase
+
+
+# TaskDataProcessFnCallable
+def hf_data_processor(
+    datum_dict: dict[str, Any],
+    task_data_spec: TaskDataSpec,
+    tokenizer: TokenizerType,
+    max_seq_length: int,
+    idx: int,
+) -> DatumSpec:
+    """Process a datum dictionary (directly loaded from data/hf_datasets/openmathinstruct2.py) into a DatumSpec for the Math Environment."""
+    user_message = datum_dict["messages"]
+    problem = user_message[0]["content"]
+    extra_env_info = {"ground_truth": user_message[1]["content"]}
+
+    message_log: LLMMessageLogType = []
+    user_message = {
+        "role": "user",
+        "content": task_data_spec.prompt.format(problem),
+    }
+    message: list[str] = tokenizer.apply_chat_template(  # type: ignore
+        [user_message],
+        tokenize=False,
+        add_generation_prompt=True,
+        add_special_tokens=False,
+    )
+    user_message["token_ids"] = tokenizer(message, return_tensors="pt")["input_ids"][0]
+    user_message["content"] = message[0]
+    message_log.append(user_message)
+
+    length = sum(len(m["token_ids"]) for m in message_log)
+
+    loss_multiplier = 1.0
+    if length > max_seq_length:
+        # make smaller and mask out
+        for chat_message in message_log:
+            chat_message["token_ids"] = chat_message["token_ids"][
+                : min(4, max_seq_length // len(message_log))
+            ]
+        loss_multiplier = 0.0
+
+    output: DatumSpec = {
+        "message_log": message_log,
+        "length": length,
+        "extra_env_info": extra_env_info,
+        "loss_multiplier": loss_multiplier,
+        "idx": idx,
+        "task_name": datum_dict["task_name"],
+    }
+    return output
+
+
+# Example of a generic math data processor
+# TaskDataProcessFnCallable
+def math_data_processor(
+    datum_dict: dict[str, Any],
+    task_data_spec: TaskDataSpec,
+    tokenizer: TokenizerType,
+    max_seq_length: int,
+    idx: int,
+) -> DatumSpec:
+    """Process a datum dictionary (directly loaded from dataset) into a DatumSpec for the Math Environment."""
+    problem = datum_dict["problem"]
+    solution = str(datum_dict["expected_answer"])
+    extra_env_info = {"ground_truth": solution}
+
+    message_log: LLMMessageLogType = []
+
+    # system prompt
+    if task_data_spec.system_prompt:
+        sys_prompt: dict[str, str | torch.Tensor] = {
+            "role": "system",
+            "content": task_data_spec.system_prompt,
+        }
+        sys = tokenizer.apply_chat_template(
+            [cast(dict[str, str], sys_prompt)],
+            tokenize=False,
+            add_generation_prompt=False,
+            add_special_tokens=False,
+        )
+        sys_prompt["token_ids"] = tokenizer(sys, return_tensors="pt")["input_ids"][0]
+        message_log.append(sys_prompt)
+
+    # user prompt
+    if task_data_spec.prompt:
+        problem = task_data_spec.prompt.format(problem)
+    user_message = {"role": "user", "content": problem}
+    message = tokenizer.apply_chat_template(
+        [user_message],
+        tokenize=False,
+        add_generation_prompt=True,
+        add_special_tokens=False,
+    )
+    user_message["token_ids"] = tokenizer(message, return_tensors="pt")["input_ids"][0]
+    user_message["content"] = message
+    message_log.append(user_message)
+
+    length = sum(len(m["token_ids"]) for m in message_log)
+
+    loss_multiplier = 1.0
+    if length > max_seq_length:
+        # make smaller and mask out
+        for indiv_message in message_log:
+            indiv_message["token_ids"] = indiv_message["token_ids"][
+                : min(4, max_seq_length // len(message_log))
+            ]
+        loss_multiplier = 0.0
+
+    output: DatumSpec = {
+        "message_log": message_log,
+        "length": length,
+        "extra_env_info": extra_env_info,
+        "loss_multiplier": loss_multiplier,
+        "idx": idx,
+    }
+    if "task_name" in datum_dict:
+        output["task_name"] = datum_dict["task_name"]
+    return output
+
+
+def setup_data(
+    tokenizer: TokenizerType,
+    data_config: DataConfig,
+    env_configs: dict[str, Any],
+) -> tuple[
+    AllTaskProcessedDataset,
+    Optional[AllTaskProcessedDataset],
+    dict[str, EnvironmentInterface],
+    dict[str, EnvironmentInterface],
+]:
+    print("\n▶ Setting up data...")
+    math_task_spec = TaskDataSpec(
+        task_name="math",
+        prompt_file=data_config["prompt_file"],
+        system_prompt_file=data_config["system_prompt_file"],
+    )
+
+    # Load OpenMathInstruct2Dataset using nemo rl datasets
+    if data_config["dataset_name"] == "OpenMathInstruct-2":
+        print("Loading nvidia/OpenMathInstruct2Dataset for training and validation")
+        data: Any = OpenMathInstruct2Dataset()
+    elif data_config["dataset_name"] == "DeepScaler":
+        print(
+            "Loading agentica-org/DeepScaleR-Preview-Dataset for training and validation"
+        )
+        data: Any = DeepScalerDataset()
+    else:
+        raise ValueError(f"No processor for dataset {data_config['dataset_name']}.")
+
+    task_data_processors: dict[str, tuple[TaskDataSpec, TaskDataProcessFnCallable]] = (
+        defaultdict(lambda: (math_task_spec, hf_data_processor))
+    )
+    task_data_processors["math"] = (math_task_spec, hf_data_processor)
+
+    math_env = MathEnvironment.options(  # type: ignore # it's wrapped with ray.remote
+        runtime_env={
+            "py_executable": get_actor_python_env(
+                "nemo_rl.environments.math_environment.MathEnvironment"
+            ),
+            "env_vars": dict(os.environ),  # Pass thru all user environment variables
+        }
+    ).remote(env_configs["math"])
+    dataset = AllTaskProcessedDataset(
+        data.formatted_ds["train"],
+        tokenizer,
+        math_task_spec,
+        task_data_processors,
+        max_seq_length=data_config["max_input_seq_length"],
+    )
+
+    val_dataset: Optional[AllTaskProcessedDataset] = None
+    if data.formatted_ds["validation"]:
+        val_dataset = AllTaskProcessedDataset(
+            data.formatted_ds["validation"],
+            tokenizer,
+            math_task_spec,
+            task_data_processors,
+            max_seq_length=data_config["max_input_seq_length"],
+        )
+    else:
+        val_dataset = None
+
+    task_to_env: dict[str, EnvironmentInterface] = defaultdict(lambda: math_env)
+    task_to_env["math"] = math_env
+    return dataset, val_dataset, task_to_env, task_to_env
+
+
+def main() -> None:
+    """Main entry point."""
+    # Parse arguments
+    args, overrides = parse_args()
+
+    if not args.config:
+        args.config = os.path.join(
+            os.path.dirname(__file__), "configs", "grpo_math_1B.yaml"
+        )
+
+    config = load_config(args.config)
+    print(f"Loaded configuration from: {args.config}")
+
+    if overrides:
+        print(f"Overrides: {overrides}")
+        config = parse_hydra_overrides(config, overrides)
+
+    config: MasterConfig = OmegaConf.to_container(config, resolve=True)
+    print("Applied CLI overrides")
+
+    # Print config
+    print("Final config:")
+    pprint.pprint(config)
+
+    # Get the next experiment directory with incremented ID
+    config["logger"]["log_dir"] = get_next_experiment_dir(config["logger"]["log_dir"])
+    print(f"📊 Using log directory: {config['logger']['log_dir']}")
+    if config["checkpointing"]["enabled"]:
+        print(
+            f"📊 Using checkpoint directory: {config['checkpointing']['checkpoint_dir']}"
+        )
+
+    init_ray()
+
+    # setup tokenizer
+    tokenizer = get_tokenizer(config["policy"]["tokenizer"])
+    assert config["policy"]["generation"] is not None, (
+        "A generation config is required for GRPO"
+    )
+    config["policy"]["generation"] = configure_generation_config(
+        config["policy"]["generation"], tokenizer
+    )
+
+    # setup data
+    (
+        dataset,
+        val_dataset,
+        task_to_env,
+        val_task_to_env,
+    ) = setup_data(tokenizer, config["data"], config["env"])
+
+    (
+        policy,
+        policy_generation,
+        cluster,
+        dataloader,
+        val_dataloader,
+        loss_fn,
+        logger,
+        checkpointer,
+        grpo_state,
+        master_config,
+    ) = setup(config, tokenizer, dataset, val_dataset)
+
+    grpo_train(
+        policy,
+        policy_generation,
+        dataloader,
+        val_dataloader,
+        tokenizer,
+        loss_fn,
+        task_to_env,
+        val_task_to_env,
+        logger,
+        checkpointer,
+        grpo_state,
+        master_config,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_skills/training/nemo_rl/start_grpo.py
+++ b/nemo_skills/training/nemo_rl/start_grpo.py
@@ -299,7 +299,7 @@ def setup_data(
     # Load OpenMathInstruct2Dataset using nemo rl datasets
     if data_config["dataset_name"] == "OpenMathInstruct-2":
         print("Loading nvidia/OpenMathInstruct2Dataset for training and validation")
-        data: Any = OpenMathInstruct2Dataset(dataset_path=data_config.get("train_data_path", "nvidia/OpenMathInstruct-2"))
+        data: Any = CustomOpenMathInstruct2Dataset(dataset_path=data_config.get("train_data_path", "nvidia/OpenMathInstruct-2"))
     elif data_config["dataset_name"] == "DeepScaler":
         print(
             "Loading agentica-org/DeepScaleR-Preview-Dataset for training and validation"


### PR DESCRIPTION
This  will work on a jsonl file with `expected_answer` and `problem` keys--at  the moment all formatting is done internally based on the tokenizer and provided template.

Here is an example python command for running it:

```python
from nemo_skills.pipeline.cli  import grpo_nemo_rl, wrap_arguments

run_number = 1
cluster = ''
wandb_project = f'georgea-nemo-rl-test'
expname =  f'repro-dapo-{run_number:02d}'
partition = 'interactive'

grpo_nemo_rl(
    ctx=wrap_arguments(
        ''
    ),
    cluster=cluster,
    partition=partition,
    wandb_project=wandb_project,
    expname=expname,
    output_dir=f'/experiments/nemo-rl-test-integration/01-grpo/run_{run_number:02d}_{suffix}',
    hf_model='/hf_models/Qwen2.5-7B',
    training_data="/data/rl-data-filtered.jsonl",
    cache_dir='/data/openmathinstruct-2/.cache',
    num_gpus=8,
    num_nodes=1,
    num_training_jobs=1,
)

```