### PR TITLE
lean eval last code block and has sorry logic fix

### DIFF
--- a/nemo_skills/code_execution/sandbox.py
+++ b/nemo_skills/code_execution/sandbox.py
@@ -245,14 +245,14 @@ class Sandbox(abc.ABC):
             output = await self._send_request(request, timeout)
         except httpx.TimeoutException:
             return "timeout"
-        if output.get("process_status") == "completed":
-            stdout = (output.get("stdout") or "").lower()
-            stderr = (output.get("stderr") or "").lower()
+        if output["process_status"] == "completed":
+            stdout = output["stdout"].lower()
+            stderr = output["stderr"].lower()
             combined = stdout + "\n" + stderr
             if re.search(r"\bsorry\b", combined) is not None:
                 return "has_sorry"
             return "completed"
-        return output.get("process_status", "error")
+        return output["process_status"]
 
     async def batch_evaluate_results(
         self,

--- a/nemo_skills/code_execution/sandbox.py
+++ b/nemo_skills/code_execution/sandbox.py
@@ -264,7 +264,7 @@ class Sandbox(abc.ABC):
         final_answer_key: str = "**FINAL ANSWER**",
         restate_formal_statement: bool = True,
         strip_theorem_from_proof: bool = True,
-        code_block_from: str = "last",
+        extract_code_mode: str = "last",
     ):
         """Evaluate results and write back to original files."""
 
@@ -283,7 +283,7 @@ class Sandbox(abc.ABC):
             if answer_format == "lean4-proof":
                 if not use_predicted_proof_key:
                     generation = clean_formal_generation(
-                        line_dict["generation"], final_answer_key=final_answer_key, code_block_from=code_block_from
+                        line_dict["generation"], final_answer_key=final_answer_key, extract_code_mode=extract_code_mode
                     )
                     line_dict["predicted_proof"] = (
                         line_dict["header"]
@@ -300,7 +300,7 @@ class Sandbox(abc.ABC):
                         )
             elif answer_format == "lean4-statement":
                 if not use_predicted_proof_key:
-                    generation = clean_formal_generation(line_dict["generation"], code_block_from=code_block_from)
+                    generation = clean_formal_generation(line_dict["generation"], extract_code_mode=extract_code_mode)
                     header = get_lean4_header()
                     line_dict["predicted_proof"] = header + generation + "\n sorry"
                 else:

--- a/nemo_skills/code_execution/sandbox.py
+++ b/nemo_skills/code_execution/sandbox.py
@@ -264,6 +264,7 @@ class Sandbox(abc.ABC):
         final_answer_key: str = "**FINAL ANSWER**",
         restate_formal_statement: bool = True,
         strip_theorem_from_proof: bool = True,
+        code_block_from: str = "last",
     ):
         """Evaluate results and write back to original files."""
 
@@ -281,7 +282,9 @@ class Sandbox(abc.ABC):
             # Prepare predicted_proof based on format
             if answer_format == "lean4-proof":
                 if not use_predicted_proof_key:
-                    generation = clean_formal_generation(line_dict["generation"], final_answer_key=final_answer_key)
+                    generation = clean_formal_generation(
+                        line_dict["generation"], final_answer_key=final_answer_key, code_block_from=code_block_from
+                    )
                     line_dict["predicted_proof"] = (
                         line_dict["header"]
                         + (line_dict["formal_statement"] if restate_formal_statement else "")
@@ -297,7 +300,7 @@ class Sandbox(abc.ABC):
                         )
             elif answer_format == "lean4-statement":
                 if not use_predicted_proof_key:
-                    generation = clean_formal_generation(line_dict["generation"])
+                    generation = clean_formal_generation(line_dict["generation"], code_block_from=code_block_from)
                     header = get_lean4_header()
                     line_dict["predicted_proof"] = header + generation + "\n sorry"
                 else:

