### PR TITLE
Update filters.trim_solutions=false to be default

### DIFF
--- a/docs/releases/openmathinstruct2/dataset.md
+++ b/docs/releases/openmathinstruct2/dataset.md
@@ -271,6 +271,7 @@ python -m nemo_skills.training.prepare_data \
     ++input_files=\'/workspace/solution-augmentation/**/output-rs*.jsonl,/workspace/new-problems-solution-augmentation/**/output-rs*.jsonl\' \
     ++output_path=/workspace/sft_data.jsonl \
     ++filters.remove_len_outlier_problems=true \
+    ++filters.trim_solutions=true \
     ++max_problem_length=1024 \
     ++filters.remove_len_outlier_solutions=true \
     ++use_chars_for_min_length=true \

--- a/docs/releases/openreasoning/dataset.md
+++ b/docs/releases/openreasoning/dataset.md
@@ -167,6 +167,7 @@ cmd = (
     "    ++filters.remove_contaminated=false "  # OpenMathReasoning is already decontaminated
     "    ++filters.remove_len_outlier_solutions=false "
     "    ++filters.remove_len_outlier_problems=false "
+    "    ++filters.trim_solutions=true "
     "    ++use_judgement=true "
 )
 run_cmd(

--- a/docs/tutorials/posts/omr-simple-recipe.md
+++ b/docs/tutorials/posts/omr-simple-recipe.md
@@ -188,8 +188,7 @@ ns run_cmd --log_dir=/workspace/prepare-sft-data --expname=prepare-sft-data --ru
       ++tokenizer=Qwen/Qwen2.5-32B-Instruct \
       ++filters.remove_contaminated=false \
       ++add_unlabeled=true \
-      ++filters.remove_no_think_tags=true \
-      ++filters.trim_solutions=false'
+      ++filters.remove_no_think_tags=true
 ```
 
 Next, [convert the model](https://nvidia.github.io/NeMo-Skills/pipelines/checkpoint-conversion/) to NeMo format. You can skip this step for NeMo-RL training.

--- a/nemo_skills/training/data_preparation_utils/config/math_rl.yaml
+++ b/nemo_skills/training/data_preparation_utils/config/math_rl.yaml
@@ -36,7 +36,7 @@ majority_filter:
 
 filters:
   remove_contaminated: true
-  remove_len_outlier_problems: true
+  remove_len_outlier_problems: false
   majority_filter: false
   drop_none_answers: true
 

--- a/nemo_skills/training/data_preparation_utils/config/math_sft.yaml
+++ b/nemo_skills/training/data_preparation_utils/config/math_sft.yaml
@@ -55,7 +55,7 @@ filters:
   drop_multi_boxed: false
   remove_contaminated: true
   majority_filter: false
-  trim_solutions: true
+  trim_solutions: false
   trim_prefix: false
   drop_incorrect_arithmetic: false
   split_arithmetic: false

--- a/recipes/openmathreasoning/pipeline/solution_generation.py
+++ b/recipes/openmathreasoning/pipeline/solution_generation.py
@@ -356,6 +356,7 @@ def prepare_for_sft(cluster, expname, run_after, stage_config, **kwargs):
         f"    ++filters.drop_multi_boxed=false "
         f"    ++filters.remove_len_outlier_problems=false "
         f"    ++filters.remove_len_outlier_solutions=false "
+        f"    ++filters.trim_solutions=false "
         f"    ++use_judgement=true "
         f"    ++contamination_file={contamination_file} "
         f"    {stage_config.get('inline_args', '')}"

--- a/recipes/openmathreasoning/scripts/simplified_recipe.py
+++ b/recipes/openmathreasoning/scripts/simplified_recipe.py
@@ -119,7 +119,6 @@ def run_training(workspace, cluster, num_gpus, training_backend, expname_prefix,
             f"    ++filters.remove_contaminated=false "
             f"    ++add_unlabeled=true "
             f"    ++filters.remove_no_think_tags=true "
-            f"    ++filters.trim_solutions=false"
         ),
         cluster=cluster,
         expname=f"{expname_prefix}-prepare-training-data",


### PR DESCRIPTION
Remove trim_solutions=true by default as that's no longer the right setting for most models. We needed it before for models that didn't finish well, but now this can just cut generations mid-sentence and force the final models to always stop after boxed.