### PR TITLE
Fix missing evaluator for SWE-bench

### DIFF
--- a/nemo_skills/inference/eval/swebench.py
+++ b/nemo_skills/inference/eval/swebench.py
@@ -166,6 +166,10 @@ class SweBenchGenerationTask(GenerationTask):
     def cleanup_litellm_cache(self):
         return
 
+    async def apply_evaluation_hook(self, data_point):
+        # currently evaluation is done directly after generation already
+        return data_point
+
     async def _execute_container_command(
         self, data_point, command, expected_file_pattern, mode, max_retries=3, timeout=100000
     ):


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/NVIDIA/NeMo-Skills/pull/825 where [this line](https://github.com/NVIDIA/NeMo-Skills/blob/main/nemo_skills/inference/generate.py#L537) was failing because `SweBenchGenerationTask` has no `evaluator` attribute.

Edit: the coderabbit summary is nonsense, I'm just overriding the existing `apply_evaluation_hook` function to be a no-op for SWE-bench because we don't use an evaluator here (yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced an asynchronous evaluation hook to the evaluation workflow, enabling a standardized post-generation processing step.
  * Current behavior remains unchanged; data passes through without modification.

* **Chores**
  * Prepared the evaluation pipeline for future extensibility with a non-disruptive hook point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->