### PR TITLE
Tool support based on Chat Completion APIs

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -136,6 +136,7 @@ class GenerateSolutionsConfig:
     # genselect config
     online_genselect_config: OnlineGenSelectConfig = field(default_factory=OnlineGenSelectConfig)
 
+    ## FIXME(sanyamk): Rethink the structure of this configuration.
     tool_config: str | None = None  # Path to tool configuration file.
 
     # if True, will move full generation to _full_generation key and keep cfg.generation_key without thinking tokens

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -136,9 +136,7 @@ class GenerateSolutionsConfig:
     # genselect config
     online_genselect_config: OnlineGenSelectConfig = field(default_factory=OnlineGenSelectConfig)
 
-    # TODO(sanyamk): tool configuration path
-    with_tools: bool = False
-    tool_config: str | None = None  # Path to tool configuration file. Required in `with_tools` is True
+    tool_config: str | None = None  # Path to tool configuration file.
 
     # if True, will move full generation to _full_generation key and keep cfg.generation_key without thinking tokens
     remove_thinking: bool = False
@@ -272,7 +270,7 @@ class GenerationTask:
 
         if self.cfg.code_execution:
             llm = get_code_execution_model(**self.cfg.server, sandbox=self.sandbox)
-        elif self.cfg.with_tools:
+        elif self.cfg.tool_config:
             llm = get_tool_calling_model(
                 **self.cfg.server, tool_config=self.cfg.tool_config, additional_config={"sandbox": self.cfg.sandbox}
             )

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -22,7 +22,7 @@ import time
 from copy import deepcopy
 from dataclasses import asdict, field, is_dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import hydra
 from omegaconf import ListConfig, OmegaConf
@@ -34,6 +34,7 @@ from nemo_skills.inference.model import (
     get_code_execution_model,
     get_model,
     get_online_genselect_model,
+    get_tool_calling_model,
     server_params,
 )
 from nemo_skills.prompt.utils import get_prompt
@@ -134,6 +135,9 @@ class GenerateSolutionsConfig:
     online_genselect: bool = False
     # genselect config
     online_genselect_config: OnlineGenSelectConfig = field(default_factory=OnlineGenSelectConfig)
+
+    # TODO(sanyamk): tool configuration path
+    with_tools: bool = False
 
     # if True, will move full generation to _full_generation key and keep cfg.generation_key without thinking tokens
     remove_thinking: bool = False
@@ -263,10 +267,16 @@ class GenerationTask:
         self.output_lock = None
 
     def setup_llm(self):
+        self.sandbox = get_sandbox(**self.cfg.sandbox) if self.cfg.sandbox is not None else None
+
         if self.cfg.code_execution:
-            sandbox = get_sandbox(**self.cfg.sandbox) if self.cfg.sandbox is not None else None
-            llm = get_code_execution_model(**self.cfg.server, sandbox=sandbox)
-        elif self.cfg.online_genselect:
+            llm = get_code_execution_model(**self.cfg.server, sandbox=self.sandbox)
+        elif self.cfg.with_tools:
+            llm = get_tool_calling_model(**self.cfg.server, sandbox=self.sandbox)
+        else:
+            llm = get_model(**self.cfg.server)
+
+        if self.cfg.online_genselect:
             # Use the same prompt parameters for genselect as the one used for generation
             self.cfg.online_genselect_config.use_completions_api = self.cfg.use_completions_api
             self.cfg.online_genselect_config.tokenizer = self.cfg.tokenizer
@@ -276,8 +286,6 @@ class GenerationTask:
             llm = get_online_genselect_model(
                 **self.cfg.server, online_genselect_config=self.cfg.online_genselect_config
             )
-        else:
-            llm = get_model(**self.cfg.server)
 
         return llm
 
