### PR TITLE
Soft failure for BFCL

### DIFF
--- a/nemo_skills/inference/eval/bfcl.py
+++ b/nemo_skills/inference/eval/bfcl.py
@@ -173,7 +173,7 @@ class BFCLGenerationTask(GenerationTask):
         except openai.BadRequestError as e:
             if "Requested token count exceeds the model's maximum context length" in str(e):
                 LOG.warning("BFCL generation failed due to running out of context. ")
-                return {"message": None, "generation": "_ran_out_of_context_"}
+                return {"message": None, "generation": ""}
             else:
                 raise
 
@@ -209,10 +209,7 @@ class BFCLGenerationTask(GenerationTask):
         model_response = self._generate_single_assistant_turn(state_dict)
         if model_response["message"] is None:
             # Ran out of context
-            return {
-                "generation": "",
-                "num_generated_tokens": 0,
-            }    
+            return {"generation": "", "num_generated_tokens": 0}    
         else:
             proc_model_response = self._process_model_response(model_response)
             return {

--- a/nemo_skills/inference/eval/bfcl.py
+++ b/nemo_skills/inference/eval/bfcl.py
@@ -260,10 +260,11 @@ class BFCLGenerationTask(GenerationTask):
                 if model_response["message"] is None:
                     # Ran out of context
                     out_of_context = True
+                    LOG.info("Quitting the multi-turn generation due to running out of context.")
                     break
+
                 output_dict["num_generated_tokens"] += model_response.get("num_generated_tokens", 0)
                 output_dict["log_dict_list"].append(model_response)
-            
 
                 if self.cfg.remove_thinking:
                     if self.cfg.use_client_parsing:

--- a/nemo_skills/inference/eval/bfcl.py
+++ b/nemo_skills/inference/eval/bfcl.py
@@ -168,7 +168,7 @@ class BFCLGenerationTask(GenerationTask):
             output = self.llm.generate(**input_dict)[0]
         # TODO: Currently we're assuming an openai interface which is not true for all servers
         except openai.BadRequestError as e:
-            if 'Please reduce the length of the messages or completion' in str(e):
+            if "Requested token count exceeds the model's maximum context length" in str(e):
                 LOG.warning("BFCL generation failed due to running out of context. ")
                 return {"message": None, "generation": "_ran_out_of_context_"}
             else:

--- a/nemo_skills/inference/eval/bfcl.py
+++ b/nemo_skills/inference/eval/bfcl.py
@@ -146,6 +146,7 @@ class BFCLGenerationTask(GenerationTask):
         if self.cfg.system_message:
             messages = [{"role": "system", "content": self.cfg.system_message}] + messages
 
+        # Step 1: Construct the prompt 
         if self.cfg.use_client_parsing:
             fmted_prompt = self.cfg.message_formatter(messages, tools=tools)
             input_dict = {
@@ -163,6 +164,8 @@ class BFCLGenerationTask(GenerationTask):
                 **self.extra_generate_params,
             }
 
+
+        # Step 2: Query the LLM server
         # Enable soft-fail when the models run out of context
         try:
             output = self.llm.generate(**input_dict)[0]
@@ -174,7 +177,7 @@ class BFCLGenerationTask(GenerationTask):
             else:
                 raise
 
-        
+        # Step 3: Parse the generated output. In case of server side parsing, merely getting the response message
         if self.cfg.use_client_parsing:
             parsed_response = self.cfg.response_parser(output["response"])["model_responses_message_for_chat_history"]
 

--- a/nemo_skills/inference/eval/bfcl.py
+++ b/nemo_skills/inference/eval/bfcl.py
@@ -171,7 +171,7 @@ class BFCLGenerationTask(GenerationTask):
             output = self.llm.generate(**input_dict)[0]
         # TODO: Currently we're assuming an openai interface which is not true for all servers
         except openai.BadRequestError as e:
-            if "Requested token count exceeds the model's maximum context length" in str(e):
+            if "Requested token count exceeds the model's maximum context length" in str(e) or "is longer than the model's context length" in str(e):
                 LOG.warning("BFCL generation failed due to running out of context. ")
                 return {"message": None, "generation": ""}
             else:

--- a/nemo_skills/inference/eval/bfcl.py
+++ b/nemo_skills/inference/eval/bfcl.py
@@ -204,11 +204,18 @@ class BFCLGenerationTask(GenerationTask):
         state_dict = {"messages": data_point["question"][0], "tools": data_point["tools"]}
 
         model_response = self._generate_single_assistant_turn(state_dict)
-        proc_model_response = self._process_model_response(model_response)
-        return {
-            "generation": proc_model_response["generation"],
-            "num_generated_tokens": model_response.get("num_generated_tokens", 0),
-        }
+        if model_response["message"] is None:
+            # Ran out of context
+            return {
+                "generation": "",
+                "num_generated_tokens": 0,
+            }    
+        else:
+            proc_model_response = self._process_model_response(model_response)
+            return {
+                "generation": proc_model_response["generation"],
+                "num_generated_tokens": model_response.get("num_generated_tokens", 0),
+            }
 
     def generate_single_data_point_multi_turn(self, data_point):
         """Generate for a single data point with multiple turns."""


### PR DESCRIPTION
Added the logic for soft failure. The model exits the conversation when it is about to run out of context. Have tested it on Qwen3-4B, and the soft fail logic worked. 