### PR TITLE
Megatron backend changes: minor fix, add random ports

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -195,7 +195,7 @@ class GenerateSolutionsConfig:
                     "Megatron server doesn't support chat completions and we can't infer tokenizer from model name. "
                     "Please provide it with an explicit `tokenizer` parameter."
                 )
-            self.cfg.use_completions_api = True
+            self.use_completions_api = True
             LOG.warning("Megatron inference is extremely slow. It's highly recommended to use other server types!")
 
     def _post_init_validate_params(self):

--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -309,7 +309,7 @@ def eval(
         generation_type=generation_type,
         generation_module=generation_module,
     )
-    get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive, server_type)
+    get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive)
     should_package_extra_datasets = extra_datasets and extra_datasets_type == ExtraDatasetType.local
     has_tasks = False
     job_id_to_tasks = {}

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -185,7 +185,7 @@ def generate(
     else:
         wandb_parameters = None
 
-    get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive, server_type)
+    get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive)
 
     if random_seeds and num_random_seeds:
         raise ValueError("Cannot specify both random_seeds and num_random_seeds")

--- a/nemo_skills/pipeline/openrlhf/ppo.py
+++ b/nemo_skills/pipeline/openrlhf/ppo.py
@@ -358,7 +358,7 @@ def ppo_openrlhf(
 
     server_config = None
     if server_type is not None:
-        get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive, server_type)
+        get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive)
         if server_address is None:  # we need to host the model
             assert server_gpus is not None, "Need to specify server_gpus if hosting the model"
             server_port = get_free_port(strategy="random") if get_random_port else 5000

--- a/nemo_skills/pipeline/utils/eval.py
+++ b/nemo_skills/pipeline/utils/eval.py
@@ -404,9 +404,7 @@ def prepare_eval_commands(
         eval_to_job_map.extend([i] * count)
 
     cur_job_idx = 0
-    get_random_port = pipeline_utils.should_get_random_port(
-        server_parameters["server_gpus"], exclusive, server_parameters["server_type"]
-    )
+    get_random_port = pipeline_utils.should_get_random_port(server_parameters["server_gpus"], exclusive)
     job_server_config, job_server_address, job_extra_arguments = pipeline_utils.configure_client(
         **server_parameters,
         extra_arguments=extra_arguments,

--- a/nemo_skills/pipeline/utils/server.py
+++ b/nemo_skills/pipeline/utils/server.py
@@ -57,8 +57,8 @@ def get_free_port(exclude: list[int] | None = None, strategy: int | str = 5000) 
         raise ValueError(f"Strategy {strategy} not supported.")
 
 
-def should_get_random_port(server_gpus, exclusive, server_type):
-    return server_gpus != 8 and not exclusive and server_type != "megatron"
+def should_get_random_port(server_gpus, exclusive):
+    return server_gpus != 8 and not exclusive
 
 
 def wrap_python_path(cmd):
@@ -149,6 +149,7 @@ def get_server_command(
             f"    --pipeline-model-parallel-size {num_nodes} "
             f"    --use-checkpoint-args "
             f"    --max-tokens-to-oom 12000000 "
+            f"    --port {server_port} "
             f"    --micro-batch-size 1 "  # that's a training argument, ignored here, but required to specify..
             f"    {server_args} "
         )

--- a/nemo_skills/pipeline/verl/ppo.py
+++ b/nemo_skills/pipeline/verl/ppo.py
@@ -358,7 +358,7 @@ def ppo_verl(
 
     server_config = None
     if server_type is not None:
-        get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive, server_type)
+        get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive)
         if server_address is None:  # we need to host the model
             assert server_gpus is not None, "Need to specify server_gpus if hosting the model"
             server_port = get_free_port(strategy="random") if get_random_port else 5000


### PR DESCRIPTION
Changes:
- Minor fix to Megatron backend inference path
- Random ports for Megatron (to allow generating multiple samples per benchmark)

Tested:
- Ran several evals, including AIME25

Example cmd to pipeclean basic functionality with BF16 checkpoint:
```
ns eval \
  --cluster=nrt \
  --server_type=megatron \
  --model=<model> \
  --output_dir=<output_dir> \
  --benchmarks=aime25 \
  --server_gpus=1 \
  --server_entrypoint="tools/run_mamba_text_generation_server.py" \
  --server_args="--no-use-tokenizer-model-from-checkpoint-args --tokenizer-model <model> --inference-max-seq-length 3000 --flash-decode --enable-cuda-graph --bf16 " \
  ++tokenizer=<tokenizer> \
  ++inference.tokens_to_generate=1024 \
  ++system_message='/think'
```

Example cmd to pipeclean functionality with quantized checkpoint:
```
ns eval \
  --cluster=nrt \
  --server_type=megatron \
  --model=<model> \
  --output_dir=<output_dir> \
  --benchmarks=aime25 \
  --server_gpus=8 \
  --num_chunks=2 \
  --server_entrypoint="tools/run_mamba_text_generation_server.py" \
  --server_args="
  ...<model params>...
    --no-use-tokenizer-model-from-checkpoint-args \
    --bf16 \
    --flash-decode \
    --enable-cuda-graph \
    --inference-max-seq-length 40000 " \
  ++tokenizer=<tokenizer> \
  ++inference.tokens_to_generate=32768 \
  ++system_message='/think'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Corrected completions API configuration during validation to ensure expected behavior.
  - Passed the selected port explicitly to the Megatron server to prevent startup misconfiguration.

- Improvements
  - Unified and simplified random port selection across pipelines, improving reliability when launching training and evaluation servers.
  - More consistent port behavior for exclusive vs. shared GPU runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->