@@ -445,10 +453,10 @@ class GenerationTask:
             inference_params = dict(self.cfg.inference)
 
         generation_params = {
-            "prompt": self.fill_prompt(data_point, all_data),
-            "stop_phrases": [self.cfg.stop_phrase] if self.cfg.stop_phrase else None,
             **inference_params,
             **self.extra_generate_params,
+            "prompt": self.fill_prompt(data_point, all_data),
+            "stop_phrases": [self.cfg.stop_phrase] if self.cfg.stop_phrase else None,
         }
 
         if self.cfg.code_execution:

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -284,7 +284,8 @@ class GenerationTask:
             self.cfg.online_genselect_config.thinking_begin = self.cfg.thinking_begin
             self.cfg.online_genselect_config.thinking_end = self.cfg.thinking_end
             llm = get_online_genselect_model(
-                **self.cfg.server, online_genselect_config=self.cfg.online_genselect_config
+                **{**self.cfg.server, "model": llm},
+                online_genselect_config=self.cfg.online_genselect_config,
             )
 
         return llm

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -138,6 +138,7 @@ class GenerateSolutionsConfig:
 
     # TODO(sanyamk): tool configuration path
     with_tools: bool = False
+    tool_config: str | None = None  # Path to tool configuration file. Required in `with_tools` is True
 
     # if True, will move full generation to _full_generation key and keep cfg.generation_key without thinking tokens
     remove_thinking: bool = False
@@ -272,7 +273,9 @@ class GenerationTask:
         if self.cfg.code_execution:
             llm = get_code_execution_model(**self.cfg.server, sandbox=self.sandbox)
         elif self.cfg.with_tools:
-            llm = get_tool_calling_model(**self.cfg.server, sandbox=self.sandbox)
+            llm = get_tool_calling_model(
+                **self.cfg.server, tool_config=self.cfg.tool_config, additional_config={"sandbox": self.cfg.sandbox}
+            )
         else:
             llm = get_model(**self.cfg.server)
 

--- a/nemo_skills/inference/model/__init__.py
+++ b/nemo_skills/inference/model/__init__.py
@@ -71,10 +71,10 @@ def get_online_genselect_model(model, online_genselect_config=None, **kwargs):
     return OnlineGenSelectWrapper(model=model, cfg=online_genselect_config or OnlineGenSelectConfig())
 
 
-def get_tool_calling_model(model, sandbox, **kwargs):
+def get_tool_calling_model(model=None, tool_config=None, additional_config=None, **kwargs):
     if isinstance(model, str):
         model = get_model(model=model, **kwargs)
-    return ToolCallingWrapper(model, sandbox)
+    return ToolCallingWrapper(model, tool_config_yaml=tool_config, additional_config=additional_config)
 
 
 def server_params():

--- a/nemo_skills/inference/model/__init__.py
+++ b/nemo_skills/inference/model/__init__.py
@@ -71,7 +71,7 @@ def get_online_genselect_model(model, online_genselect_config=None, **kwargs):
     return OnlineGenSelectWrapper(model=model, cfg=online_genselect_config or OnlineGenSelectConfig())
 
 
-def get_tool_calling_model(model=None, tool_config=None, additional_config=None, **kwargs):
+def get_tool_calling_model(model, tool_config, additional_config=None, **kwargs):
     if isinstance(model, str):
         model = get_model(model=model, **kwargs)
     return ToolCallingWrapper(model, tool_config_yaml=tool_config, additional_config=additional_config)

