### PR TITLE
Support for client side parsing for BFCL

### DIFF
--- a/nemo_skills/inference/eval/bfcl_utils.py
+++ b/nemo_skills/inference/eval/bfcl_utils.py
@@ -70,16 +70,19 @@ def execute_multi_turn_func_call(
     func_call_list: list[str],  # a list of strings of func calls
     initial_config: dict,
     involved_classes: list,
-    model_name: str,
     test_entry_id: str,
     long_context: bool = False,
-    is_evaL_run: bool = False,
 ) -> tuple[list[str], dict]:
     """
-    TODO: Add docstring
+    Execute the function calls in the list.
+
+    Args:
+        func_call_list (list[str]): A list of strings of function calls.
+        initial_config (dict): A dictionary of initial configurations for the classes.
+        involved_classes (list): A list of class names that are involved in the function calls.
+        test_entry_id (str): The id of the test entry.
+        long_context (bool): Whether to use long context.
     """
-    if is_evaL_run:
-        model_name += "_eval"
 
     class_method_name_mapping = {}
     involved_instances = {}

--- a/nemo_skills/inference/model/trtllm.py
+++ b/nemo_skills/inference/model/trtllm.py
@@ -37,7 +37,7 @@ class TRTLLMModel(BaseModel):
         # Ignored for TRTLLM. TODO: disallow setting
         reasoning_effort: str | list[int] | None = None,
         tools: list[dict] | None = None,
-        include_message: bool = False,
+        include_response: bool = False,
     ) -> list[dict]:
         if isinstance(prompt, dict):
             raise NotImplementedError("trtllm server does not support OpenAI \"messages\" as prompt.")
@@ -101,7 +101,7 @@ class TRTLLMModel(BaseModel):
         # Ignored for TRTLLM. TODO: disallow setting
         reasoning_effort: str | list[int] | None = None,
         tools: list[dict] | None = None,
-        include_message: bool = False,
+        include_response: bool = False,
     ) -> list[dict]:
         """For any generation parameter you can specify a list of values that needs to match the number of prompts.
 


### PR DESCRIPTION
By supplying the params: 
- `use_client_parsing` -> True
- `model_name` -> Model name such as "Qwen/Qwen3-4B-FC"

the bfcl implementation will use BFCL's handling of prompt formatting and tool parsing.