### PR TITLE
Cleaning up references to TRTLLM model

### DIFF
--- a/docs/pipelines/checkpoint-conversion.md
+++ b/docs/pipelines/checkpoint-conversion.md
@@ -24,7 +24,7 @@ To convert the checkpoint from one format to another use a command like this
 ns convert \
     --cluster=slurm \
     --input_model=/hf_models/Meta-Llama-3.1-70B-Instruct \
-    --output_model=/trt_models/llama3.1-70b-instruct \
+    --output_model=/nemo_models/llama3.1-70b-instruct \
     --convert_from=hf \
     --convert_to=nemo \
     --model_type=llama \

--- a/docs/pipelines/generation.md
+++ b/docs/pipelines/generation.md
@@ -117,7 +117,7 @@ Then we can run the generation
 ns generate \
        --cluster=slurm \
        --server_type=trtllm \
-       --model=/trt_models/llama-3.1-405b-instruct \
+       --model=/hf_models/Llama-3.1-405B-Instruct \
        --server_gpus=8 \
        --server_nodes=2 \
        --num_random_seeds=32 \

--- a/docs/pipelines/index.md
+++ b/docs/pipelines/index.md
@@ -22,7 +22,7 @@ This might sound a little complicated, so let's see how it works through an exam
     ns generate \
         --cluster=local \
         --server_type=trtllm \
-        --model=/workspace/qwen2.5-1.5b-instruct-trtllm \
+        --model=/hf_models/Qwen2.5-1.5B-Instruct \
         --server_gpus=1 \
         --output_dir=/workspace/generation-local-trtllm \
         --input_file=/workspace/input.jsonl \
@@ -37,7 +37,7 @@ This might sound a little complicated, so let's see how it works through an exam
     generate(
         cluster="local",
         server_type="trtllm",
-        model="/workspace/qwen2.5-1.5b-instruct-trtllm",
+        model="/hf_models/Qwen2.5-1.5B-Instruct",
         server_gpus=1,
         output_dir="/workspace/generation-local-trtllm",
         input_file="/workspace/input.jsonl",

--- a/docs/releases/openmathinstruct2/dataset.md
+++ b/docs/releases/openmathinstruct2/dataset.md
@@ -5,8 +5,7 @@ We assume you have `/workspace` defined in your [cluster config](../../basics/cl
 all commands on a slurm cluster. Change the commands accordingly if running locally
 (but it's going to take a lot of time).
 We also assume you have the [Llama3.1 405B](https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct)
-on that cluster inside `/trt_models/llama-3.1-405b-instruct` (should be mounted in your config)
-that's been [converted](../../pipelines/checkpoint-conversion.md) to TensorRT-LLM format.
+on that cluster inside `/hf_models/Llama-3.1-405B-Instruct` (should be mounted in your config).
 See [generation docs](../../pipelines/generation.md) for how you can change the below commands to instead
 run inference through Nvidia NIM API.
 
@@ -25,7 +24,7 @@ MATH dataset.
 ns generate \
     --cluster=slurm \
     --server_type=trtllm \
-    --model=/trt_models/llama-3.1-405b-instruct \
+    --model=/hf_models/Llama-3.1-405B-Instruct \
     --server_gpus=8 \
     --server_nodes=2 \
     --num_random_seeds=512 \
@@ -45,7 +44,7 @@ GSM8K dataset.
 ns generate \
     --cluster=slurm \
     --server_type=trtllm \
-    --model=/trt_models/llama-3.1-405b-instruct \
+    --model=/hf_models/Llama-3.1-405B-Instruct \
     --server_gpus=8 \
     --server_nodes=2 \
     --num_random_seeds=64 \
@@ -68,7 +67,7 @@ MATH dataset.
 ns generate \
     --cluster=slurm \
     --server_type=trtllm \
-    --model=/trt_models/llama-3.1-405b-instruct \
+    --model=/hf_models/Llama-3.1-405B-Instruct \
     --server_gpus=8 \
     --server_nodes=2 \
     --num_random_seeds=80 \
@@ -88,7 +87,7 @@ GSM8K dataset.
 ns generate \
     --cluster=slurm \
     --server_type=trtllm \
-    --model=/trt_models/llama-3.1-405b-instruct \
+    --model=/hf_models/Llama-3.1-405B-Instruct \
     --server_gpus=8 \
     --server_nodes=2 \
     --num_random_seeds=10 \
@@ -120,7 +119,7 @@ for i in range(80):
     generate(
         cluster="slurm",
         server_type="trtllm",
-        model="/trt_models/llama-3.1-405b-instruct",
+        model="/hf_models/Llama-3.1-405B-Instruct",
         server_gpus=8,
         server_nodes=2,
         num_random_seeds=32,
@@ -147,7 +146,7 @@ for i in range(10):
     generate(
         cluster="slurm",
         server_type="trtllm",
-        model="/trt_models/llama-3.1-405b-instruct",
+        model="/hf_models/Llama-3.1-405B-Instruct",
         server_gpus=8,
         server_nodes=2,
         num_random_seeds=32,

--- a/docs/releases/openmathreasoning/evaluation.md
+++ b/docs/releases/openmathreasoning/evaluation.md
@@ -167,7 +167,7 @@ Here is a sample command to run GenSelect evaluation:
 ```bash
 ns genselect \
     --preprocess_args="++input_dir=/workspace/openmath-nemotron-1.5b-eval-cot/eval-results-judged/hle" \
-    --model=/trt_models/openmath-nemotron-1.5b \
+    --model=/workspace/OpenMath-Nemotron-1.5B \
     --output_dir=/workspace/openmath-nemotron-1.5b-eval-cot/self_genselect_hle \
     --cluster=local \
     --server_type=sglang \


### PR DESCRIPTION
Removing references to old `trt_models` and `-trtllm` models in the docs.