### PR TITLE
Parallel thinking fixes

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -378,6 +378,7 @@ class GenerationTask:
                 orig_prompt_filler=self.fill_prompt,  # Needed for prompt fillling
                 parallel_thinking=self.cfg.parallel_thinking,
                 main_config=self.cfg,
+                tokenizer=self.tokenizer,
                 inference_override_config=inference_override_config,
             )
 

--- a/nemo_skills/inference/model/__init__.py
+++ b/nemo_skills/inference/model/__init__.py
@@ -72,6 +72,7 @@ def get_parallel_thinking_model(
     model,
     orig_prompt_filler,
     parallel_thinking: ParallelThinkingConfig = None,
+    tokenizer=None,
     main_config=None,
     inference_override_config=None,
 ):
@@ -89,7 +90,9 @@ def get_parallel_thinking_model(
 
     parallel_thinking_config = ParallelThinkingConfig(**filtered_config)
 
-    return ParallelThinkingTask(model=model, orig_prompt_filler=orig_prompt_filler, cfg=parallel_thinking_config)
+    return ParallelThinkingTask(
+        model=model, tokenizer=tokenizer, orig_prompt_filler=orig_prompt_filler, cfg=parallel_thinking_config
+    )
 
 
 def get_tool_calling_model(

--- a/nemo_skills/inference/model/parallel_thinking.py
+++ b/nemo_skills/inference/model/parallel_thinking.py
@@ -217,19 +217,16 @@ class ParallelThinkingTask:
             chat_template_kwargs=self.cfg.chat_template_kwargs,
         )
 
-        LOG.info(kwargs)
         for duplicate_key in ["temperature", "tokens_to_generate", "prompt"]:
             if duplicate_key in kwargs:
                 del kwargs[duplicate_key]
 
-        LOG.info("Post-deletion kwargs: ", kwargs)
-
         return await self.model.generate_async(
-            **kwargs,
             prompt=parallel_thinking_prompt,
             # Overriding the tokens_to_generate, temperature
             tokens_to_generate=self.cfg.tokens_to_generate,
             temperature=self.cfg.temperature,
+            **kwargs,
         )
 
     def _extract_selected_solution(self, generation: str, max_idx: int) -> Optional[int]:

--- a/nemo_skills/inference/model/parallel_thinking.py
+++ b/nemo_skills/inference/model/parallel_thinking.py
@@ -217,6 +217,8 @@ class ParallelThinkingTask:
             chat_template_kwargs=self.cfg.chat_template_kwargs,
         )
 
+        LOG.info(kwargs)
+
         return await self.model.generate_async(
             **kwargs,
             prompt=parallel_thinking_prompt,
@@ -362,7 +364,7 @@ class ParallelThinkingTask:
 
         # Step 2: Run GenSelect/GenSynthesis
         if self.cfg.mode == "genselect":
-            output_dict = await self._run_genselect(prompt, solutions, local_random)
+            output_dict = await self._run_genselect(prompt, solutions, local_random, **kwargs)
             parallel_thinking_result = output_dict["parallel_thinking_result"]
             result["genselect_comparison"] = parallel_thinking_result["generation"]
             result["genselect_selection_successful"] = parallel_thinking_result["selection_successful"]

--- a/nemo_skills/inference/model/parallel_thinking.py
+++ b/nemo_skills/inference/model/parallel_thinking.py
@@ -55,6 +55,7 @@ class ParallelThinkingConfig:
     use_completions_api: bool = False
     tokenizer: str | None = None
     chat_template_kwargs: dict | None = None  # extra parameters to pass to the tokenizer's apply_chat_template method
+    start_assistant_response_key: str | None = None  # whether to start assistant response with this key
 
     # GenSelect vs GenSynthesis
     mode: str | None = None  # genselect or gensynthesis
@@ -84,7 +85,7 @@ class ParallelThinkingTask:
         self.cfg = cfg
 
         if self.cfg.use_completions_api:
-            tokenizer = self.cfg.tokenizer or self.cfg.server["model"]
+            tokenizer = self.cfg.tokenizer
         else:
             tokenizer = None
 
@@ -210,7 +211,11 @@ class ParallelThinkingTask:
             "max_idx": max_idx,
         }
 
