### PR TITLE
Fix None Outputs

### DIFF
--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -473,6 +473,8 @@ class OpenAIAPIModel(BaseModel):
     def _parse_completion_response(self, response: "openai.types.Completion") -> dict:
         choice = response.choices[0]
         output = choice.text
+        if output is None:
+            output = ""
 
         # In some cases, the stop reason is not included in the text, so we add it back
         if choice.finish_reason == "stop":
@@ -494,6 +496,8 @@ class OpenAIAPIModel(BaseModel):
     def _parse_chat_completion_response(self, response) -> dict:
         choice = response.choices[0]
         output = choice.message.content
+        if output is None:
+            output = ""
         result = {'generation': output, 'num_generated_tokens': response.usage.completion_tokens}
         if choice.logprobs and choice.logprobs.content:
             result['logprobs'] = [tok.logprob for tok in choice.logprobs.content]


### PR DESCRIPTION
When we set "--reasoning-parser" in sglang, if the generation is cut half-way before the </think> part, the output text becomes None, since there is no summary part. This causes the whole engine to treat this generation as "incomplete" and raises quite a few exceptions, such as the following:

```
Traceback (most recent call last):
  File "/nemo_run/code/nemo_skills/inference/generate.py", line 616, in generate
    task.generate()
  File "/nemo_run/code/nemo_skills/inference/generate.py", line 599, in generate
    self.async_loop(data)
  File "/nemo_run/code/nemo_skills/inference/generate.py", line 533, in async_loop
    requests_in_progress, generations = self.get_llm_generations(requests_in_progress, generations)
  File "/nemo_run/code/nemo_skills/inference/generate.py", line 485, in get_llm_generations
    outputs = self.llm.get_generations(gen_ids)
  File "/nemo_run/code/nemo_skills/inference/model/base.py", line 178, in get_generations
    raise ValueError(f"Generation id {generation_id} not found.")
ValueError: Generation id b27903fe-b429-4b9c-b2bb-eae47357a483 not found.
```

We might need to change the "incomplete generation" logic later, but this one seems to be a good fix, since we do several string operations in the code.