### PR TITLE
Bug Fix w/ Translation Module

### DIFF
--- a/recipes/translation/translate_jsonl.py
+++ b/recipes/translation/translate_jsonl.py
@@ -25,7 +25,6 @@ from nemo_skills.inference.generate import GenerateSolutionsConfig, GenerationTa
 from nemo_skills.utils import nested_dataclass, setup_logging
 
 LOG = logging.getLogger(__name__)
-MAX_CONTEXT_LENGTH = 500
 
 
 def is_line_translatable_content(line: str) -> bool:
@@ -84,7 +83,7 @@ def full_language_name(lang_code: str) -> str:
     """
 
     lang_code = lang_code.lower().strip()
-    language = iso639.languages.get(alpha2=lang_code)
+    language = iso639.Lang(lang_code)
     if language:
         return language.name
 
@@ -192,7 +191,7 @@ class TranslationTask(GenerationTask):
 
                     current_doc_template.append(None)
                     current_doc_translatable_lines.append(stripped_line)
-                    all_translatable_lines.append(stripped_line[:MAX_CONTEXT_LENGTH])
+                    all_translatable_lines.append(stripped_line)
                     current_doc_translatable_indices.append(i)
                     current_doc_leading_spaces_list.append(leading_spaces)
                     current_doc_original_stripped_lines.append(stripped_line)


### PR DESCRIPTION
This PR fixes two bugs in the translation module:

* Use iso639-lang APIs (matches the package in requirements.txt), not iso639
* Remove the unintended max context length variable

Besides, to use the ported inference arguments defined in `translate_jsonl.py`, one should run with `--generation-config vllm` passed to vllm. Putting it altogether:

```
ns generate --cluster=local --server_type=vllm --model=Qwen/Qwen2.5-14B-Instruct --server_gpus=1 --input_file=[input_file] --output_dir=[output_dir] --generation_module=recipes/translation/translate_jsonl.py --server_args='--generation-config vllm' -- target_lang=it prompt_config=/workspace/recipes/translation/config/qwen25.yaml
```