### PR TITLE
Fix SWE-bench parallel runs and other issues

### DIFF
--- a/docs/evaluation/code.md
+++ b/docs/evaluation/code.md
@@ -152,7 +152,7 @@ After all jobs are complete, you can check the results in `<OUTPUT_DIR>/eval-res
   }
 }
 ```
-Keep in mind there is some variance between runs, so we recommend running evaluation multiple times and averaging out the resolve rate.
+Keep in mind there is some variance between runs, so we recommend running evaluation multiple times and averaging out the resolve rate. To do that automatically, you can set `--benchmarks=swe-bench:N`, where N is your desired number of repeats.
 
 To evaluate the same model with SWE-agent,
 all you need to do is replace `openhands` with `swe_agent` in the command above.

--- a/docs/evaluation/code.md
+++ b/docs/evaluation/code.md
@@ -112,7 +112,12 @@ SWE-bench requires models to call custom tools. By default SWE-agent & OpenHands
 
 For more details and the list of supported parsers, see the docs: [VLLM](https://docs.vllm.ai/en/stable/features/tool_calling.html#automatic-function-calling), [SGLang](https://docs.sglang.ai/advanced_features/function_calling.html).
 
-In addition, both SWE-agent and OpenHands can run without native tool calling. This means the tool calls will be parsed by the agentic framework itself. To try this out, for SWE-agent you can use the [config for SWE-agent-LM-32B](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/prompt/config/eval/swe-bench/swe-agent/swe-agent-lm-32b.yaml) and for OpenHands you can set `native_tool_calling = false` in the config. Keep in mind that by default the tool call format expected by these frameworks will likely be different from the one that the model was trained on.
+In addition, both SWE-agent and OpenHands can run without native tool calling. This means the tool calls will be parsed by the agentic framework itself. To try this out:
+
+- for SWE-agent you can use the [config for SWE-agent-LM-32B](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/prompt/config/eval/swe-bench/swe-agent/swe-agent-lm-32b.yaml) with `++agent_config=eval/swe-bench/swe-agent/swe-agent-lm-32b`
+- for OpenHands you can use the [`no-native-tool-calling` config](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/prompt/config/eval/swe-bench/openhands/no-native-tool-calling.toml) with `++agent_config=eval/swe-bench/openhands/no-native-tool-calling`
+
+Keep in mind that by default the tool call format expected by these frameworks will likely be different from the one that the model was trained on.
 
 #### Sample run
 

--- a/docs/evaluation/code.md
+++ b/docs/evaluation/code.md
@@ -112,10 +112,10 @@ SWE-bench requires models to call custom tools. By default SWE-agent & OpenHands
 
 For more details and the list of supported parsers, see the docs: [VLLM](https://docs.vllm.ai/en/stable/features/tool_calling.html#automatic-function-calling), [SGLang](https://docs.sglang.ai/advanced_features/function_calling.html).
 
-In addition, both SWE-agent and OpenHands can run without native tool calling. This means the tool calls will be parsed by the agentic framework itself. To try this out:
+In addition, both SWE-agent and OpenHands can run without native tool calling. This means the tool calls will be parsed by the agentic framework itself. To try this out, you can use the following configs with the `++agent_config` parameter:
 
-- for SWE-agent you can use the [config for SWE-agent-LM-32B](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/prompt/config/eval/swe-bench/swe-agent/swe-agent-lm-32b.yaml) with `++agent_config=eval/swe-bench/swe-agent/swe-agent-lm-32b`
-- for OpenHands you can use the [`no-native-tool-calling` config](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/prompt/config/eval/swe-bench/openhands/no-native-tool-calling.toml) with `++agent_config=eval/swe-bench/openhands/no-native-tool-calling`
+- for SWE-agent: [eval/swe-bench/swe-agent/swe-agent-lm-32b](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/prompt/config/eval/swe-bench/swe-agent/swe-agent-lm-32b.yaml). This was the config used for [SWE-agent-LM-32B](https://huggingface.co/SWE-bench/SWE-agent-LM-32B). Note that there are significant differences with the default config.
+- for OpenHands: [eval/swe-bench/openhands/no-native-tool-calling](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/prompt/config/eval/swe-bench/openhands/no-native-tool-calling.toml). This simply sets `native_tool_calling` to `false`.
 
 Keep in mind that by default the tool call format expected by these frameworks will likely be different from the one that the model was trained on.
 

--- a/nemo_skills/inference/eval/swebench.py
+++ b/nemo_skills/inference/eval/swebench.py
@@ -171,8 +171,6 @@ class SweBenchGenerationTask(GenerationTask):
         # Create logs directory if it doesn't exist
         logs_dir = self.output_dir / "apptainer_logs"
         logs_dir.mkdir(exist_ok=True)
-        log_file_path = logs_dir / f"{data_point['instance_id']}_{mode}.log"
-        LOG.info("Starting execution of an apptainer command. Logs are available at %s", log_file_path)
 
         # Fix localhost URLs not working sometimes
         command = f"echo '127.0.0.1 localhost' >/etc/hosts && {command}"
@@ -187,6 +185,14 @@ class SweBenchGenerationTask(GenerationTask):
 
         # Retry apptainer command up to max_retries times
         for attempt in range(max_retries):
+            log_file_path = logs_dir / f"{data_point['instance_id']}_{mode}_attempt{attempt + 1}.log"
+            LOG.info(
+                "Starting execution of an apptainer command (attempt %d of %d). Logs are available at %s",
+                attempt + 1,
+                max_retries,
+                log_file_path,
+            )
+
             try:
                 # Stream output to log file as it appears
                 with open(log_file_path, "w") as log_file:

--- a/nemo_skills/inference/eval/swebench.py
+++ b/nemo_skills/inference/eval/swebench.py
@@ -160,6 +160,12 @@ class SweBenchGenerationTask(GenerationTask):
     def setup_llm(self):
         return
 
+    def setup_litellm_cache(self):
+        return
+
+    def cleanup_litellm_cache(self):
+        return
+
     async def _execute_container_command(
         self, data_point, command, expected_file_pattern, mode, max_retries=3, timeout=100000
     ):

--- a/nemo_skills/inference/eval/swebench.py
+++ b/nemo_skills/inference/eval/swebench.py
@@ -413,6 +413,9 @@ class SweBenchGenerationTask(GenerationTask):
     async def process_single_datapoint(self, data_point, data):
         """Will do all necessary generations to get a single answer for the data point."""
         self.output_dir = Path(self.cfg.output_file).parent
+        if self.cfg.inference.random_seed is not None:
+            self.output_dir = self.output_dir / f"seed{self.cfg.inference.random_seed}"
+            self.output_dir.mkdir(exist_ok=True)
 
         # TODO: what's the right way to support api models, so that our standard parameters for that can be used?
         # TODO: use self.cfg.server.base_url, etc. Can we pass in API key?

--- a/nemo_skills/inference/eval/swebench.py
+++ b/nemo_skills/inference/eval/swebench.py
@@ -420,7 +420,7 @@ class SweBenchGenerationTask(GenerationTask):
         """Will do all necessary generations to get a single answer for the data point."""
         self.output_dir = Path(self.cfg.output_file).parent
         if self.cfg.inference.random_seed is not None:
-            self.output_dir = self.output_dir / f"seed{self.cfg.inference.random_seed}"
+            self.output_dir = self.output_dir / f"rs{self.cfg.inference.random_seed}"
             self.output_dir.mkdir(exist_ok=True)
 
         # TODO: what's the right way to support api models, so that our standard parameters for that can be used?

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -271,7 +271,7 @@ class GenerationTask:
             self.tokenizer = None
 
         # Setup litellm cache
-        if self.cfg.enable_litellm_cache:
+        if getattr(self.cfg, "enable_litellm_cache", False):
             # One cache per (output_file_name, chunk_id) pair
             output_file_name = Path(self.cfg.output_file).name
             self.litellm_cache_dir = (
@@ -587,7 +587,7 @@ class GenerationTask:
                 fout.write(json.dumps(gen_dict) + "\n")
 
         Path(self.cfg.output_file + "-async").unlink()
-        if self.cfg.enable_litellm_cache:
+        if getattr(self.cfg, "enable_litellm_cache", False):
             shutil.rmtree(self.litellm_cache_dir)
 
     def wait_for_server(self):

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -271,13 +271,7 @@ class GenerationTask:
             self.tokenizer = None
 
         # Setup litellm cache
-        if getattr(self.cfg, "enable_litellm_cache", False):
-            # One cache per (output_file_name, chunk_id) pair
-            output_file_name = Path(self.cfg.output_file).name
-            self.litellm_cache_dir = (
-                Path(self.cfg.output_file).parent / "litellm_cache" / f"{output_file_name}_{self.cfg.chunk_id or 0}"
-            )
-            litellm.cache = litellm.Cache(type="disk", disk_cache_dir=self.litellm_cache_dir)
+        self.setup_litellm_cache()
 
         if self.cfg.use_completions_api and self.cfg.inference.tokens_to_generate is None:
             raise ValueError("When using completions API, tokens_to_generate must be specified!")
@@ -587,8 +581,7 @@ class GenerationTask:
                 fout.write(json.dumps(gen_dict) + "\n")
 
         Path(self.cfg.output_file + "-async").unlink()
-        if getattr(self.cfg, "enable_litellm_cache", False):
-            shutil.rmtree(self.litellm_cache_dir)
+        self.cleanup_litellm_cache()
 
     def wait_for_server(self):
         server_address = self.cfg.server.get("base_url") or f"{self.cfg.server['host']}:{self.cfg.server['port']}"
@@ -597,6 +590,19 @@ class GenerationTask:
             return
         server_start_cmd = get_server_wait_cmd(server_address)
         subprocess.run(server_start_cmd, shell=True, check=True)
+
+    def setup_litellm_cache(self):
+        if self.cfg.enable_litellm_cache:
+            # One cache per (output_file_name, chunk_id) pair
+            output_file_name = Path(self.cfg.output_file).name
+            self.litellm_cache_dir = (
+                Path(self.cfg.output_file).parent / "litellm_cache" / f"{output_file_name}_{self.cfg.chunk_id or 0}"
+            )
+            litellm.cache = litellm.Cache(type="disk", disk_cache_dir=self.litellm_cache_dir)
+
+    def cleanup_litellm_cache(self):
+        if self.cfg.enable_litellm_cache:
+            shutil.rmtree(self.litellm_cache_dir)
 
     def generate(self):
         Path(self.cfg.output_file).absolute().parent.mkdir(parents=True, exist_ok=True)

--- a/nemo_skills/prompt/config/eval/swe-bench/openhands/no-native-tool-calling.toml
+++ b/nemo_skills/prompt/config/eval/swe-bench/openhands/no-native-tool-calling.toml
@@ -1,0 +1,7 @@
+[llm.model]
+# The following parameters are overridden by Nemo-Skills:
+# model, base_url, temperature, top_p.
+# Specifying them here will have no effect! Use Nemo-Skills options instead.
+api_key = "EMPTY"
+custom_llm_provider = "openai"
+native_tool_calling = false


### PR DESCRIPTION
Fixes the following issues for SWE-bench:

- Parallel runs with `--benchmark=swe-bench:N` now work correctly by separating each run's output files into a folder called `rs{seed}`. Previously, parallel runs would overwrite each other's output files, e.g. in the `trajectories` folder.
- When rerunning an Apptainer command, log files for the different attempts are now separated. Previously, each new attempt would overwrite the last one, which was annoying when debugging errors.
- Jobs no longer fail [here](https://github.com/NVIDIA/NeMo-Skills/blob/50f3747a73e62fa8ff22b1484b47c25b770eb7e4/nemo_skills/inference/generate.py#L590) because of `enable_litellm_cache` missing in `SweBenchGenerationConfig`. I think this issue was introduced by https://github.com/NVIDIA/NeMo-Skills/pull/789. I just added a `getattr` check but I'm not sure it's the cleanest solution.