--- a/nemo_skills/code_execution/utils.py
+++ b/nemo_skills/code_execution/utils.py
@@ -101,7 +101,7 @@ def extract_code_block(text: str, languages=None, extract_code_mode: str = "last
 def clean_formal_generation(
     generation: str,
     final_answer_key: str = "**FINAL ANSWER**",
-    extract_code_mode: str = "first",
+    extract_code_mode: str = "last",
 ) -> str:
     # Extract part after **FINAL ANSWER** if present
     if final_answer_key in generation:

--- a/nemo_skills/code_execution/utils.py
+++ b/nemo_skills/code_execution/utils.py
@@ -91,9 +91,9 @@ def extract_code_block(text: str, languages=None) -> str:
     if languages is None:
         languages = [""]
     for language in languages:
-        match = re.search(rf"```{language}\s*\n?(.*?)\n?```", text, re.DOTALL)
-        if match:
-            return match.group(1).strip()
+        matches = re.findall(rf"```{language}\s*\n?(.*?)\n?```", text, re.DOTALL)
+        if matches:
+            return matches[-1].strip()
     return ""
 
 

--- a/nemo_skills/code_execution/utils.py
+++ b/nemo_skills/code_execution/utils.py
@@ -87,23 +87,28 @@ def extract_code_output(generation: str, code_output_begin: str, code_output_end
     return _extract_between_separators(generation, [code_output_begin, code_output_end], extract_all)
 
 
-def extract_code_block(text: str, languages=None) -> str:
+def extract_code_block(text: str, languages=None, which: str = "last") -> str:
     if languages is None:
         languages = [""]
     for language in languages:
         matches = re.findall(rf"```{language}\s*\n?(.*?)\n?```", text, re.DOTALL)
         if matches:
-            return matches[-1].strip()
+            idx = 0 if which == "first" else -1
+            return matches[idx].strip()
     return ""
 
 
-def clean_formal_generation(generation: str, final_answer_key: str = "**FINAL ANSWER**") -> str:
+def clean_formal_generation(
+    generation: str,
+    final_answer_key: str = "**FINAL ANSWER**",
+    code_block_from: str = "first",
+) -> str:
     # Extract part after **FINAL ANSWER** if present
     if final_answer_key in generation:
         generation = generation.split(final_answer_key, 1)[1].strip()
 
     languages = ["lean4", "lean3", "lean", ""]
-    extracted_code = extract_code_block(generation, languages)
+    extracted_code = extract_code_block(generation, languages, which=code_block_from)
     if extracted_code:
         return extracted_code
 

--- a/nemo_skills/code_execution/utils.py
+++ b/nemo_skills/code_execution/utils.py
@@ -87,13 +87,13 @@ def extract_code_output(generation: str, code_output_begin: str, code_output_end
     return _extract_between_separators(generation, [code_output_begin, code_output_end], extract_all)
 
 
-def extract_code_block(text: str, languages=None, extract_mode: str = "last") -> str:
+def extract_code_block(text: str, languages=None, extract_code_mode: str = "last") -> str:
     if languages is None:
         languages = [""]
     for language in languages:
         matches = re.findall(rf"```{language}\s*\n?(.*?)\n?```", text, re.DOTALL)
         if matches:
-            idx = 0 if extract_mode == "first" else -1
+            idx = 0 if extract_code_mode == "first" else -1
             return matches[idx].strip()
     return ""
 
@@ -101,14 +101,14 @@ def extract_code_block(text: str, languages=None, extract_mode: str = "last") ->
 def clean_formal_generation(
     generation: str,
     final_answer_key: str = "**FINAL ANSWER**",
-    code_block_from: str = "first",
+    extract_code_mode: str = "first",
 ) -> str:
     # Extract part after **FINAL ANSWER** if present
     if final_answer_key in generation:
         generation = generation.split(final_answer_key, 1)[1].strip()
 
     languages = ["lean4", "lean3", "lean", ""]
-    extracted_code = extract_code_block(generation, languages, extract_mode=code_block_from)
+    extracted_code = extract_code_block(generation, languages, extract_code_mode=extract_code_mode)
     if extracted_code:
         return extracted_code
 

--- a/nemo_skills/code_execution/utils.py
+++ b/nemo_skills/code_execution/utils.py
@@ -87,13 +87,13 @@ def extract_code_output(generation: str, code_output_begin: str, code_output_end
     return _extract_between_separators(generation, [code_output_begin, code_output_end], extract_all)
 
 
-def extract_code_block(text: str, languages=None, which: str = "last") -> str:
+def extract_code_block(text: str, languages=None, extract_mode: str = "last") -> str:
     if languages is None:
         languages = [""]
     for language in languages:
         matches = re.findall(rf"```{language}\s*\n?(.*?)\n?```", text, re.DOTALL)
         if matches:
-            idx = 0 if which == "first" else -1
+            idx = 0 if extract_mode == "first" else -1
             return matches[idx].strip()
     return ""
 
@@ -108,7 +108,7 @@ def clean_formal_generation(
         generation = generation.split(final_answer_key, 1)[1].strip()
 
     languages = ["lean4", "lean3", "lean", ""]
-    extracted_code = extract_code_block(generation, languages, which=code_block_from)
+    extracted_code = extract_code_block(generation, languages, extract_mode=code_block_from)
     if extracted_code:
         return extracted_code
 

--- a/nemo_skills/evaluation/evaluator/math.py
+++ b/nemo_skills/evaluation/evaluator/math.py
@@ -54,7 +54,7 @@ class LeanEvaluatorConfig:
     final_answer_key: str = "**FINAL ANSWER**"
     restate_formal_statement: bool = True
     # Which code block to extract when multiple are present: "first" or "last"
-    code_block_from: str = "last"
+    extract_code_mode: str = "last"
 
 
 def eval_lean4_proof(cfg):

--- a/nemo_skills/evaluation/evaluator/math.py
+++ b/nemo_skills/evaluation/evaluator/math.py
@@ -53,6 +53,8 @@ class LeanEvaluatorConfig:
     timeout: float = 30.0
     final_answer_key: str = "**FINAL ANSWER**"
     restate_formal_statement: bool = True
+    # Which code block to extract when multiple are present: "first" or "last"
+    code_block_from: str = "last"
 
 
 def eval_lean4_proof(cfg):


### PR DESCRIPTION
extract last code block instead of first

"proof_status" = "has_sorry" when sorry explicitly found in stdout/err, allows for warnings to pass