### PR TITLE
Inference on LiveCodeBench-pro

### DIFF
--- a/nemo_skills/dataset/livecodebench-pro/__init__.py
+++ b/nemo_skills/dataset/livecodebench-pro/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'eval/livecodebench/python_codegen'
+DATASET_GROUP = 'code'
+METRICS_TYPE = 'livecodebench'
+EVAL_SPLIT = 'livecodebench_pro'
+EVAL_ARGS = "++eval_type=livecodebench"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/livecodebench-pro/prepare.py
+++ b/nemo_skills/dataset/livecodebench-pro/prepare.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from datasets import load_dataset
+
+if __name__ == '__main__':
+    # Write an argparse to a json file, read it in and parse it
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_dir', type=str, default=str(Path(__file__).parent))
+    args = parser.parse_args()
+
+    if not os.path.exists(args.output_dir):
+        os.makedirs(args.output_dir)
+
+    dataset = load_dataset("anonymous1926/anonymous_dataset")
+    output_file_path = os.path.join(args.output_dir, f"livecodebench_pro.jsonl")
+    with open(output_file_path, 'w') as f:
+        for split_name, split in dataset.items():
+            for row in split:
+                row['task_id'] = row.pop('problem_id')
+                row['question'] = row.pop('problem_statement')
+                row['split'] = split_name
+                json.dump(
+                    row,
+                    f,
+                )
+                f.write('\n')

--- a/nemo_skills/evaluation/evaluator/code.py
+++ b/nemo_skills/evaluation/evaluator/code.py
@@ -91,64 +91,82 @@ def install_from_git(git_url):
 class LiveCodeBenchEvaluatorConfig:
     language: str = "python"  # "cpp" is another option now
     test_file: str = None
+    is_livecodebench_pro: bool = False  # "to support LiveCodeBench-pro"
 
 
 def eval_livecodebench(cfg):
-    try:
-        from livecodebench.evaluate import evaluate
-    except ImportError:
-        LOG.info("Package 'livecodebench' not found. Attempting to install...")
-        install_from_git("git+https://github.com/wasiahmad/livecodebench.git")
-        try:
-            from livecodebench.evaluate import evaluate
-        except ImportError:
-            LOG.info("Failed to install 'livecodebench'. Please install it manually.")
-            raise
-
     eval_config = LiveCodeBenchEvaluatorConfig(_init_nested=True, **cfg.eval_config)
-    assert eval_config.language in ["python", "cpp"]
-    if eval_config.language == "cpp":
-        assert eval_config.test_file is not None
 
-    release_version = None
-    for jsonl_file in unroll_files(cfg.input_files):
-        with open(jsonl_file) as f:
-            samples = [preprocess_code(json.loads(line), eval_config.language) for line in f]
-            for sample in samples:
-                sample["question_id"] = sample["task_id"]
-                sample["code_list"] = [sample["completion"]]
-                if release_version is None:
-                    release_version = sample["release_version"]
-                if release_version != sample["release_version"]:
-                    raise ValueError(
-                        f"All samples should have the same release version, "
-                        f"but got {release_version} and {sample['release_version']}"
-                    )
-        with open(jsonl_file, "wt", encoding="utf-8") as f:
-            for sample in samples:
-                f.write(json.dumps(sample) + "\n")
+    if eval_config.is_livecodebench_pro:
+        assert eval_config.language == "python"
+        for jsonl_file in unroll_files(cfg.input_files):
+            with open(jsonl_file) as f:
+                samples = [preprocess_code(json.loads(line), eval_config.language) for line in f]
+                for sample in samples:
+                    sample["problem_id"] = sample.pop("task_id")
+                    sample["text_response"] = sample.pop("completion")
+                    sample["response_meta"] = None
 