--- a/nemo_skills/inference/model/__init__.py
+++ b/nemo_skills/inference/model/__init__.py
@@ -64,14 +64,14 @@ def get_code_execution_model(server_type, code_execution=None, sandbox=None, **k
     return CodeExecutionWrapper(model=model, sandbox=sandbox, config=code_execution_config)
 
 
-def get_online_genselect_model(model=None, online_genselect_config=None, **kwargs):
+def get_online_genselect_model(model, online_genselect_config=None, **kwargs):
     """A helper function to create OnlineGenSelect model."""
     if isinstance(model, str):
         model = get_model(model=model, **kwargs)
     return OnlineGenSelectWrapper(model=model, cfg=online_genselect_config or OnlineGenSelectConfig())
 
 
-def get_tool_calling_model(model=None, sandbox=None, **kwargs):
+def get_tool_calling_model(model, sandbox, **kwargs):
     if isinstance(model, str):
         model = get_model(model=model, **kwargs)
     return ToolCallingWrapper(model, sandbox)

--- a/nemo_skills/inference/model/__init__.py
+++ b/nemo_skills/inference/model/__init__.py
@@ -28,6 +28,9 @@ from .megatron import MegatronModel
 from .online_genselect import OnlineGenSelectConfig, OnlineGenSelectWrapper
 from .openai import OpenAIModel
 
+# Tool Calling
+from .tool_call import ToolCallingWrapper
+
 # Utilities
 from .vllm import VLLMModel
 
@@ -61,12 +64,17 @@ def get_code_execution_model(server_type, code_execution=None, sandbox=None, **k
     return CodeExecutionWrapper(model=model, sandbox=sandbox, config=code_execution_config)
 
 
-def get_online_genselect_model(server_type, online_genselect_config=None, **kwargs):
+def get_online_genselect_model(model=None, online_genselect_config=None, **kwargs):
     """A helper function to create OnlineGenSelect model."""
-    model = get_model(server_type=server_type, **kwargs)
-    if online_genselect_config is None:
-        online_genselect_config = OnlineGenSelectConfig()
-    return OnlineGenSelectWrapper(model=model, cfg=online_genselect_config)
+    if isinstance(model, str):
+        model = get_model(model=model, **kwargs)
+    return OnlineGenSelectWrapper(model=model, cfg=online_genselect_config or OnlineGenSelectConfig())
+
+
+def get_tool_calling_model(model=None, sandbox=None, **kwargs):
+    if isinstance(model, str):
+        model = get_model(model=model, **kwargs)
+    return ToolCallingWrapper(model, sandbox)
 
 
 def server_params():

--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import copy
 import json
 import logging
 from typing import Dict, List
@@ -52,12 +53,16 @@ class ToolCallingWrapper:
         tool_name = tool_call["function"]["name"]
         tool_args = tool_call["function"]["arguments"]
 
+        ##
+        # TODO(sanyamk): Not all tool arguments might necessarily be in JSON format.
+        #   Kept here to handle errors for now.
         try:
             tool_args = json.loads(tool_args)
         except json.decoder.JSONDecodeError as e:
             LOG.exception(e)
             return {"error": "Tool argument parsing failed."}
 
+        ## TODO(sanyamk): Only exceptions related to tool execution here, all others must fail.
         try:
             result = await self.client_manager.execute_tool(tool_name, tool_args)
         except Exception as e:
@@ -91,7 +96,7 @@ class ToolCallingWrapper:
         generation_steps = []
         reasoning_steps = []
 
-        conversation = list(prompt)
+        conversation = copy.deepcopy(prompt)
 
         while True:
             generation = await self.model.generate_async(prompt=conversation, tools=tools, **generation_kwargs)

--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import textwrap
+from typing import Dict, List
+
+from litellm.types.utils import ChatCompletionMessageToolCall
+
+from nemo_skills.code_execution.sandbox import Sandbox
+from nemo_skills.utils import get_logger_name
+
+from .base import BaseModel
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+
+class ToolCallingWrapper:
+    """
+    Wrapper to handle tool calling.
+
+    TODO(sanyamk): Supports only Chat Completions API for now.
+    """
+
+    def __init__(self, model: BaseModel, sandbox: Sandbox):
+        self.model = model
+        self.sandbox = sandbox
+
+    async def _parse_tool_calls(self, tool_calls: List[ChatCompletionMessageToolCall]):
+        """Convert tool calls to conversation message item."""
+
+        tool_calls = [
+            {
+                "type": tool_call.type,
+                "function": {"name": tool_call.function.name, "arguments": tool_call.function.arguments},
+            }
+            for tool_call in tool_calls
+        ]
+
+        return {"role": "assistant", "tool_calls": tool_calls}
+
+    ## TODO(sanyamk): Support tool call IDs.
+    async def _execute_tool_call(self, tool_name: str, tool_args):
+        if isinstance(tool_args, str):
+            try:
+                tool_args = json.loads(tool_args)
+            except json.decoder.JSONDecodeError as e:
+                LOG.exception(e)
+
+                return {
+                    "role": "tool",
+                    "name": tool_name,
+                    "content": json.dumps({"error": "Tool execution failed, unable to parse arguments."}),
+                }
+
+        ## TODO(sanyamk): Replace tool handlers with MCP.
+        if tool_name == "exa_websearch":
+            tool_code = textwrap.dedent(
+                f"""
+                from exa_py import Exa
+                import os
+
+                exa = Exa(os.getenv("EXA_API_KEY"))
+
+                result = exa.answer({repr(tool_args["query"])})
+
+                print(result.answer)
+            """
+            )
+        else:
+            try:
+                raise NotImplementedError
+            except NotImplementedError as e:
+                LOG.exception(e)
+
+            return {
+                "role": "tool",
+                "name": tool_name,
+                "content": json.dumps({"error": "Tool not supported."}),
+            }
+
+        tool_output, _ = await self.sandbox.execute_code(generated_code=tool_code, language="python")
+
+        if tool_output["process_status"] != "completed":
+            try:
+                raise ValueError(tool_output["stderr"])
+            except ValueError as e:
+                LOG.exception(e)
+
+            return {
+                "role": "tool",
+                "name": tool_name,
+                "content": json.dumps({"error": tool_output["stderr"]}),
+            }
+
+        return {
+            "role": "tool",
+            "name": tool_name,
+            "content": json.dumps({"result": tool_output["stdout"]}),
+        }
+
+    async def _execute_tool_calls(self, tool_calls: List[dict]):
+        return [
+            await self._execute_tool_call(tool_call["function"]["name"], tool_call["function"]["arguments"])
+            for tool_call in tool_calls
+        ]
+
+    async def generate_async(
+        self,
+        prompt: List,
+        tools: List[dict] = None,
+        **generation_kwargs,
+    ) -> Dict:
+        ## FIXME(sanyamk): Will be moved away from here.
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "exa_websearch",
+                    "description": "Search the web using Exa. Provide relevant links in your answer.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "Search query for Exa.",
+                            }
+                        },
+                        "required": ["query"],
+                    },
+                },
+            }
+        ]
+
+        assert isinstance(prompt, list), "Only use ChatCompletion API for now."
+        assert isinstance(tools, list), "Missing tools specification."
+
+        ## Bookkeeping.
+        num_tool_calls = 0
+        generation_steps = []
+        reasoning_steps = []
+
+        conversation = list(prompt)
+
+        while True:
+            generation = await self.model.generate_async(prompt=conversation, tools=tools, **generation_kwargs)
+
+            content = generation.get("generation")
+            reasoning_content = generation.get("reasoning_content")
+            tool_calls = generation.get("tool_calls", [])
+
+            if content:
+                generation_steps.append(content)
+                message = {"role": "assistant", "content": content}
+                conversation.append(message)
+
+            if reasoning_content:
+                reasoning_steps.append(reasoning_content)
+
+            if tool_calls:
+                tool_calls_message = await self._parse_tool_calls(tool_calls)
+                conversation.append(tool_calls_message)
+
+                tool_calls_output_message = await self._execute_tool_calls(tool_calls_message["tool_calls"])
+                conversation.extend(tool_calls_output_message)
+
+                num_tool_calls += len(tool_calls)
+
+                continue
+
+            break
+
+        return {
+            "generation": "".join(generation_steps),
+            "num_tool_calls": num_tool_calls,
+            "reasoning_content": reasoning_steps,
+            "conversation": conversation,
+        }

