### PR TITLE
hle with detail splits

### DIFF
--- a/docs/evaluation/scientific-knowledge.md
+++ b/docs/evaluation/scientific-knowledge.md
@@ -8,6 +8,8 @@ More details are coming soon!
 
 - Benchmark is defined in [`nemo_skills/dataset/hle/__init__.py`](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/dataset/hle/__init__.py)
 - Original benchmark source is [here](https://huggingface.co/datasets/cais/hle).
+- The `text` split includes all non-image examples. It is further divided into `eng`, `chem`, `bio`, `cs`, `phy`, `math`, `human`, `other`. Currently, **all** of these splits contain only text data.
+
 ### SimpleQA
 
 - Benchmark is defined in [`nemo_skills/dataset/simpleqa/__init__.py`](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/dataset/simpleqa/__init__.py)


### PR DESCRIPTION
Previously, only "math" split is available in HLE. This PR added all other categories so users can easily evaluate one specific area of the HLE datasets. 
Also, doc is updated. Adding a note that it's fully text-only for now.

```
nemo-run/0 Preparing hle
nemo-run/0 Writing text.jsonl: 100%|██████████| 2500/2500 [00:00<00:00, 14402.80it/s]
nemo-run/0 Writing other.jsonl: 100%|██████████| 2500/2500 [00:00<00:00, 23931.08it/s]
nemo-run/0 Writing human.jsonl: 100%|██████████| 2500/2500 [00:00<00:00, 23758.70it/s]
nemo-run/0 Writing math.jsonl: 100%|██████████| 2500/2500 [00:00<00:00, 19805.60it/s]
nemo-run/0 Writing phy.jsonl: 100%|██████████| 2500/2500 [00:00<00:00, 23385.57it/s]
nemo-run/0 Writing cs.jsonl: 100%|██████████| 2500/2500 [00:00<00:00, 23304.54it/s]
nemo-run/0 Writing bio.jsonl: 100%|██████████| 2500/2500 [00:00<00:00, 23410.73it/s]
nemo-run/0 Writing chem.jsonl: 100%|██████████| 2500/2500 [00:00<00:00, 24450.94it/s]
nemo-run/0 Writing eng.jsonl: 100%|██████████| 2500/2500 [00:00<00:00, 24641.18it/s]
```