### PR TITLE
Fix tool calling

### DIFF
--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -142,7 +142,6 @@ class ToolCallingWrapper:
                 tool_calls_message = self.call_interpreter.parse(tool_calls)
                 conversation[-1].update(tool_calls_message)
 
-                ## TODO(sanyamk): refactor to not rely on hardcoded dict keys.
                 tool_calls_output_messages = await self._execute_tool_calls(
                     tool_calls_message["tool_calls"], request_id=request_id
                 )

--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -120,29 +120,12 @@ class ToolCallingWrapper:
         while True:
             if isinstance(tokens_to_generate, int) and tokens_to_generate <= 0:
                 break
-            print("!!", conversation)
-            from transformers import AutoTokenizer
-
-            tok = AutoTokenizer.from_pretrained(
-                "/home/igitman/workspace/openreasoning-toolcall-hf/", trust_remote_code=True
-            )
-            conv_to_print = copy.deepcopy(conversation)
-            for conv in conv_to_print:
-                if "tool_calls" in conv:
-                    conv["tool_calls"][0]["function"]["arguments"] = json.loads(
-                        conv["tool_calls"][0]["function"]["arguments"]
-                    )
-            prompt_str = tok.apply_chat_template(
-                conv_to_print, tools=tools, tokenize=False, add_generation_prompt=False
-            )
-            print("@@", prompt_str)
             generation = await self.model.generate_async(
                 prompt=conversation,
                 tools=tools,
-                tokens_to_generate=16000,
+                tokens_to_generate=tokens_to_generate,
                 **generation_kwargs,
             )
-            print("##", generation)
             if isinstance(tokens_to_generate, int):
                 tokens_to_generate -= generation["num_generated_tokens"]
 

--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -16,6 +16,7 @@ import asyncio
 import copy
 import json
 import logging
+import uuid
 from collections import defaultdict
 from typing import Dict, List
 
@@ -63,7 +64,7 @@ class ToolCallingWrapper:
         self.call_interpreter = ChatCompletionCallInterpreter()
         self.response_formatter = ChatCompletionResponseFormatter()
 
-    async def _execute_tool_call(self, tool_call):
+    async def _execute_tool_call(self, tool_call, request_id: str):
         ## TODO(sanyamk): The correct key format needs to be cohesive with other formatters.
         tool_name = tool_call["function"]["name"]
         tool_args = tool_call["function"]["arguments"]
@@ -80,15 +81,15 @@ class ToolCallingWrapper:
         ## TODO(sanyamk): Only exceptions related to tool execution here, all others must fail.
         try:
             # Allow providers to specify extra_args behavior internally if needed in the future
-            result = await self.tool_manager.execute_tool(tool_name, tool_args, extra_args=None)
+            result = await self.tool_manager.execute_tool(tool_name, tool_args, extra_args={"request_id": request_id})
         except Exception as e:
             LOG.exception(e)
             return {"error": "Tool execution failed."}
 
         return result
 
