### PR TITLE
Allow skipping :0 for evals

### DIFF
--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -242,7 +242,7 @@ def eval(
     if " " in str(benchmarks):
         raise ValueError("benchmarks should be separated with commas")
 
-    benchmarks = {k: int(v) for k, v in [b.split(":") for b in benchmarks.split(",")]}
+    benchmarks = {k: int(v) for k, v in [b.split(":") if ":" in b else (b, 0) for b in benchmarks.split(",")]}
     extra_datasets = extra_datasets or os.environ.get("NEMO_SKILLS_EXTRA_DATASETS")
 
     if num_jobs is None:
@@ -274,6 +274,9 @@ def eval(
     if num_jobs < 0:
         # if num_jobs is -1, we run all benchmarks in parallel
         num_jobs = total_evals
+
+    if num_jobs == 0:
+        return None
 
     evals_per_job = total_evals // num_jobs if num_jobs > 0 else total_evals
     remainder = total_evals % num_jobs

--- a/nemo_skills/pipeline/utils/server.py
+++ b/nemo_skills/pipeline/utils/server.py
@@ -199,7 +199,7 @@ def get_server_command(
 
     # check if the model path is mounted if not vllm;
     # vllm can also pass model name as "model_path" so we need special processing
-    if server_type not in ["vllm", "sglang"]:
+    if server_type not in ["vllm", "sglang", "trtllm-serve"]:
         check_if_mounted(cluster_config, model_path)
 
     # the model path will be mounted, so generally it will start with /


### PR DESCRIPTION
can just specify `--benchmarks=gsm8k` and it will default to `gsm8k:0`