### PR TITLE
Slurm: fix time format, and allow default timeout 

### DIFF
--- a/cluster_configs/example-slurm.yaml
+++ b/cluster_configs/example-slurm.yaml
@@ -63,8 +63,9 @@ job_name_prefix: "nemo_skills:"
 # this will be used as a slurm parameter + to signal SFT job to finish
 # before the timeout to have time to save the last checkpoint
 # timeouts:
-#   partition_name1: 06:00:00
-#   partition_name2: 01:30:00
+#   default: "06:00:00"
+#   partition_name1: "06:00:00"
+#   partition_name2: "01:30:00"
 
 # define any environment variables. Note that HF_HOME is required by default and needs to be a mounted path!
 # env_vars:

--- a/nemo_skills/pipeline/utils/cluster.py
+++ b/nemo_skills/pipeline/utils/cluster.py
@@ -40,9 +40,8 @@ _logged_optional_env_vars = set()
 
 
 def get_timeout(cluster_config, partition):
-    if "timeouts" not in cluster_config:
-        timeout = "10000:00:00:00"
-    else:
+    default_timeout = cluster_config.get("timeouts", {}).get("default", "10000:00:00:00")
+    try:
         timeout = cluster_config["timeouts"][partition or cluster_config["partition"]]
 
         # subtracting 15 minutes to account for the time it takes to save the model
@@ -51,6 +50,8 @@ def get_timeout(cluster_config, partition):
         timeout = (
             f"00:{time_diff.seconds // 3600:02d}:{(time_diff.seconds % 3600) // 60:02d}:{time_diff.seconds % 60:02d}"
         )
+    except KeyError:
+        timeout = default_timeout
     return timeout
 
 

--- a/nemo_skills/pipeline/utils/cluster.py
+++ b/nemo_skills/pipeline/utils/cluster.py
@@ -265,7 +265,7 @@ def update_ssh_tunnel_config(cluster_config: dict):
                 cluster_config["ssh_tunnel"][key] = os.path.expandvars(cluster_config["ssh_tunnel"][key])
                 LOG.info(f"Resolved `{key}` to `{cluster_config['ssh_tunnel'][key]}`")
 
-    if "$" in cluster_config["ssh_tunnel"]["identity"]:
+    if "$" in cluster_config["ssh_tunnel"].get("identity", ""):
         raise ValueError(
             "SSH identity cannot be resolved from environment variables. "
             "Please provide a valid path to the identity file."

--- a/nemo_skills/pipeline/utils/cluster.py
+++ b/nemo_skills/pipeline/utils/cluster.py
@@ -40,7 +40,10 @@ _logged_optional_env_vars = set()
 
 
 def get_timeout(cluster_config, partition):
-    default_timeout = cluster_config.get("timeouts", {}).get("default", "10000:00:00:00")
+    # Time format for SLURM: "minutes", "minutes:seconds", "hours:minutes:seconds",
+    # "days-hours", "days-hours:minutes" and "days-hours:minutes:seconds"
+    # https://slurm.schedmd.com/sbatch.html#OPT_time
+    default_timeout = cluster_config.get("timeouts", {}).get("default", "10000-00:00:00")
     try:
         timeout = cluster_config["timeouts"][partition or cluster_config["partition"]]
 
@@ -48,7 +51,7 @@ def get_timeout(cluster_config, partition):
         # the format expected by nemo is days:hours:minutes:seconds
         time_diff = datetime.strptime(timeout, "%H:%M:%S") - datetime.strptime("00:15:00", "%H:%M:%S")
         timeout = (
-            f"00:{time_diff.seconds // 3600:02d}:{(time_diff.seconds % 3600) // 60:02d}:{time_diff.seconds % 60:02d}"
+            f"0-{time_diff.seconds // 3600:02d}:{(time_diff.seconds % 3600) // 60:02d}:{time_diff.seconds % 60:02d}"
         )
     except KeyError:
         timeout = default_timeout

--- a/nemo_skills/pipeline/utils/exp.py
+++ b/nemo_skills/pipeline/utils/exp.py
@@ -29,6 +29,7 @@ from torchx.specs.api import AppState
 
 from nemo_skills.pipeline.utils.cluster import (
     get_env_variables,
+    get_timeout,
     get_tunnel,
     temporary_env_update,
     tunnel_hash,
@@ -227,10 +228,7 @@ def get_executor(
                 slurm_kwargs = {}
             slurm_kwargs["exclusive"] = True
 
-    if "timeouts" not in cluster_config:
-        timeout = "10000:00:00:00"
-    else:
-        timeout = cluster_config["timeouts"][partition]
+    timeout = get_timeout(cluster_config, partition)
 
     additional_parameters = {"time_min": time_min} if time_min is not None else {}
     if cluster_config.get("mail_type") is not None:


### PR DESCRIPTION
- Allow "default" timeout to be specified for partitions to avoid listing all available partitions in "timeouts" section
- Fix time format to `D-HH:MM:SS` according to the docs https://slurm.schedmd.com/sbatch.html#OPT_time (previously failed on some clusters)