### PR TITLE
Pin openai version to v1.99.9

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -28,7 +28,7 @@ ipython
 math-verify[antlr4_9_3]
 nemo_run @ git+https://github.com/NVIDIA/NeMo-Run
 numpy
-openai
+openai==1.99.9
 pyyaml
 rank_bm25
 requests


### PR DESCRIPTION
Temporary fix for https://github.com/openai/openai-python/issues/2564.