### PR TITLE
AIMO inference tutorial

### DIFF
--- a/docs/tutorials/notebooks/demo_aimo_inference.ipynb
+++ b/docs/tutorials/notebooks/demo_aimo_inference.ipynb
@@ -1,0 +1,616 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "62aa155e-9613-4ca9-a88d-d11ce4ac8b0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GPU 0: NVIDIA H100 80GB HBM3 \n",
+      "GPU 1: NVIDIA H100 80GB HBM3 \n"
+     ]
+    }
+   ],
+   "source": [
+    "import asyncio\n",
+    "import contextlib\n",
+    "import os\n",
+    "import signal\n",
+    "import subprocess\n",
+    "import time\n",
+    "import warnings\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import psutil\n",
+    "import requests\n",
+    "import transformers\n",
+    "from transformers.utils import logging\n",
+    "\n",
+    "from nemo_skills.code_execution.sandbox import get_sandbox\n",
+    "from nemo_skills.inference.model import get_code_execution_model\n",
+    "from nemo_skills.prompt.utils import get_prompt\n",
+    "\n",
+    "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\"\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "logging.set_verbosity_error()\n",
+    "\n",
+    "!nvidia-smi -L | cut -d '(' -f 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ed515c34-98c2-4d46-b00a-239a3faa47b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASE_DIR = \"./\"\n",
+    "MODEL_DIR_HF = f\"{BASE_DIR}/OpenMath-Nemotron-14B-kaggle\"\n",
+    "MODEL_DIR_BF16 = f\"{BASE_DIR}/OpenMath-Nemotron-14B-kaggle-bf16-trtllm\"\n",
+    "MODEL_DIR_FP8 = f\"{BASE_DIR}/OpenMath-Nemotron-14B-kaggle-fp8-trtllm\"\n",
+    "MODEL_DIR_FP8_DRAFT = f\"{BASE_DIR}/OpenMath-Nemotron-14B-kaggle-fp8-redrafter-trtllm\"\n",
+    "benchmark = {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9bd2af26-291d-4d2a-a3f8-07b98354e047",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def wait_for_server(host, port, timeout=300, interval=1):\n",
+    "    url = f\"http://{host}:{port}\"\n",
+    "    start_time = time.time()\n",
+    "    while True:\n",
+    "        try:\n",
+    "            response = requests.put(url)\n",
+    "            if response.status_code != 403:\n",
+    "                return True\n",
+    "        except requests.RequestException:\n",
+    "            if time.time() - start_time > timeout:\n",
+    "                raise TimeoutError(\"Server did not respond within timeout period\")\n",
+    "            time.sleep(interval)\n",
+    "\n",
+    "\n",
+    "def start_server(model_dir, port=5000):\n",
+    "    host = \"127.0.0.1\"\n",
+    "    cmd = (\n",
+    "        f\"trtllm-serve serve {model_dir} \"\n",
+    "        f\"    --tokenizer {MODEL_DIR_HF}\"\n",
+    "        f\"    --backend trt \"\n",
+    "        f\"    --tp_size 2 \"\n",
+    "        f\"    --kv_cache_free_gpu_memory_fraction 0.92 \"\n",
+    "        f\"    --max_batch_size 12 \"\n",
+    "        f\"    --host {host} \"\n",
+    "        f\"    --port {port}\"\n",
+    "    )\n",
+    "    print(f\"Starting server from {model_dir} at {host}:{port}\")\n",
+    "    model_name = model_dir.split(\"/\")[-1]\n",
+    "    log_path = Path(f\"{model_name}_server_logs.log\").resolve()\n",
+    "    log_file = open(log_path, \"w\", buffering=1)\n",
+    "    proc = subprocess.Popen(cmd, shell=True, stdout=log_file, stderr=subprocess.STDOUT, preexec_fn=os.setsid)\n",
+    "    print(\"Waiting for server to be ready (might take a while) ...\")\n",
+    "    wait_for_server(host, port)\n",
+    "    print(\"Server ready!\")\n",
+    "    return proc\n",
+    "\n",
+    "\n",
+    "def kill_server(proc, port=5000):\n",
+    "    os.killpg(proc.pid, signal.SIGTERM)\n",
+    "    time.sleep(10)\n",
+    "\n",
+    "    for proc in psutil.process_iter([\"pid\", \"name\"]):\n",
+    "        for conn in proc.connections(kind=\"inet\"):\n",
+    "            if conn.laddr.port == port:\n",
+    "                print(f\"Killing process {proc.info['name']} (PID: {proc.info['pid']}) running on port {port}\")\n",
+    "                os.kill(proc.info[\"pid\"], 9)\n",
+    "                break\n",
+    "\n",
+    "    time.sleep(10)\n",
+    "    print(\"Server closed.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "93801d3c-3388-4d2d-982a-031b39d0bdcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def run_generation(request_id, prompt_obj, llm, problem):\n",
+    "    stream = None\n",
+    "    try:\n",
+    "        stream = await llm.generate_async(\n",
+    "            prompt=prompt_obj.fill({\"problem\": problem}),\n",
+    "            stream=True,\n",
+    "            random_seed=request_id,\n",
+    "            temperature=0.7,\n",
+    "            tokens_to_generate=20000,\n",
+    "            **prompt_obj.get_code_execution_args(),\n",
+    "        )\n",
+    "        full_generation = \"\"\n",
+    "        async for response in stream:\n",
+    "            full_generation += response[\"generation\"]\n",
+    "        return full_generation\n",
+    "    except asyncio.CancelledError:\n",
+    "        # Close the stream so the server is notified on cancellation\n",
+    "        with contextlib.suppress(Exception):\n",
+    "            if stream is not None:\n",
+    "                if hasattr(stream, \"aclose\"):\n",
+    "                    await stream.aclose()\n",
+    "                elif hasattr(stream, \"close\"):\n",
+    "                    stream.close()\n",
+    "        raise\n",
+    "\n",
+    "\n",
+    "async def main_loop(prompt_obj, llm, problem):\n",
+    "    num_generations = 12\n",
+    "    cancel_after_done = 10\n",
+    "    tasks = [asyncio.create_task(run_generation(i, prompt_obj, llm, problem)) for i in range(num_generations)]\n",
+    "\n",
+    "    completed = 0\n",
+    "    all_generations = []\n",
+    "\n",
+    "    # Consume as they finish\n",
+    "    for fut in asyncio.as_completed(tasks):\n",
+    "        res = await fut\n",
+    "        all_generations.append(res)\n",
+    "        completed += 1\n",
+    "        if completed >= cancel_after_done:\n",
+    "            # cancel remaining\n",
+    "            for t in tasks:\n",
+    "                if not t.done():\n",
+    "                    t.cancel()\n",
+    "            break\n",
+    "\n",
+    "    # Drain only the still-pending tasks to avoid duplicates\n",
+    "    pending = [t for t in tasks if not t.done()]\n",
+    "    if pending:\n",
+    "        drained = await asyncio.gather(*pending, return_exceptions=True)\n",
+    "        # keep only successful returns (skip exceptions like CancelledError)\n",
+    "        all_generations.extend(r for r in drained if not isinstance(r, Exception))\n",
+    "\n",
+    "    return all_generations\n",
+    "\n",
+    "\n",
+    "def build_table(bench, tokenizer):\n",
+    "    data = {\n",
+    "        \"Metric\": [\n",
+    "            \"Num Generations\",\n",
+    "            \"Total Generation Time\",\n",
+    "            \"Batch Throughput (Tok/sec)\",\n",
+    "            \"Avg Request Throughput (Tok/sec)\",\n",
+    "        ]\n",
+    "    }\n",
+    "    for name, rec in bench.items():\n",
+    "        gens = [g for g in rec[\"gens\"] if isinstance(g, str)]\n",
+    "        tt = max(rec[\"total_time\"], 1e-9)\n",
+    "        toks = np.array([len(tokenizer.encode(g)) for g in gens], dtype=float)\n",
+    "        batch_tp = toks.sum() / tt\n",
+    "        per_req_tp = toks / tt\n",
+    "        data[name] = [\n",
+    "            f\"{len(gens)}\",\n",
+    "            f\"{tt:.1f}\",\n",
+    "            f\"{batch_tp:.1f}\",\n",
+    "            f\"{per_req_tp.mean():.1f} ± {per_req_tp.std():.1f}\",\n",
+    "        ]\n",
+    "    return pd.DataFrame(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "97195ac8-a7ec-4cc5-8e4e-91d98ffba54e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[worker unknown] 2025-08-29 09:23:53,871 INFO: Applied worker memory limit (RLIMIT_AS/RLIMIT_DATA): 21474836480 bytes\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " * Serving Flask app 'local_sandbox_server'\n",
+      " * Debug mode: off\n"
+     ]
+    }
+   ],
+   "source": [
+    "sandbox_cmd = \"python -m nemo_skills.code_execution.local_sandbox.local_sandbox_server\"\n",
+    "subprocess.Popen(sandbox_cmd, shell=True)\n",
+    "time.sleep(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "627617b1-edad-47ec-8237-b9276fca85e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sandbox = get_sandbox()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d4744baf-99be-48f8-bb1f-4d9513e208cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting server from .//OpenMath-Nemotron-14B-kaggle-fp8-redrafter-trtllm at 127.0.0.1:5000\n",
+      "Waiting for server to be ready (might take a while) ...\n",
+      "Server ready!\n"
+     ]
+    }
+   ],
+   "source": [
+    "server_process = start_server(MODEL_DIR_FP8_DRAFT)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5764571b-fdae-451a-b756-a6fbf0c97d8f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"object\":\"list\",\"data\":[{\"id\":\"OpenMath-Nemotron-14B-kaggle-fp8-redrafter-trtllm\",\"object\":\"model\",\"created\":1756459594,\"owned_by\":\"tensorrt_llm\"}]}"
+     ]
+    }
+   ],
+   "source": [
+    "# Openai trtllm server\n",
+    "!curl -s http://127.0.0.1:5000/v1/models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5f197f46-a96f-44af-98b4-cb1206d7af34",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"backend\":\"ipython\",\"sessions\":{}}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[worker unknown] 2025-08-29 09:26:34,667 INFO: active_sessions=0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Code execution server\n",
+    "!curl -s http://127.0.0.1:6000/sessions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "bfd2db6b-33b1-4ace-acc6-b219aa9dbdd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tokenizer = transformers.AutoTokenizer.from_pretrained(MODEL_DIR_FP8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7cdc825f-d200-48d6-8d61-ae6d83a7a9da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sandbox = get_sandbox()\n",
+    "code_execution = {\"max_code_executions\": 2, \"sandbox_traceback_verbosity\": \"plain\"}\n",
+    "prompt_obj = get_prompt(\"generic/math\", tokenizer=MODEL_DIR_FP8, code_tags=\"openmath\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "1d9d9651-4da8-4ea5-9817-0cf1cba21b0c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = get_code_execution_model(\n",
+    "    server_type=\"trtllm\", model=MODEL_DIR_FP8, sandbox=sandbox, code_execution=code_execution\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "5765fca5-84d5-4748-b7c9-12a4e59354a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "problem = r\"\"\"\n",
+    "The Fibonacci numbers are defined as follows: $F_0 = 0$, $F_1 = 1$, and $F_{n+1} = F_n + F_{n-1}$ for $n \\geq 1$.\n",
+    "There are $N$ positive integers $n$ strictly less than $10^{101}$ such that $n^2 + (n+1)^2$ is a multiple of 5 but $F_{n-1}^2 + F_n^2$ is not.\n",
+    "How many prime factors does $N$ have, counted with multiplicity?\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47e69a26-bd9e-4a46-b03c-c73463314f74",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ad8a8b07-35bf-4a70-a8e6-66a9f21193cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bench = {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "df130bdc-d05d-4264-8d28-a44cb6c9e09d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t0 = time.perf_counter()\n",
+    "gens_fp8_draft = await main_loop(prompt_obj, llm, problem)\n",
+    "bench[\"fp8_draft\"] = {\n",
+    "    \"gens\": gens_fp8_draft,\n",
+    "    \"total_time\": time.perf_counter() - t0,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "9603c44b-934f-453d-b5a6-8bbdadbcb5a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Server closed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "kill_server(server_process)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "f1f8515c-59d1-40e1-a44c-be7e5aa5dc74",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting server from .//OpenMath-Nemotron-14B-kaggle-fp8-trtllm at 127.0.0.1:5000\n",
+      "Waiting for server to be ready (might take a while) ...\n",
+      "Server ready!\n"
+     ]
+    }
+   ],
+   "source": [
+    "server_process = start_server(MODEL_DIR_FP8)\n",
+    "llm = get_code_execution_model(\n",
+    "    server_type=\"trtllm\", model=MODEL_DIR_FP8, sandbox=sandbox, code_execution=code_execution\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "7440221c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t0 = time.perf_counter()\n",
+    "gens_fp8 = await main_loop(prompt_obj, llm, problem)\n",
+    "bench[\"fp8\"] = {\n",
+    "    \"gens\": gens_fp8,\n",
+    "    \"total_time\": time.perf_counter() - t0,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "5e458122",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Server closed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "kill_server(server_process)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "b72e2cbd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting server from .//OpenMath-Nemotron-14B-kaggle-bf16-trtllm at 127.0.0.1:5000\n",
+      "Waiting for server to be ready (might take a while) ...\n",
+      "Server ready!\n"
+     ]
+    }
+   ],
+   "source": [
+    "server_process = start_server(MODEL_DIR_BF16)\n",
+    "llm = get_code_execution_model(\n",
+    "    server_type=\"trtllm\", model=MODEL_DIR_BF16, sandbox=sandbox, code_execution=code_execution\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "16d33377",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t0 = time.perf_counter()\n",
+    "gens_bf16 = await main_loop(prompt_obj, llm, problem)\n",
+    "bench[\"bf16\"] = {\n",
+    "    \"gens\": gens_bf16,\n",
+    "    \"total_time\": time.perf_counter() - t0,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "0a909688-bc2f-4b95-ae59-ce0986e1c9c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Metric</th>\n",
+       "      <th>fp8_draft</th>\n",
+       "      <th>fp8</th>\n",
+       "      <th>bf16</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Num Generations</td>\n",
+       "      <td>10</td>\n",
+       "      <td>10</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Total Generation Time</td>\n",
+       "      <td>30.5</td>\n",
+       "      <td>64.7</td>\n",
+       "      <td>144.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Batch Throughput (Tok/sec)</td>\n",
+       "      <td>1385.4</td>\n",
+       "      <td>751.7</td>\n",
+       "      <td>346.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Avg Request Throughput (Tok/sec)</td>\n",
+       "      <td>138.5 ± 24.6</td>\n",
+       "      <td>75.2 ± 11.0</td>\n",
+       "      <td>34.6 ± 6.1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                             Metric     fp8_draft          fp8        bf16\n",
+       "0                   Num Generations            10           10          10\n",
+       "1             Total Generation Time          30.5         64.7       144.2\n",
+       "2        Batch Throughput (Tok/sec)        1385.4        751.7       346.0\n",
+       "3  Avg Request Throughput (Tok/sec)  138.5 ± 24.6  75.2 ± 11.0  34.6 ± 6.1"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "build_table(bench, tokenizer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da901d45-bb3a-42e2-9b1d-41f2fee11757",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials/posts/omr-aimo2-inference-recipe.md
+++ b/docs/tutorials/posts/omr-aimo2-inference-recipe.md
@@ -21,7 +21,7 @@ By the end of this tutorial and companion notebook, you will have a local setup 
 4.  **Launching the Inference Server**: Set up the LLM server and a parallel code execution sandbox to handle the tool-use capabilities of our model.
 5.  **Running Inference**: Finally, we'll send math problems to our custom inference engine and observe its problem-solving abilities.
 
-See the [companion notebook](../notebooks/demo_aimo_inference.ipynb) for launching the inference server and benchmarking.
+See the [companion notebook](https://github.com/NVIDIA/NeMo-Skills/tree/main/docs/tutorials/notebooks/demo_aimo_inference.ipynb) for launching the inference server and benchmarking.
 
 -----
 
@@ -238,7 +238,7 @@ Your TensorRT-LLM engine, now supercharged with ReDrafter, is ready to be served
 
 ## 4\. Benchmarking and results
 
-We’ve prepared a [companion notebook](../notebooks/demo_aimo_inference.ipynb) where you can try out the full pipeline yourself. The notebook was run with the same container setup and installations as section 1 above, along with 2 H100 GPUs for inference.
+We’ve prepared a [companion notebook](https://github.com/NVIDIA/NeMo-Skills/tree/main/docs/tutorials/notebooks/demo_aimo_inference.ipynb) where you can try out the full pipeline yourself. The notebook was run with the same container setup and installations as section 1 above, along with 2 H100 GPUs for inference.
 In the notebook, you can:
 
 - Run inference on different TensorRT-LLM engines (BF16, FP8, FP8+ReDrafter).
@@ -313,4 +313,4 @@ The code confirms that the valid bases are 21 and 49, summing to 70.
 
 </details>
 
-To turn off tool-calling in the [companion notebook](../notebooks/demo_aimo_inference.ipynb) use `get_model` instead of `get_code_execution_model` as shown in the NeMo-Skills [docs](https://nvidia.github.io/NeMo-Skills/).
+To turn off tool-calling in the [companion notebook](https://github.com/NVIDIA/NeMo-Skills/tree/main/docs/tutorials/notebooks/demo_aimo_inference.ipynb) use `get_model` instead of `get_code_execution_model` as shown in the NeMo-Skills [docs](https://nvidia.github.io/NeMo-Skills/).

--- a/docs/tutorials/posts/omr-aimo2-inference-recipe.md
+++ b/docs/tutorials/posts/omr-aimo2-inference-recipe.md
@@ -1,0 +1,316 @@
+---
+date: 2025-08-28
+readtime: 20
+---
+
+# Building an Efficient Inference Engine for Math Problems
+
+This tutorial guides you through creating a high-performance inference engine using [NeMo-Skills](https://nvidia.github.io/NeMo-Skills/) to tackle complex math problems. It demonstrates the inference pipeline used to win the [AIMO-2 competition](https://www.kaggle.com/competitions/ai-mathematical-olympiad-progress-prize-2/writeups/nemoskills-1st-place-solution-nemoskills). With FP8 quantization and ReDrafter speculative decoding, we demonstrate up to 4× faster batched inference compared to BF16 on two H100 GPUs.
+
+We will leverage [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) for optimized model serving, including an advanced technique called ReDrafter for speculative decoding.
+
+By the end of this tutorial and companion notebook, you will have a local setup capable of running efficient inference with a large language model (LLM) integrated with a code execution sandbox.
+
+<!-- more -->
+
+## What We'll Cover
+
+1.  **Setting up Your Environment**: Get your system ready by installing necessary libraries within a suitable container.
+2.  **Preparing Model Weights**: Download a pre-trained OpenMath model and convert it into an optimized TensorRT-LLM engine using FP8 quantization.
+3.  **Accelerating Inference with ReDrafter**: Discover ReDrafter, a speculative decoding technique, train a draft model, and integrate it into our TensorRT-LLM engine for faster generation.
+4.  **Launching the Inference Server**: Set up the LLM server and a parallel code execution sandbox to handle the tool-use capabilities of our model.
+5.  **Running Inference**: Finally, we'll send math problems to our custom inference engine and observe its problem-solving abilities.
+
+See the [companion notebook](../notebooks/demo_aimo_inference.ipynb) for launching the inference server and benchmarking.
+
+-----
+
+## 1\. Setting Up Your Environment
+
+Our first step is to establish a consistent and isolated environment. We will use a NVIDIA PyTorch NGC container and install the essential libraries: TensorRT-LLM for model optimization and NeMo-Skills for the overall pipeline management.
+FP8 inference requires a GPU that supports FP8 inference such as Ada Lovelace or Hopper architecture or later. For this example we assume two GPUs are available.
+
+### Container Setup and Library Installation
+
+Once inside the `nvcr.io/nvidia/pytorch:25.05-py3` container, run the following commands to install TensorRT-LLM and NeMo-Skills:
+
+```bash
+# Ensure no conflicting TensorRT installations and install TensorRT-LLM
+[ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt
+pip uninstall -y tensorrt
+pip3 install tensorrt_llm==1.1.0rc0
+
+# Install NeMo-Skills
+pip install git+https://github.com/NVIDIA/NeMo-Skills.git
+```
+
+-----
+
+## 2\. Preparing Model Weights
+
+Now that our environment is ready, the next step is to prepare our Large Language Model (LLM). We'll download the `nvidia/OpenMath-Nemotron-14B-Kaggle` model and transform it into an optimized TensorRT-LLM engine using FP8 quantization.
+
+**Note on FP8 Quantization:** FP8 (8-bit floating point) quantization is highly efficient but requires GPUs that support `E4M3 FP8` (like NVIDIA Hopper GPUs). For other GPUs, `int8_wo` (8-bit integer with weight-only quantization) is recommended and does not require calibration.
+
+### Downloading Model Weights and Dataset
+
+Generate a Hugging Face token and export it as an environment variable, then use the Hugging Face CLI to download the necessary models and datasets.
+
+```bash
+# Export your Hugging Face token
+export HF_TOKEN=hf_YOUR_HUGGING_FACE_TOKEN # Replace with your actual token
+
+# Install Hugging Face CLI
+pip install -U "huggingface_hub[cli]"
+
+# Download the 14B parameter main model
+huggingface-cli download nvidia/OpenMath-Nemotron-14B-kaggle --local-dir OpenMath-Nemotron-14B-kaggle
+
+# Download the OpenMathReasoning dataset for calibration
+huggingface-cli download nvidia/OpenMathReasoning --repo-type dataset --local-dir OpenMathReasoning
+```
+
+### Preparing the Calibration Dataset for FP8 Quantization
+
+For FP8 quantization, a small calibration dataset representative of inference data is essential. We'll use a subset of the `OpenMathReasoning` dataset to create it. Save the following as `prepare_calibration_data.py`:
+
+```python title="prepare_calibration_data.py"
+import os
+from itertools import islice
+
+from datasets import Dataset, load_dataset
+
+from nemo_skills.prompt.utils import get_prompt
+
+# Define paths and parameters
+LOCAL_DATASET_PATH = './calibration_dataset'
+CALIB_DATASET_NAME = "nvidia/OpenMathReasoning"
+CALIB_SPLIT = 'tir'
+CALIB_SIZE = 4096
+
+# Load samples, format them, and save as a Parquet file
+print(f"Loading and formatting {CALIB_SIZE} samples for calibration...")
+ds_samples = load_dataset(CALIB_DATASET_NAME, split=CALIB_SPLIT, streaming=True)
+ds_samples = list(islice(ds_samples, CALIB_SIZE))
+
+prompt_template = get_prompt('generic/math', tokenizer='nvidia/OpenMath-Nemotron-14B-kaggle')
+calibration_dataset = Dataset.from_dict(
+    {
+        "text": [
+            prompt_template.format_assistant_response(
+                prompt_template.fill(
+                    {k: v for k, v in sample.items() if k in ['problem', 'generated_solution']},
+                    start_assistant_response_key='generated_solution',
+                )
+            )
+            for sample in ds_samples
+        ]
+    }
+)
+
+os.makedirs(LOCAL_DATASET_PATH, exist_ok=True)
+calibration_dataset.to_parquet(f"{LOCAL_DATASET_PATH}/data.parquet")
+print(f"Calibration dataset saved to {LOCAL_DATASET_PATH}/data.parquet")
+```
+
+Run the script:
+
+```bash
+python prepare_calibration_data.py
+```
+
+### Converting and Quantizing to TensorRT-LLM Engine
+
+Now, convert the Hugging Face model to a TensorRT-LLM engine, applying FP8 quantization and using the prepared calibration dataset. This step generates the FP8 quantized LLM inference engine.
+
+```bash
+ns convert \
+    --input_model OpenMath-Nemotron-14B-kaggle \
+    --output_model OpenMath-Nemotron-14B-kaggle-fp8-trtllm \
+    --convert_from hf \
+    --convert_to trtllm \
+    --num_gpus 2 \
+    --dtype fp8 \
+    --hf_model_name nvidia/OpenMath-Nemotron-14B-kaggle \
+    --model_type qwen \
+    --max_input_len 30000 \
+    --max_seq_len 32000 \
+    --no-trt_reuse_tmp_engine \
+    --calib_dataset ./calibration_dataset
+```
+
+After this command, your FP8 LLM engine is ready for deployment.
+
+-----
+
+## 3\. Accelerating Inference with ReDrafter
+
+To push our inference efficiency further, we will integrate [ReDrafter](https://machinelearning.apple.com/research/redrafter-nvidia-tensorrt-llm). This speculative decoding technique uses a smaller "draft" model to predict tokens, allowing the main LLM to generate responses much faster. ReDrafter is an RNN-based inference method developed by Apple. The ReDrafter [implementation](https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/redrafter) is compatible with most models supported within the TensorRT-LLM library.
+
+### Installing and Training ReDrafter
+
+First, install the ReDrafter library. The tokenizer and training data for the draft model should be the same as those used for the base model. If the original training data is not available, base model generations can also be used for training the draft model.
+
+```bash
+# Install the ReDrafter library
+pip install --no-binary=protobuf --ignore-requires-python \
+        "git+https://github.com/apple/ml-recurrent-drafter.git#egg=recurrent-drafting[dev,train]"
+
+# Train the ReDrafter model
+ns run_cmd --log_dir ./logs/ \
+torchrun --nproc_per_node=2 -m nemo_skills.training.train_redrafter \
+    --llm_name_or_path 'OpenMath-Nemotron-14B-kaggle' \
+    --dataset "OpenMathReasoning" \
+    --dataset_split "tir" \
+    --bf16 True \
+    --output_dir "redrafter_output" \
+    --num_train_epochs 1 \
+    --per_device_train_batch_size 1 \
+    --gradient_accumulation_steps 4 \
+    --save_strategy "no" \
+    --learning_rate 0.001 \
+    --weight_decay 0. \
+    --warmup_ratio 0.1 \
+    --lr_scheduler_type "cosine" \
+    --logging_steps 20 \
+    --tf32 True \
+    --model_max_length 2048 \
+    --dataset_nrows 50000 \
+    --drafter_predict_n_tokens 3 \
+    --drafter_num_layers 2 \
+    --rnn True \
+    --phase train \
+    --report_to wandb # Remove if not using wandb
+```
+
+During training, observe the `redrafter2_top1` score. Aiming for above `0.6` indicates good performance (60% of steps accept the next three drafted tokens).
+
+### Building the TensorRT-LLM Engine for the Draft Model
+
+Now, we'll convert our trained ReDrafter model into a TensorRT-LLM checkpoint and then combine it with our main LLM to create the final, accelerated TensorRT-LLM engine.
+
+First, clone the TensorRT-LLM repository to access its conversion scripts:
+
+```bash
+git clone https://github.com/NVIDIA/TensorRT-LLM/
+```
+
+Next, convert the trained ReDrafter PyTorch checkpoint to a TensorRT-LLM checkpoint.
+
+```bash
+# Base model intermediate checkpoint from FP8 quantisation step
+export BASE_TRTLLM_CKPT=$(pwd)/OpenMath-Nemotron-14B-kaggle-fp8-trtllm-tmp-ckpt
+# Trained draft checkpoint
+export REDRAFTER_PYTORCH_CKPT=$(pwd)/redrafter_output/redrafter__redrafter_OpenMath-Nemotron-14B-kaggle_n_3_lr_0.001_layers_2
+export REDRAFTER_TRTLLM_CKPT=$(pwd)/OpenMath-Nemotron-14B-kaggle-fp8-draft-ckpt
+
+cd ./TensorRT-LLM/examples/redrafter
+python convert_checkpoint.py \
+    --base_model_checkpoint_dir $BASE_TRTLLM_CKPT \
+    --drafter_model_dir $REDRAFTER_PYTORCH_CKPT \
+    --output_dir $REDRAFTER_TRTLLM_CKPT \
+    --dtype bfloat16 \
+    --tp_size 2 \
+    --redrafter_num_beams 1 \
+    --redrafter_draft_len_per_beam 3
+cd ../../../
+```
+
+Finally, build the combined TensorRT-LLM engine - base model with a draft head for speculative decoding.
+```bash
+trtllm-build \
+    --checkpoint_dir $REDRAFTER_TRTLLM_CKPT \
+    --output_dir OpenMath-Nemotron-14B-kaggle-fp8-redrafter-trtllm \
+    --gemm_plugin fp8 \
+    --use_paged_context_fmha=enable \
+    --max_batch_size 32 \
+    --max_seq_len 32000 \
+    --max_input_len 32000 \
+    --max_num_tokens 32000 \
+    --speculative_decoding_mode explicit_draft_tokens \
+    --max_beam_width 1 \
+    --kv_cache_type paged
+```
+
+Your TensorRT-LLM engine, now supercharged with ReDrafter, is ready to be served!
+
+-----
+
+## 4\. Benchmarking and results
+
+We’ve prepared a [companion notebook](../notebooks/demo_aimo_inference.ipynb) where you can try out the full pipeline yourself. The notebook was run with the same container setup and installations as section 1 above, along with 2 H100 GPUs for inference.
+In the notebook, you can:
+
+- Run inference on different TensorRT-LLM engines (BF16, FP8, FP8+ReDrafter).
+- Compare performance benchmarks.
+- Explore advanced controls like **terminating after the first N generations complete**.
+- Run inference with tool-calling.
+
+Here’s a sample of the kind of benchmark results you’ll see:
+
+| Metric                        | BF16 | FP8   | FP8+ReDrafter  |
+|-------------------------------|---------------|-------|-------|
+| Total Generation Time (s)     | 144.2 | 64.7  |  30.5  |
+| Average Sample Throughput (Tok/s) | 34.6 | 75.2   |  138.5  |
+
+*(full benchmarks and code available in the notebook)*
+
+-----
+
+## 5\. Optional: Enabling tool-calling and the code execution sandbox
+
+The OpenMath LLM is a powerful model that can use Python as a tool integrated in its reasoning. This means it doesn't just generate text; it can also write and execute Python code in a sandbox to solve problems. In the companion notebook, we provide an example how to launch both the LLM server and its accompanying code execution sandbox.
+
+The interaction works like this:
+
+1.  The LLM generates Python code wrapped in `<tool_call>` and `</tool_call>` tokens.
+2.  The inference engine extracts and sends this code to the sandbox.
+3.  The sandbox executes the code and returns the results.
+4.  The output is fed back to the LLM for continued generation or to finalize its answer.
+
+Here's an example of such an interaction:
+<details markdown><summary><b>Show Example Output</b></summary>
+
+Therefore, b = k - 7 = 21 or 49. So, same result. Therefore, sum is 70.
+
+Alternatively, maybe I can write a small program to check for all bases b > 9, compute 9b + 7 and b + 7, check if the latter divides the former, and collect all such bases. Then sum them. Let's do that to verify.
+
+Here's a Python code to perform the check:
+
+```
+    <tool_call>
+    # Initialize a list to store valid bases
+    valid_bases = []
+
+    # Check bases from 10 upwards
+    for b in range(10, 10000):  # Arbitrary large upper limit
+        num1 = 9 * b + 7
+        num2 = b + 7
+        if num1 % num2 == 0:
+            valid_bases.append(b)
+            print(f"Found base: {b}")
+
+    # Sum the valid bases
+    sum_bases = sum(valid_bases)
+    print(f"Sum: {sum_bases}")
+
+    # If sum is over 1000, take modulo 1000
+    if sum_bases > 1000:
+        result = sum_bases % 1000
+    else:
+        result = sum_bases
+
+    print(f"Final Result: {result}")
+    </tool_call>
+    ```output
+    Found base: 21
+    Found base: 49
+    Sum: 70
+    Final Result: 70
+    ```
+```
+The code confirms that the valid bases are 21 and 49, summing to 70.
+
+</details>
+
+To turn off tool-calling in the [companion notebook](../notebooks/demo_aimo_inference.ipynb) use `get_model` instead of `get_code_execution_model` as shown in the NeMo-Skills [docs](https://nvidia.github.io/NeMo-Skills/).


### PR DESCRIPTION
Recreated the PR to come from a new branch, as had issues with incorrectly signed commits.  

Tutorial for running AIMO2 inference pipeline locally using OpenMath-14B as the base model.
Jupyter notebook serving the LLM and the sandbox. 
There is a hyperlink from the tutorial to the jupyter notebook - I could not verify if this hyperlink will still work once it is added to the docs but it should. 

Note,
- There is a fixed commit in the Nemo-Skills installation; code execution `generate` seems to be removed on the latest version. Similarly trtllm is fixed version, as we need v1.x and latest pip does not have this.  
- The environment set ups and engine creation. The jupyter notebook contains hosting and inference. 
- We hoped to get the notebook set up in kaggle; but it was proving too much work because of change in the kaggle env and trtllm in the interim since aimo2.  