### PR TITLE
Update default sandbox parameters

### DIFF
--- a/dockerfiles/sandbox/nginx.conf.template
+++ b/dockerfiles/sandbox/nginx.conf.template
@@ -46,9 +46,9 @@ ${UPSTREAM_SERVERS}
             proxy_set_header X-Session-ID $http_x_session_id;
 
             # Timeouts for long-running code execution
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 300s;
-            proxy_read_timeout 300s;
+            proxy_connect_timeout 1200s;
+            proxy_send_timeout 1200s;
+            proxy_read_timeout 1200s;
 
             # Don't buffer response for streaming
             proxy_buffering off;

--- a/nemo_skills/code_execution/local_sandbox/local_sandbox_server.py
+++ b/nemo_skills/code_execution/local_sandbox/local_sandbox_server.py
@@ -443,7 +443,7 @@ def _after_log_session_count(response):
     return response
 
 
-MEM_LIMIT_BYTES = int(os.environ.get("NEMO_SKILLS_SANDBOX_MEM_LIMIT", 10 * 1024**3))  # 10 GiB default
+MEM_LIMIT_BYTES = int(os.environ.get("NEMO_SKILLS_SANDBOX_MEM_LIMIT", 50 * 1024**3))  # 50 GiB default
 
 # Set per-worker memory limit for ipython session
 resource.setrlimit(resource.RLIMIT_AS, (2 * MEM_LIMIT_BYTES, 2 * MEM_LIMIT_BYTES))


### PR DESCRIPTION
Mainly for better Lean compilation experience. Sometimes we need higher timeouts and default 10gb of memory isn't always enough