-    async def _execute_tool_calls(self, tool_calls: List):
-        tasks = [self._execute_tool_call(tool_call) for tool_call in tool_calls]
+    async def _execute_tool_calls(self, tool_calls: List, request_id: str):
+        tasks = [self._execute_tool_call(tool_call, request_id=request_id) for tool_call in tool_calls]
         tool_results = await asyncio.gather(*tasks)
         return [
             self.response_formatter.format(tool_call, tool_result)
@@ -113,17 +114,18 @@ class ToolCallingWrapper:
         result_steps = defaultdict(list)
         conversation = copy.deepcopy(prompt)
 
+        # assigning a unique request id to pass to tool calls if they need to be stateful
+        request_id = str(uuid.uuid4())
+
         while True:
             if isinstance(tokens_to_generate, int) and tokens_to_generate <= 0:
                 break
-
             generation = await self.model.generate_async(
                 prompt=conversation,
                 tools=tools,
                 tokens_to_generate=tokens_to_generate,
                 **generation_kwargs,
             )
-
             if isinstance(tokens_to_generate, int):
                 tokens_to_generate -= generation["num_generated_tokens"]
 
@@ -139,7 +141,9 @@ class ToolCallingWrapper:
                 conversation.append(tool_calls_message)
 
                 ## TODO(sanyamk): refactor to not rely on hardcoded dict keys.
-                tool_calls_output_messages = await self._execute_tool_calls(tool_calls_message["tool_calls"])
+                tool_calls_output_messages = await self._execute_tool_calls(
+                    tool_calls_message["tool_calls"], request_id=request_id
+                )
                 conversation.extend(tool_calls_output_messages)
 
                 result_steps["num_tool_calls"].append(len(tool_calls))

--- a/nemo_skills/mcp/adapters.py
+++ b/nemo_skills/mcp/adapters.py
@@ -114,5 +114,5 @@ class ChatCompletionResponseFormatter(ToolResponseFormatter):
             "role": "tool",
             "name": tool_call["function"]["name"],
             "tool_call_id": tool_call["id"],
-            "content": json.dumps(result),
+            "content": json.dumps(result) if not isinstance(result, str) else result,
         }

--- a/nemo_skills/mcp/servers/python_tool.py
+++ b/nemo_skills/mcp/servers/python_tool.py
@@ -41,14 +41,19 @@ mcp = FastMCP(name="python_tool")
 # Initialized from config in main()
 sandbox = None
 
+# TODO: how should we control timeout in description?
+description = (
+    "Call this function to execute Python code in a stateful Jupyter notebook environment. "
+    "Python will respond with the output of the execution or time out after 120.0 seconds."
+)
 
-@mcp.tool()
+
+@mcp.tool(name="stateful_python_code_exec", description=description)
 async def execute(
-    code: Annotated[str, Field(description="Code to run in python interpreter")],
+    code: Annotated[str, Field(description="Code to execute")],
     session_id: Annotated[str | None, Field(description="Session id for session persistence")] = None,
     timeout: Annotated[float, Field(description="Time in seconds to allow the job to run")] = 10,
 ) -> ExecutionResult:
-    """Executes the given python code"""
     language = "ipython"
     try:
         output, _ = await sandbox.execute_code(code, language=language, timeout=timeout, session_id=session_id)

--- a/nemo_skills/mcp/servers/python_tool.py
+++ b/nemo_skills/mcp/servers/python_tool.py
@@ -123,6 +123,8 @@ class PythonTool(MCPClientTool):
         merged_extra.setdefault("timeout", self._config.get("exec_timeout_s", 10))
         merged_extra["session_id"] = self.requests_to_sessions[request_id]
         result = await self._client.call_tool(tool=tool_name, args=arguments, extra_args=merged_extra)
+        print("!!!", result)
+        print("@@@", self.requests_to_sessions)
         self.requests_to_sessions[request_id] = result["session_id"]
         output = f"{result['output_dict']['stdout']}{result['output_dict']['stderr']}"
         if output.endswith("\n"):  # there is always a trailing newline, removing it