--- a/nemo_skills/mcp/adapters.py
+++ b/nemo_skills/mcp/adapters.py
@@ -15,8 +15,9 @@
 
 import json
 from abc import ABC, abstractmethod
+from typing import List
 
-from openai.types.chat import ChatCompletionMessageToolCall
+from litellm.types.utils import ChatCompletionMessageToolCall
 
 
 # ==============================
@@ -54,7 +55,7 @@ class OpenAISchemaAdapter(ToolSchemaAdapter):
             {
                 "type": "function",
                 "function": {
-                    "name": f"{t['name']}",
+                    "name": t["name"],
                     "description": t["description"],
                     "parameters": t["input_schema"],
                 },
@@ -77,4 +78,34 @@ class CompletionResponseFormatter(ToolResponseFormatter):
             "role": "tool",
             "content": json.dumps(result),
             "tool_call_id": tool_call.id,
+        }
+
+
+class ChatCompletionCallInterpreter(ToolCallInterpreter):
+    """Convert tool calls to a chat message item.
+
+    Should be broadly compatible with any OpenAI-like APIs,
+    and HuggingFace Chat templates.
+
+    NOTE(sanyamk): For error handling, delay JSON parsing of arguments to the model class.
+    """
+
+    def parse(self, tool_calls: List[ChatCompletionMessageToolCall]):
+        tool_calls = [
+            {
+                "type": tool_call.type,
+                "function": {"name": tool_call.function.name, "arguments": tool_call.function.arguments},
+            }
+            for tool_call in tool_calls
+        ]
+
+        return {"role": "assistant", "tool_calls": tool_calls}
+
+
+class ChatCompletionResponseFormatter(ToolResponseFormatter):
+    def format(self, tool_name, result):
+        return {
+            "role": "tool",
+            "name": tool_name,
+            "content": json.dumps(result),
         }

