### PR TITLE
Fix sandbox container build for arm64

### DIFF
--- a/dockerfiles/Dockerfile.sandbox
+++ b/dockerfiles/Dockerfile.sandbox
@@ -27,7 +27,8 @@ RUN apt-get update && \
     tar -xjf /tmp/pypy.tar.bz2 -C /opt/ && \
     ln -s /opt/pypy3.10-v7.3.17-$PYPY_ARCH/bin/pypy3 /usr/bin/pypy3 && \
     /usr/bin/pypy3 -m ensurepip && \
-    rm /tmp/pypy.tar.bz2
+    rm /tmp/pypy.tar.bz2 && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # Install the DMOJ judge-server using pip (OJBench eval requirement)
 RUN pip install git+https://github.com/DMOJ/judge-server.git@11bf2cd03df83f0df5970a08e98b4cec2dfaecd5

--- a/dockerfiles/Dockerfile.sandbox
+++ b/dockerfiles/Dockerfile.sandbox
@@ -16,7 +16,6 @@
 FROM tiangolo/uwsgi-nginx-flask:python3.10
 
 # Install dependencies required for Lean 4, pypy3, and other tools
-ARG TARGETARCH
 RUN apt-get update && \
     apt-get install -y curl git net-tools bzip2 build-essential libseccomp-dev && \
     case "$TARGETARCH" in \

--- a/dockerfiles/Dockerfile.sandbox
+++ b/dockerfiles/Dockerfile.sandbox
@@ -19,10 +19,12 @@ FROM tiangolo/uwsgi-nginx-flask:python3.10
 ARG TARGETARCH
 RUN apt-get update && \
     apt-get install -y curl git net-tools bzip2 build-essential libseccomp-dev && \
-    case "$TARGETARCH" in \
+    ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    case "$ARCH" in \
         amd64) PYPY_ARCH=linux64 ;; \
         arm64|aarch64) PYPY_ARCH=aarch64 ;; \
-    *) echo "Unsupported TARGETARCH '$TARGETARCH'" >&2; exit 1 ;; \
+        x86_64) PYPY_ARCH=linux64 ;; \
+    *) echo "Unsupported TARGETARCH '$ARCH'" >&2; exit 1 ;; \
     esac && \
     curl -L https://downloads.python.org/pypy/pypy3.10-v7.3.17-$PYPY_ARCH.tar.bz2 -o /tmp/pypy.tar.bz2 && \
     tar -xjf /tmp/pypy.tar.bz2 -C /opt/ && \

--- a/dockerfiles/Dockerfile.sandbox
+++ b/dockerfiles/Dockerfile.sandbox
@@ -19,11 +19,10 @@ FROM tiangolo/uwsgi-nginx-flask:python3.10
 ARG TARGETARCH
 RUN apt-get update && \
     apt-get install -y curl git net-tools bzip2 build-essential libseccomp-dev && \
-    ARCH="${TARGETARCH:-amd64}" && \
-    case "$ARCH" in \
+    case "$TARGETARCH" in \
         amd64) PYPY_ARCH=linux64 ;; \
         arm64|aarch64) PYPY_ARCH=aarch64 ;; \
-    *) echo "Unsupported TARGETARCH '$ARCH'" >&2; exit 1 ;; \
+    *) echo "Unsupported TARGETARCH '$TARGETARCH'" >&2; exit 1 ;; \
     esac && \
     curl -L https://downloads.python.org/pypy/pypy3.10-v7.3.17-$PYPY_ARCH.tar.bz2 -o /tmp/pypy.tar.bz2 && \
     tar -xjf /tmp/pypy.tar.bz2 -C /opt/ && \

--- a/dockerfiles/Dockerfile.sandbox
+++ b/dockerfiles/Dockerfile.sandbox
@@ -19,7 +19,12 @@ FROM tiangolo/uwsgi-nginx-flask:python3.10
 ARG TARGETARCH
 RUN apt-get update && \
     apt-get install -y curl git net-tools bzip2 build-essential libseccomp-dev && \
-    PYPY_ARCH=$( [ "$TARGETARCH" = "amd64" ] && echo linux64 || echo aarch64 ) && \
+    ARCH="${TARGETARCH:-amd64}" && \
+    case "$ARCH" in \
+        amd64) PYPY_ARCH=linux64 ;; \
+        arm64|aarch64) PYPY_ARCH=aarch64 ;; \
+    *) echo "Unsupported TARGETARCH '$ARCH'" >&2; exit 1 ;; \
+    esac && \
     curl -L https://downloads.python.org/pypy/pypy3.10-v7.3.17-$PYPY_ARCH.tar.bz2 -o /tmp/pypy.tar.bz2 && \
     tar -xjf /tmp/pypy.tar.bz2 -C /opt/ && \
     ln -s /opt/pypy3.10-v7.3.17-$PYPY_ARCH/bin/pypy3 /usr/bin/pypy3 && \

--- a/dockerfiles/Dockerfile.sandbox
+++ b/dockerfiles/Dockerfile.sandbox
@@ -16,6 +16,7 @@
 FROM tiangolo/uwsgi-nginx-flask:python3.10
 
 # Install dependencies required for Lean 4, pypy3, and other tools
+ARG TARGETARCH
 RUN apt-get update && \
     apt-get install -y curl git net-tools bzip2 build-essential libseccomp-dev && \
     case "$TARGETARCH" in \

--- a/dockerfiles/Dockerfile.sandbox
+++ b/dockerfiles/Dockerfile.sandbox
@@ -16,11 +16,13 @@
 FROM tiangolo/uwsgi-nginx-flask:python3.10
 
 # Install dependencies required for Lean 4, pypy3, and other tools
+ARG TARGETARCH
 RUN apt-get update && \
     apt-get install -y curl git net-tools bzip2 build-essential libseccomp-dev && \
-    curl -L https://downloads.python.org/pypy/pypy3.10-v7.3.17-linux64.tar.bz2 -o /tmp/pypy.tar.bz2 && \
+    PYPY_ARCH=$( [ "$TARGETARCH" = "amd64" ] && echo linux64 || echo aarch64 ) && \
+    curl -L https://downloads.python.org/pypy/pypy3.10-v7.3.17-$PYPY_ARCH.tar.bz2 -o /tmp/pypy.tar.bz2 && \
     tar -xjf /tmp/pypy.tar.bz2 -C /opt/ && \
-    ln -s /opt/pypy3.10-v7.3.17-linux64/bin/pypy3 /usr/bin/pypy3 && \
+    ln -s /opt/pypy3.10-v7.3.17-$PYPY_ARCH/bin/pypy3 /usr/bin/pypy3 && \
     /usr/bin/pypy3 -m ensurepip && \
     rm /tmp/pypy.tar.bz2
 


### PR DESCRIPTION
This PR fixes the issue for #876 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-architecture sandbox images (x86_64 and ARM64) with automatic selection and setup of the appropriate PyPy runtime.

* **Chores**
  * Add build argument to enable architecture-aware builds and explicit handling for unsupported architectures.
  * Update runtime symlinking and remove temporary artifacts and package cache to reduce image size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->