### PR TITLE
Allow generation type or custom module in `eval` pipeline

### DIFF
--- a/nemo_skills/inference/__init__.py
+++ b/nemo_skills/inference/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .factory import GenerationType, GENERATION_MODULE_MAP
+
+__all__ = ["GenerationType", "GENERATION_MODULE_MAP"]

--- a/nemo_skills/inference/factory.py
+++ b/nemo_skills/inference/factory.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class GenerationType(str, Enum):
+    generate = "generate"
+    reward = "reward"
+    math_judge = "math_judge"
+    check_contamination = "check_contamination"
+
+
+GENERATION_MODULE_MAP = {
+    GenerationType.generate: "nemo_skills.inference.generate",
+    GenerationType.math_judge: "nemo_skills.inference.llm_math_judge",
+    GenerationType.check_contamination: "nemo_skills.inference.check_contamination",
+}

--- a/nemo_skills/inference/factory.py
+++ b/nemo_skills/inference/factory.py
@@ -3,7 +3,6 @@ from enum import Enum
 
 class GenerationType(str, Enum):
     generate = "generate"
-    reward = "reward"
     math_judge = "math_judge"
     check_contamination = "check_contamination"
 

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 import hydra
-from omegaconf import ListConfig, OmegaConf, open_dict
+from omegaconf import ListConfig, OmegaConf
 from tqdm import tqdm
 
 from nemo_skills.code_execution.sandbox import get_sandbox, sandbox_params

--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -22,6 +22,7 @@ import typer
 
 import nemo_skills.pipeline.utils as pipeline_utils
 from nemo_skills.dataset.utils import ExtraDatasetType
+from nemo_skills.inference import GenerationType
 from nemo_skills.pipeline.app import app, typer_unpacker
 from nemo_skills.pipeline.generate import generate as _generate
 from nemo_skills.pipeline.utils.eval import prepare_eval_commands
@@ -54,6 +55,13 @@ def eval(
         "If you want to use multiple benchmarks, separate them with comma. E.g. gsm8k:4,human-eval",
     ),
     expname: str = typer.Option("eval", help="Name of the experiment"),
+    generation_type: GenerationType | None = typer.Option(None, help="Type of generation to perform"),
+    generation_module: str = typer.Option(
+        None,
+        help="Path to the generation module to use. "
+        "If not specified, will use the registered generation module for the "
+        "generation type (which is required in this case).",
+    ),
     model: str = typer.Option(None, help="Path to the model to be evaluated"),
     server_address: str = typer.Option(None, help="Address of the server hosting the model"),
     server_type: pipeline_utils.SupportedServers = typer.Option(..., help="Type of server to use"),
@@ -261,6 +269,8 @@ def eval(
         with_sandbox,
         wandb_parameters,
         extra_eval_args,
+        generation_type=generation_type,
+        generation_module=generation_module,
     )
     get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive, server_type)
     should_package_extra_datasets = extra_datasets and extra_datasets_type == ExtraDatasetType.local

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import importlib
 import logging
-from enum import Enum
 from typing import List
 
 import typer
@@ -21,25 +20,11 @@ import typer
 import nemo_skills.pipeline.utils as pipeline_utils
 from nemo_skills.pipeline.app import app, typer_unpacker
 from nemo_skills.utils import compute_chunk_ids, get_logger_name, setup_logging, str_ids_to_list
+from nemo_skills.inference import GenerationType, GENERATION_MODULE_MAP
 
 LOG = logging.getLogger(get_logger_name(__file__))
 
 # TODO: add num_jobs here for consistency with eval?
-
-
-class GenerationType(str, Enum):
-    generate = "generate"
-    reward = "reward"
-    math_judge = "math_judge"
-    check_contamination = "check_contamination"
-
-
-GENERATION_MODULE_MAP = {
-    GenerationType.generate: "nemo_skills.inference.generate",
-    GenerationType.math_judge: "nemo_skills.inference.llm_math_judge",
-    GenerationType.check_contamination: "nemo_skills.inference.check_contamination",
-}
-
 
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 @typer_unpacker


### PR DESCRIPTION
This PR introduces two new CLI arguments for `ns eval`.

```shell
│    --generation_type                                          [generate|reward|math_judge|check_contamination]  Type of generation to perform [default: None]         │
│    --generation_module                                        TEXT                                              Path to the generation module to use. If not          │
│                                                                                                                 specified, will use the registered generation module  │
│                                                                                                                 for the generation type (which is required in this    │
│                                                                                                                 case).                                                │
│ 
```