--- a/nemo_skills/mcp/adapters.py
+++ b/nemo_skills/mcp/adapters.py
@@ -94,6 +94,7 @@ class ChatCompletionCallInterpreter(ToolCallInterpreter):
         tool_calls = [
             {
                 "type": tool_call.type,
+                "id": tool_call.id,
                 "function": {"name": tool_call.function.name, "arguments": tool_call.function.arguments},
             }
             for tool_call in tool_calls
@@ -103,9 +104,15 @@ class ChatCompletionCallInterpreter(ToolCallInterpreter):
 
 
 class ChatCompletionResponseFormatter(ToolResponseFormatter):
-    def format(self, tool_name, result):
+    """Convert tool call result to chat message item.
+
+    Use in conjunction with `ChatCompletionCallInterpreter`.
+    """
+
+    def format(self, tool_call, result):
         return {
             "role": "tool",
-            "name": tool_name,
+            "name": tool_call["function"]["name"],
+            "tool_call_id": tool_call["id"],
             "content": json.dumps(result),
         }

--- a/nemo_skills/mcp/config/exa.yaml
+++ b/nemo_skills/mcp/config/exa.yaml
@@ -1,0 +1,13 @@
+adapters:
+  schema_adapter: nemo_skills.mcp.adapters.OpenAISchemaAdapter
+  call_interpreter: nemo_skills.mcp.adapters.ChatCompletionCallInterpreter
+  response_formatter: nemo_skills.mcp.adapters.ChatCompletionResponseFormatter
+
+tools:
+- id: exa
+  client: nemo_skills.mcp.clients.MCPStdioClient
+  params:
+    command: python
+    args: ["-m", "nemo_skills.mcp.servers.exa_tool"]
+    ## To inject EXA_API_KEY key via stdio args.
+    init_hook: nemo_skills.mcp.utils.exa_stdio_connector

--- a/nemo_skills/mcp/servers/exa_tool.py
+++ b/nemo_skills/mcp/servers/exa_tool.py
@@ -51,7 +51,7 @@ async def exa_websearch(
         "x-api-key": EXA_API_KEY,
         "Content-Type": "application/json",
     }
-    payload = {"query": f"{query}"}
+    payload = {"query": query}
 
     async with httpx.AsyncClient() as client:
         response = await client.post(url, headers=headers, json=payload)


### PR DESCRIPTION
A JSON dump of example arguments.
```json
{
  "benchmarks": "gpqa",
  "split": "debug",
  "data_dir": "/store/data/nemo_skills",
  "server_type": "vllm",
  "model": "/store/models/hf_models/Qwen3-14B",
  "server_gpus": 1,
  "server_nodes": 1,
  "server_args": "--async-scheduling --enable-auto-tool-choice --tool-call-parser hermes --reasoning-parser deepseek_r1",
  "with_sandbox": true,
  "output_dir": "....",
  "expname": "...",
  "cluster": "....",
  "partition": "...",
  "time_min": 30,
  "exclusive": false,
  "ctx": "wrap_arguments('++prompt_config=/nemo_run/code/nemo_tir/prompt/config/gpt-oss/gpqa.yaml ++inference.tokens_to_generate=20000 ++inference.temperature=1.0 ++inference.top_p=1.0 ++max_concurrent_requests=1024 ++tool_config=/nemo_run/code/nemo_skills/mcp/config/exa.yaml ++skip_filled=True')"
}
```

TODO:
- [x] Support for MCP servers
- [x] Support for tool descriptions as input to the chat completion request.
- [ ] Add tests

Out of Scope:
- Support for custom parsing for models that do not support tool calling with Chat Completion API.