-        parallel_thinking_prompt = self.parallel_thinking_prompt.fill(parallel_thinking_input)
+        parallel_thinking_prompt = self.parallel_thinking_prompt.fill(
+            parallel_thinking_input,
+            start_assistant_response_key=self.cfg.start_assistant_response_key,
+            chat_template_kwargs=self.cfg.chat_template_kwargs,
+        )
 
         return await self.model.generate_async(
             **kwargs,

--- a/nemo_skills/inference/model/parallel_thinking.py
+++ b/nemo_skills/inference/model/parallel_thinking.py
@@ -215,8 +215,7 @@ class ParallelThinkingTask:
         )
 
         for duplicate_key in ["temperature", "tokens_to_generate", "prompt"]:
-            if duplicate_key in kwargs:
-                del kwargs[duplicate_key]
+            kwargs.pop(duplicate_key, None)
 
         return await self.model.generate_async(
             prompt=parallel_thinking_prompt,

--- a/nemo_skills/inference/model/parallel_thinking.py
+++ b/nemo_skills/inference/model/parallel_thinking.py
@@ -84,7 +84,7 @@ class ParallelThinkingTask:
         self.cfg = cfg
 
         if self.cfg.use_completions_api:
-            tokenizer = self.cfg.tokenizer or self.model.model_name_or_path
+            tokenizer = self.cfg.tokenizer or self.cfg.server["model"]
         else:
             tokenizer = None
 
@@ -189,9 +189,6 @@ class ParallelThinkingTask:
                     )
 
         return prompt_to_solutions_dict
-
-    def _format_solutions_for_parallel_thinking(self, solutions: List[Dict]) -> str:
-        """Format solutions for parallel thinking prompt."""
 
     async def _generate_parallel_thinking_contraction(
         self, prompt: Union[str, List], solutions: List[Dict], **kwargs
@@ -349,6 +346,7 @@ class ParallelThinkingTask:
         if not solutions:
             return {
                 self.cfg.solution_key: "",
+                "generation": "",  # Required by inference/generate.py
                 "solution_list": [],
                 f"{self.cfg.mode}_comparison": "",
                 f"{self.cfg.mode}_num_generated_tokens": 0,

--- a/nemo_skills/inference/model/parallel_thinking.py
+++ b/nemo_skills/inference/model/parallel_thinking.py
@@ -218,6 +218,11 @@ class ParallelThinkingTask:
         )
 
         LOG.info(kwargs)
+        for duplicate_key in ["temperature", "tokens_to_generate", "prompt"]:
+            if duplicate_key in kwargs:
+                del kwargs[duplicate_key]
+
+        LOG.info("Post-deletion kwargs: ", kwargs)
 
         return await self.model.generate_async(
             **kwargs,

--- a/nemo_skills/inference/model/parallel_thinking.py
+++ b/nemo_skills/inference/model/parallel_thinking.py
@@ -79,24 +79,21 @@ class ParallelThinkingTask:
     to choose the best one or synthesize a new solution.
     """
 
-    def __init__(self, model: BaseModel, orig_prompt_filler, cfg: ParallelThinkingConfig):
+    def __init__(self, model: BaseModel, tokenizer: str | None, orig_prompt_filler, cfg: ParallelThinkingConfig):
         self.model = model
         self.orig_prompt_filler = orig_prompt_filler
         self.cfg = cfg
 
-        if self.cfg.use_completions_api:
-            tokenizer = self.cfg.tokenizer
-        else:
-            tokenizer = None
+        self.tokenizer = tokenizer
 
         # Load GenSelect/GenSynthesis prompt
         if self.cfg.mode == "genselect":
             self.parallel_thinking_prompt = get_prompt(
-                prompt_config=self.cfg.genselect.prompt_config, tokenizer=tokenizer
+                prompt_config=self.cfg.genselect.prompt_config, tokenizer=self.tokenizer
             )
         elif self.cfg.mode == "gensynthesis":
             self.parallel_thinking_prompt = get_prompt(
-                prompt_config=self.cfg.gensynthesis.prompt_config, tokenizer=tokenizer
+                prompt_config=self.cfg.gensynthesis.prompt_config, tokenizer=self.tokenizer
             )
         else:
             raise ValueError(f"Invalid parallel thinking mode: {self.cfg.mode}")


### PR DESCRIPTION
There were a few arguments not being passed during genselect generation which are particularly necessary for tool usage during genselect. Testing with gpt-oss distilled models revealed these shortcomings. This PR fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a config option to set the assistant response key and tokenizer-awareness in parallel-thinking flows.

* **Bug Fixes**
  * Ensured empty-result branches include a "generation" field to satisfy downstream expectations.
  * Forwarded generation-related options through all execution paths to avoid dropped settings.

* **Refactor**
  * Cleaned up generation-parameter handling by removing conflicting keys before model calls and preserving generation fields across branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->