--- a/nemo_skills/mcp/servers/python_tool.py
+++ b/nemo_skills/mcp/servers/python_tool.py
@@ -49,7 +49,7 @@ description = (
 
 
 @mcp.tool(name="stateful_python_code_exec", description=description)
-async def execute(
+async def stateful_python_code_exec(
     code: Annotated[str, Field(description="Code to execute")],
     session_id: Annotated[str | None, Field(description="Session id for session persistence")] = None,
     timeout: Annotated[float, Field(description="Time in seconds to allow the job to run")] = 10,

--- a/nemo_skills/mcp/tool_manager.py
+++ b/nemo_skills/mcp/tool_manager.py
@@ -65,6 +65,7 @@ class ToolManager:
         self._tools: Dict[str, Tool] = {}
         self._qualified_tool_map: Dict[str, str] = {}  # qualified name -> tool_class_name
         self._tool_list_cache: List[Dict[str, Any]] | None = None
+        self._raw_to_qualified_map: Dict[str, str] = {}  # raw name -> qualified name
         self._list_lock = asyncio.Lock()
 
         overrides = overrides or {}
@@ -104,8 +105,8 @@ class ToolManager:
             async def load_provider(provider_id: str, tool: Tool) -> List[Dict[str, Any]]:
                 entries = await tool.list_tools()
                 out: List[Dict[str, Any]] = []
-                # Be defensive: handle None and deduplicate within the same provider by raw tool name
                 local_seen: set[str] = set()
+
                 for entry in entries or []:
                     raw_name = entry.get("name")
                     if not raw_name or raw_name in local_seen:
@@ -113,10 +114,12 @@ class ToolManager:
                     local_seen.add(raw_name)
                     qualified_name = f"{provider_id}.{raw_name}"
                     if qualified_name in local_qualified_map:
-                        # Skip duplicates instead of failing hard; keep first occurrence
-                        continue
+                        raise ValueError(f"Duplicate qualified tool name: '{qualified_name}'")
+                    if raw_name in self._raw_to_qualified_map:
+                        raise ValueError(f"Duplicate raw tool name across providers: '{raw_name}'")
+                    self._raw_to_qualified_map[raw_name] = qualified_name
                     local_qualified_map[qualified_name] = provider_id
-                    out.append({**entry, "name": qualified_name, "server": provider_id})
+                    out.append({**entry, "name": raw_name, "server": provider_id})
                 return out
 
             tasks = [load_provider(pid, tool) for pid, tool in self._tools.items()]
@@ -137,6 +140,6 @@ class ToolManager:
             raise ValueError(f"No tool registered for class '{provider_id}'")
         return tool, bare_name
 
-    async def execute_tool(self, qualified_name: str, args: Dict[str, Any], extra_args: Dict[str, Any] | None = None):
-        tool, bare = self._resolve(qualified_name)
+    async def execute_tool(self, raw_name: str, args: Dict[str, Any], extra_args: Dict[str, Any] | None = None):
+        tool, bare = self._resolve(self._raw_to_qualified_map[raw_name])
         return await tool.execute(bare, args, extra_args=extra_args)

--- a/nemo_skills/mcp/tool_manager.py
+++ b/nemo_skills/mcp/tool_manager.py
@@ -119,6 +119,11 @@ class ToolManager:
                         raise ValueError(f"Duplicate raw tool name across providers: '{raw_name}'")
                     self._raw_to_qualified_map[raw_name] = qualified_name
                     local_qualified_map[qualified_name] = provider_id
+                    # dropping title (recursively) as it's meant to be shown to users, not model
+                    entry.get("input_schema", {}).pop("title", None)
+                    for parameter in entry.get("input_schema", {}).get("properties", {}).values():
+                        parameter.pop("title", None)
+
                     out.append({**entry, "name": raw_name, "server": provider_id})
                 return out
 

--- a/nemo_skills/mcp/utils.py
+++ b/nemo_skills/mcp/utils.py
@@ -86,6 +86,7 @@ def hydra_config_connector_factory(config_obj):
         client.server_params = StdioServerParameters(
             command=client.server_params.command,
             args=list(client.server_params.args) + ["--config-dir", temp_dir, "--config-name", "config"],
+            env=client.server_params.env,
         )
 
     return connector


### PR DESCRIPTION
A few fixes for tool-calling
1. Fix a bug where tool calls were always added as a new assistant turn, instead of being appended to the previous turn
2. Add reasoning_content back into conversation if it's available
3. Add request_id parameter that's always passed in extra_args to support stateful tools
4. Update python tool to use request id as well as to return the string output of stdout/stderr instead of dict
5. Remove title from tool definition as it's not meant to be shown to the model
6. Remove python class from tool name. Otherwise, it's not possible to match tool names as the model might be trained with.
7. Rename python tool and update description
