### PR TITLE
Remove sharding docs

### DIFF
--- a/docs/releases/openmathreasoning/dataset.md
+++ b/docs/releases/openmathreasoning/dataset.md
@@ -51,34 +51,6 @@ pip install -U "huggingface_hub[cli]"
 hf download deepseek-ai/DeepSeek-R1 --local-dir DeepSeek-R1
 ```
 
-At the time of our experiments serving DeepSeek-R1 model with sglang was faster than with TensorRT-LLM, so
-we do not convert that model, but instead prepare a sharded checkpoint that is much faster to load.
-
-```python
-from nemo_skills.pipeline.cli import run_cmd, wrap_arguments
-
-cmd = (
-    "python3 nemo_skills/conversion/save_sharded_state.py "
-    "    --model-path=/hf_models/DeepSeek-R1 "
-    "    --output=/hf_models/DeepSeek-R1-tp16 "
-    "    --tensor-parallel-size=16 "
-    "    --context-len=8192 "
-    "    --trust-remote-code "
-    "    --nnodes 2 "
-    "    --dist-init-addr $SLURM_MASTER_NODE:20000 "
-    "    --node-rank $SLURM_PROCID "
-)
-
-run_cmd(
-    ctx=wrap_arguments(cmd),
-    cluster="slurm",
-    num_gpus=8,
-    num_nodes=2,
-    container="sglang",
-    log_dir="/hf_models/DeepSeek-R1-tp16",
-)
-```
-
 ## Problem generation pipeline
 
 [Problem generation pipeline](https://github.com/NVIDIA/NeMo-Skills/tree/main/recipes/openmathreasoning/pipeline/problem_generation.py)

--- a/docs/releases/openreasoning/dataset.md
+++ b/docs/releases/openreasoning/dataset.md
@@ -44,33 +44,6 @@ To download the model you can run the following from `/workspace` folder on Slur
 hf download deepseek-ai/DeepSeek-R1-0528 --local-dir DeepSeek-R1-0528
 ```
 
-The next step is optional, but we recommend sharding the checkpoint to avoid very long loading time.
-
-```python
-from nemo_skills.pipeline.cli import run_cmd, wrap_arguments
-
-cmd = (
-    "python3 nemo_skills/conversion/save_sharded_state.py "
-    "    --model-path=/workspace/DeepSeek-R1-0528 "
-    "    --output=/workspace/DeepSeek-R1-0528-tp16 "
-    "    --tensor-parallel-size=16 "
-    "    --context-len=8192 "
-    "    --trust-remote-code "
-    "    --nnodes 2 "
-    "    --dist-init-addr $SLURM_MASTER_NODE:20000 "
-    "    --node-rank $SLURM_PROCID "
-)
-
-run_cmd(
-    ctx=wrap_arguments(cmd),
-    cluster="slurm",
-    num_gpus=8,
-    num_nodes=2,
-    container="sglang",
-    log_dir="/workspace/DeepSeek-R1-0528-tp16",
-)
-```
-
 Finally, launch the data generation command. You can adjust `num_chunks` (how many jobs to launch in parallel) and
 `dependent_jobs` (how many jobs to launch sequentially in case there is a fixed timeout on cluster) to fit your setup.
 
@@ -93,11 +66,11 @@ generate(
     input_file="/workspace/open-reasoning/sdg/math-problems.jsonl",
     output_dir="/workspace/open-reasoning/sdg/solutions",
     expname="r1-0528-math-solutions",
-    model="/workspace/DeepSeek-R1-0528-tp16",
+    model="/workspace/DeepSeek-R1-0528",
     server_type="sglang",
     server_gpus=8,
     server_nodes=2,
-    server_args=f"--load-format sharded_state --context-length {tokens_to_generate + 2000}",
+    server_args=f"--ep-size 16 --context-length {tokens_to_generate + 2000}",
     num_random_seeds=num_solutions,
     # set these according to your cluster configuration
     # num_chunks=N,

--- a/recipes/opencodereasoning/configs/solution_sdg/r1.yaml
+++ b/recipes/opencodereasoning/configs/solution_sdg/r1.yaml
@@ -33,11 +33,11 @@ stages:
     # Arguments passed as kwargs to the pipeline function (e.g. generate())
     stage_kwargs:
       # assuming the model is in fp8 and running on H100 GPUs
-      model: /hf_models/DeepSeek-R1-tp16  # checkpoint is pre-sharded to tp16 for faster loading
+      model: /hf_models/DeepSeek-R1
       server_type: sglang
       server_gpus: 8
       server_nodes: 2
-      server_args: "--load-format sharded_state --context-length 32768"
+      server_args: "--ep-size 16 --context-length 32768"
       num_random_seeds: ${num_random_seeds_to_generate}
       num_chunks: 10  # since data is big, we are parallelizing it 10x (for each seed, so in total 80 jobs are scheduled)
       # if your slurm cluster has a mandatory job timeout, you can schedule multiple dependent jobs with

--- a/recipes/openmathreasoning/configs/solution_sdg/r1.yaml
+++ b/recipes/openmathreasoning/configs/solution_sdg/r1.yaml
@@ -50,11 +50,11 @@ stages:
     # Arguments passed as kwargs to the pipeline function (e.g. generate())
     stage_kwargs:
       # assuming the model is in fp8 and running on H100 GPUs
-      model: /hf_models/DeepSeek-R1-tp16  # checkpoint is pre-sharded to tp16 for faster loading
+      model: /hf_models/DeepSeek-R1
       server_type: sglang
       server_gpus: 8
       server_nodes: 2
-      server_args: "--load-format sharded_state --context-length 18384"
+      server_args: "--ep-size 16 --context-length 18384"
       num_random_seeds: ${num_random_seeds_to_generate}
       num_chunks: 10  # since data is big, we are parallelizing it 10x (for each seed, so in total 80 jobs are scheduled)
       # if your slurm cluster has a mandatory job timeout, you can schedule multiple dependent jobs with


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Removed obsolete sharded model conversion section.
  - Updated dataset guides to use the non-sharded DeepSeek-R1 path and revised server arguments to reflect the new setup.

- Chores
  - Updated solution generation configs to use the non-sharded DeepSeek-R1 path.
  - Switched server arguments to an explicit parallelism setting, aligning configs with the updated runtime.
  - Simplifies setup and removes reliance on sharded model artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->