-        # https://github.com/wasiahmad/livecodebench/blob/main/livecodebench/evaluate.py#L10
-        evaluate(
-            custom_output_file=jsonl_file,
-            release_version=f"release_{release_version}",
-            k_list=[1],
-            language=eval_config.language,
-            test_file=None if eval_config.language == "python" else eval_config.test_file,
-            num_process_evaluate=12,
-            timeout=6 if eval_config.language == "python" else 30,
-        )
+            with open(jsonl_file, "wt", encoding="utf-8") as f:
+                for sample in samples:
+                    f.write(json.dumps(sample) + "\n")
 
-        with open(jsonl_file[:-6] + '_eval_results.json', 'rt', encoding="utf-8") as fin:
-            eval_grades = json.load(fin)
-        # adding is_correct key to allow compute_metrics to work
-        with open(jsonl_file, "wt", encoding="utf-8") as f:
-            for sample in samples:
-                sample['graded_list'] = eval_grades['eval'][sample['task_id']]['graded_list']
-                f.write(json.dumps(sample) + "\n")
+    else:
+        assert eval_config.language in ["python", "cpp"]
+        if eval_config.language == "cpp":
+            assert eval_config.test_file is not None
 
-        # moving eval file to ensure metrics are recomputed
-        shutil.move(jsonl_file[:-6] + '_eval_results.json', jsonl_file[:-6] + '_eval_results-saved.json')
+        release_version = None
+        for jsonl_file in unroll_files(cfg.input_files):
+            with open(jsonl_file) as f:
+                samples = [preprocess_code(json.loads(line), eval_config.language) for line in f]
+                for sample in samples:
+                    sample["question_id"] = sample["task_id"]
+                    sample["code_list"] = [sample["completion"]]
+                    if release_version is None:
+                        release_version = sample["release_version"]
+                    if release_version != sample["release_version"]:
+                        raise ValueError(
+                            f"All samples should have the same release version, "
+                            f"but got {release_version} and {sample['release_version']}"
+                        )
+
+            with open(jsonl_file, "wt", encoding="utf-8") as f:
+                for sample in samples:
+                    f.write(json.dumps(sample) + "\n")
+
+            try:
+                from livecodebench.evaluate import evaluate
+            except ImportError:
+                LOG.info("Package 'livecodebench' not found. Attempting to install...")
+                install_from_git("git+https://github.com/wasiahmad/livecodebench.git")
+                try:
+                    from livecodebench.evaluate import evaluate
+                except ImportError:
+                    LOG.info("Failed to install 'livecodebench'. Please install it manually.")
+                    raise
+
+            # https://github.com/wasiahmad/livecodebench/blob/main/livecodebench/evaluate.py#L10
+            evaluate(
+                custom_output_file=jsonl_file,
+                release_version=f"release_{release_version}",
+                k_list=[1],
+                language=eval_config.language,
+                test_file=None if eval_config.language == "python" else eval_config.test_file,
+                num_process_evaluate=12,
+                timeout=6 if eval_config.language == "python" else 30,
+            )
+
+            with open(jsonl_file[:-6] + '_eval_results.json', 'rt', encoding="utf-8") as fin:
+                eval_grades = json.load(fin)
+            # adding is_correct key to allow compute_metrics to work
+            with open(jsonl_file, "wt", encoding="utf-8") as f:
+                for sample in samples:
+                    sample['graded_list'] = eval_grades['eval'][sample['task_id']]['graded_list']
+                    f.write(json.dumps(sample) + "\n")
+
+            # moving eval file to ensure metrics are recomputed
+            shutil.move(jsonl_file[:-6] + '_eval_results.json', jsonl_file[:-6] + '_eval_results-saved.json')
 
 
 def eval_evalplus(cfg):


### PR DESCRIPTION
In this PR, we are adding inference support for [LiveCodeBench-pro](https://livecodebenchpro.com/) through nemo-skills. Primary changes are:

- Dataset download through `nemo-skills/dataset/livecodebench-pro`
- Evaluation logic implemented at `nemo_skills/evaluation/evaluator/code.py`