### PR TITLE
Reduce default `max_concurrent_requests` back to 512

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -101,7 +101,7 @@ class GenerateSolutionsConfig:
 
     # maximum number of concurrent requests to the server for the async loop
     # if sync loop is used, this is the batch size
-    max_concurrent_requests: int = 1024
+    max_concurrent_requests: int = 512
     # chunk the dataset into equal sized parts and index into them
     num_chunks: int | None = None  # if specified, will split the data into chunks and only generate for one chunk
     chunk_id: int | None = None  # if specified, will index the specified chunk only


### PR DESCRIPTION
1024 causes the following errors on some clusters (backtrace truncated):

```
...
  File "/nemo_run/code/nemo_skills/inference/generate.py", line 475, in process_single_datapoint
    return await self.llm.generate_async(**generation_params)
  File "/nemo_run/code/nemo_skills/inference/model/context_retry.py", line 173, in async_wrapper
    return await handle_context_retries_async(func, self, args, kwargs, config)
  File "/nemo_run/code/nemo_skills/inference/model/context_retry.py", line 192, in handle_context_retries_async
    result = await func(self, *args, **kwargs)
  File "/nemo_run/code/nemo_skills/inference/model/base.py", line 256, in generate_async
    response = await litellm.acompletion(**request_params, **self.litellm_kwargs)
...
  File "/usr/local/lib/python3.10/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 501, in exception_type
    raise InternalServerError(
litellm.exceptions.InternalServerError: litellm.InternalServerError: InternalServerError: OpenAIException - Connection error.
```