### PR TITLE
Fix ruff config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,9 +38,8 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.9
     hooks:
-      ## See https://docs.astral.sh/ruff/formatter/#sorting-imports.
       - id: ruff-check
-        args: ["--select", "I", "--fix"]
+        args: ["--fix"]
       - id: ruff-format
 
   - repo: local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,7 @@ markers = [
 [tool.ruff]
 target-version = "py310"
 line-length = 119
+
+[tool.ruff.lint]
+## See https://docs.astral.sh/ruff/formatter/#sorting-imports.
+extend-select = ["I"]


### PR DESCRIPTION
Previous usage of `--select` was overriding the defaults. `--extend-select` is the right option.

For reference see: https://github.com/astral-sh/ruff/issues/8926#issuecomment-1834048218