### PR TITLE
add code timeout metrics

### DIFF
--- a/nemo_skills/inference/model/code_execution.py
+++ b/nemo_skills/inference/model/code_execution.py
@@ -126,6 +126,7 @@ class CodeExecutionWrapper:
         generation_time = 0
         code_execution_time = 0
         stopped_on_repetition = False
+        code_timeout = 0
         # adding plus one to make sure there is always some completion after the last requested code block
         try:
             for generation_index in range(effective_max_code_executions + 1):
@@ -185,6 +186,9 @@ class CodeExecutionWrapper:
                         remaining_code_executions,
                     )
 
+                    if "process_status" in execution_dict and execution_dict["process_status"] == "timeout":
+                        code_timeout += 1
+
                     if is_openai_format:
                         request["prompt"][-2]["content"] += code_output
                     else:
@@ -208,6 +212,7 @@ class CodeExecutionWrapper:
                 "generation_time": generation_time,
                 "code_execution_time": code_execution_time,
                 "stopped_on_repetition": stopped_on_repetition,
+                "code_timeout": code_timeout,
             }
         finally:
             # Clean up session if we created one and configured to do so

--- a/nemo_skills/inference/model/code_execution.py
+++ b/nemo_skills/inference/model/code_execution.py
@@ -126,7 +126,7 @@ class CodeExecutionWrapper:
         generation_time = 0
         code_execution_time = 0
         stopped_on_repetition = False
-        code_timeout = 0
+        num_code_timeouts = 0
         # adding plus one to make sure there is always some completion after the last requested code block
         try:
             for generation_index in range(effective_max_code_executions + 1):
@@ -187,7 +187,7 @@ class CodeExecutionWrapper:
                     )
 
                     if "process_status" in execution_dict and execution_dict["process_status"] == "timeout":
-                        code_timeout += 1
+                        num_code_timeouts += 1
 
                     if is_openai_format:
                         request["prompt"][-2]["content"] += code_output
@@ -212,7 +212,7 @@ class CodeExecutionWrapper:
                 "generation_time": generation_time,
                 "code_execution_time": code_execution_time,
                 "stopped_on_repetition": stopped_on_repetition,
-                "code_timeout": code_timeout,
+                "num_code_timeouts": num_code_timeouts,
             }
         finally:
             # Clean up session if we created one and configured to do so


### PR DESCRIPTION
https://github.com/NVIDIA/NeMo-Skills/issues/834


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses now include a code_timeout field reporting how many executed code blocks timed out during a run.
  * Timeout occurrences are aggregated per request and returned alongside other execution details.
  * No other behavior changes to execution results; all existing fields remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->