### PR TITLE
add supergpqa to dataset

### DIFF
--- a/docs/evaluation/scientific-knowledge.md
+++ b/docs/evaluation/scientific-knowledge.md
@@ -16,6 +16,21 @@ More details are coming soon!
 - Original benchmark source code for SimpleQA (OpenAI) is [here](https://github.com/openai/simple-evals/) and the leaderboard is [here](https://www.kaggle.com/benchmarks/openai/simpleqa). An improved version with 1,000 examples from Google, SimpleQA-verified, is [here](https://www.kaggle.com/benchmarks/deepmind/simpleqa-verified).
 - To use the SimpleQA-verified, set `split=verified`. To use the original version of SimpleQA, please set `split=test`.
 
+### SuperGPQA
+- Benchmark is defined in [`nemo_skills/dataset/supergpqa/__init__.py`](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/dataset/supergpqa/__init__.py)
+- Original benchmark source is [here](https://github.com/SuperGPQA/SuperGPQA). The official leaderboard is available [here](https://supergpqa.github.io/#Dataset).
+- The `science` split contains all the data where the discipline is "Science". The default full split is `test`.
+
+| Reproduction                                                      |   pass@1[avg-of-2] |   majority@2 |   reference |
+|:--------------------------------------------------------------|:-------------------|:-------------|:---------|
+| GPT-oss 20b (high, no tool) |                               47.02  |      47.79  |    44.91 |
+| GPT-oss 120b (high, no tool) |            53.40 |      53.57 |  51.87	 |
+| Qwen3-30b-a3b-think   |            55.82 |      55.88  |  N/A |
+
+> [Source of reference](https://supergpqa.github.io/#Dataset) and the arXiv paper did not mention the reasoning effort set for GPT-oss.
+
+
+
 ### scicode
 
 !!! note

--- a/docs/evaluation/scientific-knowledge.md
+++ b/docs/evaluation/scientific-knowledge.md
@@ -18,10 +18,8 @@ More details are coming soon!
 
 ### SuperGPQA
 - Benchmark is defined in [`nemo_skills/dataset/supergpqa/__init__.py`](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/dataset/supergpqa/__init__.py)
-- Original benchmark source is [here](https://github.com/SuperGPQA/SuperGPQA). The official leaderboard is available [here](https://supergpqa.github.io/#Dataset).
+- Original benchmark source is available in the [SuperGPQA repository](https://github.com/SuperGPQA/SuperGPQA). The official leaderboard is listed on the [SuperGPQA dataset page](https://supergpqa.github.io/#Dataset).
 - The `science` split contains all the data where the discipline is "Science". The default full split is `test`.
-
-
 
 
 ### scicode

--- a/docs/evaluation/scientific-knowledge.md
+++ b/docs/evaluation/scientific-knowledge.md
@@ -21,13 +21,6 @@ More details are coming soon!
 - Original benchmark source is [here](https://github.com/SuperGPQA/SuperGPQA). The official leaderboard is available [here](https://supergpqa.github.io/#Dataset).
 - The `science` split contains all the data where the discipline is "Science". The default full split is `test`.
 
-| Reproduction                                                      |   pass@1[avg-of-2] |   majority@2 |   reference |
-|:--------------------------------------------------------------|:-------------------|:-------------|:---------|
-| GPT-oss 20b (high, no tool) |                               47.02  |      47.79  |    44.91 |
-| GPT-oss 120b (high, no tool) |            53.40 |      53.57 |  51.87	 |
-| Qwen3-30b-a3b-think   |            55.82 |      55.88  |  N/A |
-
-> [Source of reference](https://supergpqa.github.io/#Dataset) and the arXiv paper did not mention the reasoning effort set for GPT-oss.
 
 
 

--- a/nemo_skills/dataset/supergpqa/__init__.py
+++ b/nemo_skills/dataset/supergpqa/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+DATASET_GROUP = "multichoice"
+METRICS_TYPE = "multichoice"
+EVAL_ARGS = "++eval_type=multichoice"
+EVAL_SPLIT = "test"
+GENERATION_ARGS = "++prompt_config=eval/aai/mcq-10choices"

--- a/nemo_skills/dataset/supergpqa/prepare.py
+++ b/nemo_skills/dataset/supergpqa/prepare.py
@@ -63,6 +63,7 @@ def format_entry(entry):
     return {
         "expected_answer": f"{chr(ord('A') + correct_answer_index)}",
         "uuid": uuid,
+        "subset_for_metrics": entry["discipline"],
         "discipline": discipline,
         "field": field,
         "subfield": subfield,
@@ -86,6 +87,12 @@ def save_data(split, random_seed):
     output_file = data_dir / f"{split}.jsonl"
     random.seed(random_seed)
     dataset = load_dataset("m-a-p/SuperGPQA")["train"]
+    if split == "science":
+        dataset = dataset.filter(lambda x: x["discipline"] == "Science")
+    elif split == "test":
+        dataset = dataset
+    else:
+        raise ValueError(f"Invalid split: {split}")
 
     write_data_to_file(output_file, dataset)
 
@@ -95,14 +102,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "--split",
         default="all",
-        choices=("all", "test"),
+        choices=("all", "test", "science"),
         help="Dataset split to process.",
     )
     parser.add_argument("--random_seed", type=int, default=42)
     args = parser.parse_args()
 
     if args.split == "all":
-        for split in ["test"]:
+        for split in ["test", "science"]:
             save_data(split, args.random_seed)
     else:
         save_data(args.split, args.random_seed)

--- a/nemo_skills/dataset/supergpqa/prepare.py
+++ b/nemo_skills/dataset/supergpqa/prepare.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from nemo_skills.dataset.utils import get_mcq_fields
+
+"""
+Preprocessing adapted from nemo_skills/dataset/gpqa/prepare.py
+"""
+
+
+def preprocess(text):
+    if text is None:
+        return " "
+    text = text.strip()
+    text = text.replace("  ", " ")
+    return text
+
+
+def format_entry(entry):
+    uuid: str = entry["uuid"]
+    question: str = entry["question"]
+    options: list[str] = entry["options"]
+    answer_letter: str = entry["answer_letter"]
+    answer: str = entry["answer"]
+    discipline: str = entry["discipline"]
+    field: str = entry["field"]
+    subfield: str = entry["subfield"]
+    difficulty: str = entry["difficulty"]
+    is_calculation: bool = entry["is_calculation"]
+
+    assert ord(answer_letter) >= ord("A") and ord(answer_letter) <= ord("J")
+    answer_index = ord(answer_letter) - ord("A")
+
+    choices = [preprocess(option) for option in options]
+    if len(choices) != len(set(choices)):
+        raise ValueError(f"Choices are not unique: {choices}")
+
+    correct_answer = choices[answer_index]
+    random.shuffle(choices)
+    correct_answer_index = choices.index(correct_answer)
+    assert correct_answer_index >= 0 and correct_answer_index < len(choices)
+    assert preprocess(answer) == choices[correct_answer_index]  # recheck after shuffling
+
+    return {
+        "expected_answer": f"{chr(ord('A') + correct_answer_index)}",
+        "uuid": uuid,
+        "discipline": discipline,
+        "field": field,
+        "subfield": subfield,
+        "difficulty": difficulty,
+        "is_calculation": is_calculation,
+        **get_mcq_fields(question, choices),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout)
+            fout.write("\n")
+
+
+def save_data(split, random_seed):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    output_file = data_dir / f"{split}.jsonl"
+    random.seed(random_seed)
+    dataset = load_dataset("m-a-p/SuperGPQA")["train"]
+
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--split",
+        default="all",
+        choices=("all", "test"),
+        help="Dataset split to process.",
+    )
+    parser.add_argument("--random_seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.split == "all":
+        for split in ["test"]:
+            save_data(split, args.random_seed)
+    else:
+        save_data(args.split, args.random_seed)


### PR DESCRIPTION
Adding SuperGPQA to our benchmarks. 
Source: https://supergpqa.github.io/

Official code implementation / grading is not available. 
Reusing most of the code from `gpqa/prepare.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SuperGPQA multiple-choice dataset support with a data-prep CLI that outputs JSONL, shows progress, applies deterministic choice shuffling, and validates answers/options.
  * Introduced default evaluation settings: multiple-choice metrics, test split, and a 10-choice prompt configuration.
* **Documentation**
  * Added a "SuperGPQA" entry documenting benchmark details, splits, sources, and reproduction notes.
* **Chores**
  * Added license header and note that defaults can be overridden via command-line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->