### PR TITLE
Only run env var check for identity file when key available

### DIFF
--- a/nemo_skills/pipeline/utils/cluster.py
+++ b/nemo_skills/pipeline/utils/cluster.py
@@ -264,7 +264,7 @@ def update_ssh_tunnel_config(cluster_config: dict):
                 cluster_config["ssh_tunnel"][key] = os.path.expandvars(cluster_config["ssh_tunnel"][key])
                 LOG.info(f"Resolved `{key}` to `{cluster_config['ssh_tunnel'][key]}`")
 
-    if "$" in cluster_config["ssh_tunnel"].get("identity", ""):
+    if "$" in (cluster_config["ssh_tunnel"].get("identity") or ""):
         raise ValueError(
             "SSH identity cannot be resolved from environment variables. "
             "Please provide a valid path to the identity file."

--- a/nemo_skills/pipeline/utils/cluster.py
+++ b/nemo_skills/pipeline/utils/cluster.py
@@ -264,7 +264,7 @@ def update_ssh_tunnel_config(cluster_config: dict):
                 cluster_config["ssh_tunnel"][key] = os.path.expandvars(cluster_config["ssh_tunnel"][key])
                 LOG.info(f"Resolved `{key}` to `{cluster_config['ssh_tunnel'][key]}`")
 
-    if "$" in cluster_config["ssh_tunnel"]["identity"]:
+    if "$" in cluster_config["ssh_tunnel"].get("identity", ""):
         raise ValueError(
             "SSH identity cannot be resolved from environment variables. "
             "Please provide a valid path to the identity file."


### PR DESCRIPTION
The example cluster configurations suggest that `ssh_tunnel.identity` can be skipped, but running it leads to the following error:

```shell
  File "/code/NeMo-Skills/nemo_skills/pipeline/utils/cluster.py", line 267, in update_ssh_tunnel_config
    if "$" in cluster_config["ssh_tunnel"]["identity"]:
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'identity'
```

I change it to use `.get` for the dictionary with empty default string. This approach also allows users to directly use the identity available in the system's SSH agent (as supported by the underlying Fabric connector in Nemo Run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when SSH tunnel configuration omits an identity value, improving stability for environments that do not supply this field.
  * Preserved validation for unresolved environment-variable references in the identity setting, so errors are still raised when variable placeholders remain unresolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->