### PR TITLE
Add responses api type

### DIFF
--- a/docs/basics/inference.md
+++ b/docs/basics/inference.md
@@ -34,12 +34,13 @@ Click on :material-plus-circle: symbols in the snippet below to learn more detai
     ```python
     from nemo_skills.inference.model import get_model
     from nemo_skills.prompt.utils import get_prompt
+    import asyncio
 
     llm = get_model(model="meta-llama/Llama-3.1-8B-Instruct", server_type="vllm")  # localhost by default
     prompt_obj = get_prompt('generic/default') # (1)!
     prompt = prompt_obj.fill({'question': "What's 2 + 2?"})
     print(prompt) # (2)!
-    output = llm.generate_sync(prompt=prompt)
+    output = asyncio.run(llm.generate_async(prompt=prompt))
     print(output["generation"]) # (3)!
     ```
 
@@ -69,6 +70,7 @@ Click on :material-plus-circle: symbols in the snippet below to learn more detai
     ```python
     from nemo_skills.inference.model import get_model
     from nemo_skills.prompt.utils import get_prompt
+    import asyncio
 
     llm = get_model( # (1)!
         server_type="openai",  # NIM models are using OpenAI API
@@ -80,7 +82,7 @@ Click on :material-plus-circle: symbols in the snippet below to learn more detai
     prompt = prompt_obj.fill({'question': "What's 2 + 2?"})
 
     print(prompt) # (3)!
-    output = llm.generate_sync(prompt=prompt)
+    output = asyncio.run(llm.generate_async(prompt=prompt))
     print(output["generation"]) # (4)!
     ```
 

--- a/docs/basics/prompt-format.md
+++ b/docs/basics/prompt-format.md
@@ -108,7 +108,7 @@ which outputs
 
 #### Example 2 - Prompt formatted as a string
 
-If you want to use completions API, you can set `++use_completions_api=True`. This will use model's tokenizer to format
+If you want to use completions API, you can set `++inference.completion_type=text`. This will use model's tokenizer to format
 messages as a string (you can specify a custom tokenizer with `++tokenizer=...` argument).
 
 Here is an example of the input to completions api

--- a/docs/pipelines/generation.md
+++ b/docs/pipelines/generation.md
@@ -366,6 +366,7 @@ We also support automatic trimming of generation budget or context when using vl
 
     from nemo_skills.prompt.utils import get_prompt
     from nemo_skills.inference.model import get_model
+    import asyncio
 
     prompt = get_prompt(
         "generic/math",
@@ -382,7 +383,7 @@ We also support automatic trimming of generation budget or context when using vl
 
     # The 1M generation budget is well beyond the 40960 context window size of Qwen/Qwen3-0.6B
     # We will automatically reduce the generation budget to fit in the context window
-    output_dict = llm.generate_sync(input_prompt, tokens_to_generate=1_000_000)
+    output_dict = asyncio.run(llm.generate_async(input_prompt, tokens_to_generate=1_000_000))
     ```
     To specify this setting for the generation or eval pipeline use
     ```bash
@@ -395,6 +396,7 @@ We also support automatic trimming of generation budget or context when using vl
     ```python hl_lines="15-16"
     from nemo_skills.prompt.utils import get_prompt
     from nemo_skills.inference.model import get_model
+    import asyncio
 
     prompt = get_prompt(
         "generic/math",
@@ -413,7 +415,7 @@ We also support automatic trimming of generation budget or context when using vl
 
     # We will automatically reduce the prompt from the start to fit in the context window
     # Note that this requires the `tokens_to_generate` budget to be specified
-    output_dict = llm.generate_sync(prompt=input_prompt, tokens_to_generate=1024)
+    output_dict = asyncio.run(llm.generate_async(prompt=input_prompt, tokens_to_generate=1024))
     ```
     To specify this setting for the generation or eval pipeline use
     ```bash
@@ -427,6 +429,7 @@ We also support automatic trimming of generation budget or context when using vl
 
     from nemo_skills.prompt.utils import get_prompt
     from nemo_skills.inference.model import get_model
+    import asyncio
 
     prompt = get_prompt(
         "generic/math",
@@ -445,7 +448,7 @@ We also support automatic trimming of generation budget or context when using vl
 
     # We will automatically reduce the prompt from the end to fit in the context window
     # Note that this requires the `tokens_to_generate` budget to be specified
-    output_dict = llm.generate_sync(prompt=input_prompt, tokens_to_generate=1024)
+    output_dict = asyncio.run(llm.generate_async(prompt=input_prompt, tokens_to_generate=1024))
     ```
     To specify this setting for the generation or eval pipeline use
     ```bash

--- a/docs/pipelines/generation.md
+++ b/docs/pipelines/generation.md
@@ -126,7 +126,7 @@ ns generate \
        --input_file=/nemo_run/code/nemo_skills/dataset/math/train.jsonl \
        ++prompt_config=generic/math-base \
        ++examples_type=math_text_detailed \
-       ++use_completions_api=True \
+       ++inference.completion_type=text \
        ++tokenizer=meta-llama/Llama-3.1-405B \
        ++stop_phrase='\\n\\n\\n\\n\\n\\n'
 ```

--- a/docs/releases/openmathinstruct2/dataset.md
+++ b/docs/releases/openmathinstruct2/dataset.md
@@ -33,7 +33,7 @@ ns generate \
     --input_file=/nemo_run/code/nemo_skills/dataset/math/train.jsonl \
     ++prompt_config=generic/math-base \
     ++examples_type=math_text_detailed \
-    ++use_completions_api=True \
+    ++inference.completion_type=text \
     ++tokenizer=meta-llama/Llama-3.1-405B \
     ++stop_phrase='\\n\\n\\n\\n\\n\\n'
 ```
@@ -53,7 +53,7 @@ ns generate \
     --input_file=/nemo_run/code/nemo_skills/dataset/gsm8k/train.jsonl \
     ++prompt_config=generic/math-base \
     ++examples_type=gsm8k_text_detailed \
-    ++use_completions_api=True \
+    ++inference.completion_type=text \
     ++tokenizer=meta-llama/Llama-3.1-405B \
     ++stop_phrase='\\n\\n\\n\\n\\n\\n'
 ```
@@ -76,7 +76,7 @@ ns generate \
     ++prompt_config=generic/problem-augmentation \
     ++examples_type=math_problem_augmentation \
     ++generation_key=problem \
-    ++use_completions_api=True \
+    ++inference.completion_type=text \
     ++tokenizer=meta-llama/Llama-3.1-405B \
     ++stop_phrase='\\n\\n\\n\\n\\n\\n'
 ```
@@ -96,7 +96,7 @@ ns generate \
     ++prompt_config=generic/problem-augmentation-similar \
     ++examples_type=gsm8k_problem_augmentation \
     ++generation_key=problem \
-    ++use_completions_api=True \
+    ++inference.completion_type=text \
     ++tokenizer=meta-llama/Llama-3.1-405B \
     ++stop_phrase='\\n\\n\\n\\n\\n\\n'
 ```
@@ -128,7 +128,7 @@ for i in range(80):
         ctx=wrap_arguments(
             f"++prompt_config=generic/math-base "
             f"++examples_type=math_text_detailed "
-            f"++use_completions_api=True "
+            f"++inference.completion_type=text "
             f"++tokenizer=meta-llama/Llama-3.1-405B "
             f"++stop_phrase='\n\n\n\n\n\n' "
         ),
@@ -155,7 +155,7 @@ for i in range(10):
         ctx=wrap_arguments(
             f"++prompt_config=generic/math-base "
             f"++examples_type=gsm8k_text_detailed "
-            f"++use_completions_api=True "
+            f"++inference.completion_type=text "
             f"++tokenizer=meta-llama/Llama-3.1-405B "
             f"++stop_phrase='\n\n\n\n\n\n' "
         ),

--- a/docs/releases/openmathreasoning/evaluation.md
+++ b/docs/releases/openmathreasoning/evaluation.md
@@ -104,7 +104,7 @@ ns eval \
     --with_sandbox \
     ++code_tags=openmath \
     ++prompt_config=openmath/tir \
-    ++use_completions_api=True \
+    ++inference.completion_type=text \
     ++inference.tokens_to_generate=32768 \
     ++inference.temperature=0.6 \
     ++code_execution=true \
@@ -127,7 +127,7 @@ ns eval \
     --with_sandbox \
     ++code_tags=openmath \
     ++prompt_config=generic/math \
-    ++use_completions_api=True \
+    ++inference.completion_type=text \
     ++inference.tokens_to_generate=32768 \
     ++inference.temperature=0.6 \
     ++code_execution=true

--- a/docs/tutorials/posts/gpt-oss-python.md
+++ b/docs/tutorials/posts/gpt-oss-python.md
@@ -68,7 +68,7 @@ eval(
         # we currently implement native Python code tool through text completions API
         # as we found alternative implementations to have issues.
         # We will switch to the official responses API when the support is added
-        "++use_completions_api=true "
+        "++inference.completion_type=text "
         "++code_tags=gpt-oss "
         # gpt-oss generates a lot of code, so need to set max_code_executions high!
         # you can also add ++server.code_execution.code_execution_timeout=120 to match
@@ -219,7 +219,7 @@ generate(
         # we currently implement native Python code tool through text completions API
         # as we found alternative implementations to have issues.
         # We will switch to the official responses API when the support is added
-        "++use_completions_api=true "
+        "++inference.completion_type=text "
         "++code_tags=gpt-oss "
         # gpt-oss generates a lot of code, so need to set max_code_executions high!
         # you can also add ++server.code_execution.code_execution_timeout=120 to match

--- a/nemo_skills/dataset/ruler/prepare.py
+++ b/nemo_skills/dataset/ruler/prepare.py
@@ -31,7 +31,7 @@ GENERATION_ARGS = (
     "++inference.tokens_to_generate={tokens_to_generate} "
     # ruler is adding prefix for assistant response, so it has to go through completions api
     "++start_assistant_response_key=generation "
-    "++use_completions_api=True "
+    "++inference.completion_type=text "
 )
 """
 TOKENS_TO_GENERATE = {"niah": 128, "vt": 30, "cwe": 120, "fwe": 50, "qa": 32}

--- a/nemo_skills/inference/chat_interface/chat_service.py
+++ b/nemo_skills/inference/chat_interface/chat_service.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Iterator
 
@@ -56,13 +57,15 @@ class ChatService:
             raise RuntimeError(f"Error preparing prompt: {e}") from e
 
         extra_params = prompt_obj.get_code_execution_args() if use_code else {}
-        stream_iter_list = llm.generate_sync(
-            prompt=prompt_filled,
-            tokens_to_generate=int(tokens_to_generate),
-            temperature=float(temperature),
-            stream=True,
-            stop_phrases=prompt_obj.stop_phrases or [],
-            **extra_params,
+        stream_iter_list = asyncio.run(
+            llm.generate_async(
+                prompt=prompt_filled,
+                tokens_to_generate=int(tokens_to_generate),
+                temperature=float(temperature),
+                stream=True,
+                stop_phrases=prompt_obj.stop_phrases or [],
+                **extra_params,
+            )
         )
         if not stream_iter_list:
             raise RuntimeError("LLM did not return a stream iterator.")

--- a/nemo_skills/inference/eval/bfcl.py
+++ b/nemo_skills/inference/eval/bfcl.py
@@ -31,6 +31,7 @@ from nemo_skills.inference.eval.bfcl_utils import (
 )
 from nemo_skills.inference.generate import GenerateSolutionsConfig, GenerationTask, InferenceConfig
 from nemo_skills.inference.model import server_params
+from nemo_skills.inference.model.base import CompletionType
 from nemo_skills.inference.model.utils import is_context_window_exceeded_error
 from nemo_skills.utils import get_help_message, get_logger_name, nested_dataclass, setup_logging
 
@@ -117,10 +118,13 @@ class ClientMessageParser:
 
     def construct_input_dict(self, messages: list[dict], tools: list[dict]):
         fmted_prompt = self.message_formatter(messages, tools=tools)
+        kwargs = asdict(self.cfg.inference)
+        # Replace the completion type with text
+        kwargs["completion_type"] = CompletionType.text
         return {
             "prompt": fmted_prompt,
             "include_response": True,
-            **asdict(self.cfg.inference),
+            **kwargs,
         }
 
     def parse_output_dict(self, output_dict: dict):

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -623,10 +623,28 @@ class GenerationTask:
 
         # Litellm async logging worker sometimes does not stop. We force terminate the async loop.
         # TODO: Remove this once LiteLLM fixes it.
+        LOG.info("Starting to cancel tasks")
+        sys.stdout.flush()
+        sys.stderr.flush()
+        LOG.info("Lets go!")
         while True:
             tasks_to_cancel = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
             if len(tasks_to_cancel) == 0:
                 break
+            LOG.info(
+                "Tasks to cancel: %s",
+                [
+                    {
+                        "task": str(task),
+                        "done": task.done(),
+                        "cancelled": task.cancelled(),
+                        "coro": repr(task.get_coro()),
+                    }
+                    for task in tasks_to_cancel
+                ],
+            )
+            sys.stdout.flush()
+            sys.stderr.flush()
             for task in tasks_to_cancel:
                 task.cancel()
             await asyncio.gather(*tasks_to_cancel, return_exceptions=True)

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -623,7 +623,8 @@ class GenerationTask:
 
         # Litellm async logging worker sometimes does not stop. We force stop them.
         # TODO: Remove this once LiteLLM fixes it.
-        await _cancel_other_async_tasks()
+        loop = asyncio.get_running_loop()
+        loop.stop()
 
     def restore_async_order(self):
         # After we are done, need to restore the order and resave without position ids
@@ -719,14 +720,3 @@ if __name__ == "__main__":
     else:
         setup_logging()
         generate()
-
-
-async def _cancel_other_async_tasks():
-    tasks_to_cancel = []
-    for t in asyncio.all_tasks():
-        if t is asyncio.current_task():
-            continue
-        t.cancel()
-        tasks_to_cancel.append(t)
-    if tasks_to_cancel:
-        await asyncio.gather(*tasks_to_cancel, return_exceptions=True)

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -610,7 +610,8 @@ class GenerationTask:
             # Create tasks for all remaining data points
             tasks = []
             for data_point in remaining_data_points:
-                task = asyncio.create_task(self._process_single_datapoint_with_semaphore(data_point, data, fout, pbar))
+                # task = asyncio.create_task(self._process_single_datapoint_with_semaphore(data_point, data, fout, pbar))
+                task = self._process_single_datapoint_with_semaphore(data_point, data, fout, pbar)
                 tasks.append(task)
 
             # Wait for all tasks to complete
@@ -623,7 +624,7 @@ class GenerationTask:
 
         # Litellm async logging worker sometimes does not stop. We force terminate the async loop.
         # TODO: Remove this once LiteLLM fixes it.
-        raise TerminateAsyncLoop()
+        # raise TerminateAsyncLoop()
 
     def restore_async_order(self):
         # After we are done, need to restore the order and resave without position ids

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -627,7 +627,7 @@ class GenerationTask:
         LOG.info("Async session closed, is it working?")
         from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 
-        GLOBAL_LOGGING_WORKER.stop()
+        await GLOBAL_LOGGING_WORKER.stop()
         LOG.info("Is logger stopped?")
 
     def restore_async_order(self):

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -621,7 +621,7 @@ class GenerationTask:
 
         self.restore_async_order()
 
-        # Litellm async logging worker sometimes does not stop. We force terminate the async loop.
+        # Litellm async logging worker sometimes does not stop. We force cancel its tasks.
         # TODO: Remove this once LiteLLM fixes it.
         while True:
             tasks = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -624,7 +624,7 @@ class GenerationTask:
         # Litellm async logging worker sometimes does not stop. We force stop them.
         # TODO: Remove this once LiteLLM fixes it.
         LOG.info("Cancelling other async tasks")
-        await _cancel_other_async_tasks()
+        # await _cancel_other_async_tasks()
 
     def restore_async_order(self):
         # After we are done, need to restore the order and resave without position ids

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -625,6 +625,10 @@ class GenerationTask:
             LOG.warning("Pending task at shutdown: %r | coro=%r", t, getattr(t, "get_coro", lambda: None)())
         await litellm.aclient_session.aclose()
         LOG.info("Async session closed, is it working?")
+        from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+
+        GLOBAL_LOGGING_WORKER.stop()
+        LOG.info("Is logger stopped?")
 
     def restore_async_order(self):
         # After we are done, need to restore the order and resave without position ids

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -623,7 +623,7 @@ class GenerationTask:
 
         # Litellm async logging worker sometimes does not stop. We force stop them.
         # TODO: Remove this once LiteLLM fixes it.
-        await _cancel_logging_tasks()
+        await _cancel_other_async_tasks()
 
     def restore_async_order(self):
         # After we are done, need to restore the order and resave without position ids
@@ -721,14 +721,12 @@ if __name__ == "__main__":
         generate()
 
 
-async def _cancel_logging_tasks():
+async def _cancel_other_async_tasks():
     tasks_to_cancel = []
     for t in asyncio.all_tasks():
         if t is asyncio.current_task():
             continue
-        coro = t.get_coro()
-        if "Logging" in str(coro):
-            t.cancel()
-            tasks_to_cancel.append(t)
+        t.cancel()
+        tasks_to_cancel.append(t)
     if tasks_to_cancel:
         await asyncio.gather(*tasks_to_cancel, return_exceptions=True)

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -624,7 +624,7 @@ class GenerationTask:
         # Litellm async logging worker sometimes does not stop. We force stop them.
         # TODO: Remove this once LiteLLM fixes it.
         LOG.info("Cancelling other async tasks")
-        # await _cancel_other_async_tasks()
+        await _cancel_other_async_tasks()
 
     def restore_async_order(self):
         # After we are done, need to restore the order and resave without position ids
@@ -748,6 +748,8 @@ async def _cancel_other_async_tasks():
                 f"location={location}, "
                 f"exception={t.exception() if t.done() else None}"
             )
+        sys.stdout.flush()
+        sys.stderr.flush()
         if not tasks_to_cancel:
             return
         for t in tasks_to_cancel:

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -627,7 +627,7 @@ class GenerationTask:
         LOG.info("Async session closed, is it working?")
         from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 
-        await GLOBAL_LOGGING_WORKER.stop()
+        await GLOBAL_LOGGING_WORKER.clear_queue()
         LOG.info("Is logger stopped?")
 
     def restore_async_order(self):

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -623,6 +623,8 @@ class GenerationTask:
         pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
         for t in pending:
             LOG.warning("Pending task at shutdown: %r | coro=%r", t, getattr(t, "get_coro", lambda: None)())
+        await litellm.aclient_session.aclose()
+        LOG.info("Async session closed, is it working?")
 
     def restore_async_order(self):
         # After we are done, need to restore the order and resave without position ids

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -629,7 +629,7 @@ class GenerationTask:
                 break
             for task in tasks_to_cancel:
                 task.cancel()
-            await asyncio.gather(*tasks_to_cancel)
+            await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
 
     def restore_async_order(self):
         # After we are done, need to restore the order and resave without position ids

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -714,16 +714,10 @@ HELP_MESSAGE = get_help_message(
 )
 
 
-if __name__ == "__main__":
-    if "--help" in sys.argv or "-h" in sys.argv:
-        print(HELP_MESSAGE)
-    else:
-        setup_logging()
-        generate()
-
-
 async def _cancel_other_async_tasks():
-    LOG.info("Cancelling other async tasks")
+    LOG.info("INSIDE _cancel_other_async_tasks function - START")
+    sys.stdout.flush()
+    sys.stderr.flush()
     attempt = 0
     while True:
         tasks_to_cancel = []
@@ -769,3 +763,11 @@ async def _cancel_other_async_tasks():
                 f"tasks still running out of {len(tasks_to_cancel)} total"
             )
         await asyncio.sleep(0.1)
+
+
+if __name__ == "__main__":
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print(HELP_MESSAGE)
+    else:
+        setup_logging()
+        generate()

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -620,6 +620,9 @@ class GenerationTask:
             pbar.close()
 
         self.restore_async_order()
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        for t in pending:
+            LOG.warning("Pending task at shutdown: %r | coro=%r", t, getattr(t, "get_coro", lambda: None)())
 
     def restore_async_order(self):
         # After we are done, need to restore the order and resave without position ids

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -623,6 +623,7 @@ class GenerationTask:
 
         # Litellm async logging worker sometimes does not stop. We force stop them.
         # TODO: Remove this once LiteLLM fixes it.
+        LOG.info("Cancelling other async tasks")
         await _cancel_other_async_tasks()
 
     def restore_async_order(self):

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -40,6 +40,7 @@ from nemo_skills.inference.model import (
     get_tool_calling_model,
     server_params,
 )
+from nemo_skills.inference.model.base import CompletionType
 from nemo_skills.prompt.utils import get_prompt, get_token_count
 from nemo_skills.utils import (
     chunk_data,
@@ -56,6 +57,13 @@ LOG = logging.getLogger(get_logger_name(__file__))
 
 @nested_dataclass(kw_only=True)
 class InferenceConfig:
+    # Type of completion to generate when using OpenAI
+    # "chat": used by default
+    # "text": for text completions, in this case we will
+    # take the tokenizer from the model and apply it to the prompt before sending it.
+    # You can override tokenizer with tokenizer parameter.
+    # "responses": for responses api format.
+    completion_type: CompletionType = CompletionType.chat
     temperature: float = 0.0  # Temperature of 0 means greedy decoding
     top_k: int = -1
     top_p: float = 0.95
@@ -76,10 +84,10 @@ class GenerateSolutionsConfig:
     input_file: str  # Path to the input file with data
     output_file: str  # Where to save the generations
     prompt_config: str | None = None  # How to format the data into prompts
-    # by default we use chat completions, set this to True to use completions API. In that case we will take the
-    # tokenizer from the model and apply it to the prompt before sending it. You can override tokenizer with
-    # tokenizer parameter
+
+    # Deprecated, please use completion_type in the InferenceConfig instead
     use_completions_api: bool = False
+
     # path or name of the tokenizer to use for completions API. By default uses server.model
     tokenizer: str | None = None
     # extra parameters to pass to the tokenizer's apply_chat_template method
@@ -199,7 +207,7 @@ class GenerateSolutionsConfig:
                     "Megatron server doesn't support chat completions and we can't infer tokenizer from model name. "
                     "Please provide it with an explicit `tokenizer` parameter."
                 )
-            self.use_completions_api = True
+            self.inference.completion_type = CompletionType.text
             LOG.warning("Megatron inference is extremely slow. It's highly recommended to use other server types!")
 
     def _post_init_validate_params(self):
@@ -214,6 +222,11 @@ class GenerateSolutionsConfig:
         for param, default_value in self._get_disallowed_params():
             if getattr(self, param) != default_value:
                 raise ValueError(f"{param} must be {default_value}")
+
+    def _post_init_deprecated_params(self):
+        if self.use_completions_api:
+            self.inference.completion_type = CompletionType.text
+            LOG.warning("use_completions_api is deprecated, please use ++inference.completion_type=text instead.")
 
     def _get_disallowed_params(self):
         """Returns a list of parameters with their default values to check that they are not changed from the defaults"""
@@ -261,7 +274,7 @@ class GenerationTask:
 
         # chat template kwargs goes either into extra body of inference or as a prompt parameter
         if self.cfg.chat_template_kwargs:
-            if not self.cfg.use_completions_api:
+            if self.cfg.inference.completion_type != CompletionType.text:
                 if "chat_template_kwargs" in self.cfg.inference.extra_body:
                     raise ValueError(
                         "chat_template_kwargs is provided in both inference.extra_body and as a separate argument. "
@@ -273,7 +286,7 @@ class GenerationTask:
 
         # Setup tokenizer
         if (
-            self.cfg.use_completions_api
+            self.cfg.inference.completion_type == CompletionType.text
             or self.cfg.server.get("enable_soft_fail", False)
             or self.cfg.count_prompt_tokens
         ):
@@ -285,7 +298,7 @@ class GenerationTask:
         # Setup litellm cache
         self.setup_litellm_cache()
 
-        if self.cfg.use_completions_api and self.cfg.inference.tokens_to_generate is None:
+        if self.cfg.inference.completion_type == CompletionType.text and self.cfg.inference.tokens_to_generate is None:
             raise ValueError("When using completions API, tokens_to_generate must be specified!")
 
         # Setup prompt formatter and LLM
@@ -342,7 +355,7 @@ class GenerationTask:
 
         prompt = get_prompt(
             prompt_config=self.cfg.prompt_config,
-            tokenizer=self.tokenizer if self.cfg.use_completions_api else None,
+            tokenizer=self.tokenizer if self.cfg.inference.completion_type == CompletionType.text else None,
             code_tags=self.cfg.code_tags,
             examples_type=self.cfg.examples_type,
             system_message=self.cfg.system_message,

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -627,8 +627,7 @@ class GenerationTask:
             if t is asyncio.current_task():
                 continue
             coro = t.get_coro()
-            qualname = getattr(coro, "__qualname__", "")
-            if "Logging" in qualname:
+            if "Logging" in str(coro):
                 t.cancel()
                 tasks_to_cancel.append(t)
         if tasks_to_cancel:

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -722,6 +722,7 @@ if __name__ == "__main__":
 
 
 async def _cancel_other_async_tasks():
+    LOG.info("Cancelling other async tasks")
     attempt = 0
     while True:
         tasks_to_cancel = []
@@ -730,6 +731,7 @@ async def _cancel_other_async_tasks():
                 continue
             tasks_to_cancel.append(t)
 
+        LOG.info(f"Tasks to cancel: {len(tasks_to_cancel)}")
         for t in tasks_to_cancel:
             coro = t.get_coro()
             coro_name = getattr(coro, "__qualname__", repr(coro))

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -190,15 +190,6 @@ class BaseModel:
     def _build_completion_request_params(self, **kwargs) -> dict:
         pass
 
-    def _build_request_params(self, prompt: str | list[dict], stream: bool, **kwargs) -> dict:
-        if isinstance(prompt, str):
-            return self._build_completion_request_params(prompt=prompt, stream=stream, **kwargs)
-        elif isinstance(prompt, list):
-            request_params = self._build_chat_request_params(messages=prompt, stream=stream, **kwargs)
-            return request_params
-        else:
-            raise ValueError("Either prompt or messages must be provided")
-
     @with_context_retry
     async def generate_async(
         self,

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -133,9 +133,6 @@ class BaseModel:
             api_base=self.base_url,  # Used in later versions with responses API
         )
         httpx_limits = httpx.Limits(max_keepalive_connections=None, max_connections=None)
-        litellm.logging = False
-        litellm.disable_streaming_logging = True
-        litellm._logging.disable_debugging()
         litellm.client_session = httpx.Client(limits=httpx_limits)
         litellm.aclient_session = httpx.AsyncClient(limits=httpx_limits)
 

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -132,7 +132,7 @@ class BaseModel:
             base_url=self.base_url,
             api_base=self.base_url,  # Used in later versions with responses API
         )
-        httpx_limits = httpx.Limits(max_keepalive_connections=None, max_connections=None)
+        httpx_limits = httpx.Limits(max_keepalive_connections=2048, max_connections=2048)
         litellm.client_session = httpx.Client(limits=httpx_limits)
         litellm.aclient_session = httpx.AsyncClient(limits=httpx_limits)
 

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -130,6 +130,7 @@ class BaseModel:
             max_retries=max_retries,
             api_key=api_key,
             base_url=self.base_url,
+            api_base=self.base_url,  # Used in later versions with responses API
         )
         httpx_limits = httpx.Limits(max_keepalive_connections=2048, max_connections=2048)
         litellm.client_session = httpx.Client(limits=httpx_limits)

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -135,6 +135,7 @@ class BaseModel:
         httpx_limits = httpx.Limits(max_keepalive_connections=None, max_connections=None)
         litellm.logging = False
         litellm.disable_streaming_logging = True
+        litellm._logging.disable_debugging()
         litellm.client_session = httpx.Client(limits=httpx_limits)
         litellm.aclient_session = httpx.AsyncClient(limits=httpx_limits)
 

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -133,6 +133,8 @@ class BaseModel:
             api_base=self.base_url,  # Used in later versions with responses API
         )
         httpx_limits = httpx.Limits(max_keepalive_connections=None, max_connections=None)
+        litellm.logging = False
+        litellm.disable_streaming_logging = True
         litellm.client_session = httpx.Client(limits=httpx_limits)
         litellm.aclient_session = httpx.AsyncClient(limits=httpx_limits)
 

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -17,7 +17,6 @@ import os
 from enum import Enum
 from typing import Union
 
-import httpx
 import litellm
 import openai
 
@@ -132,9 +131,9 @@ class BaseModel:
             base_url=self.base_url,
             api_base=self.base_url,  # Used in later versions with responses API
         )
-        httpx_limits = httpx.Limits(max_keepalive_connections=2048, max_connections=2048)
-        litellm.client_session = httpx.Client(limits=httpx_limits)
-        litellm.aclient_session = httpx.AsyncClient(limits=httpx_limits)
+        # httpx_limits = httpx.Limits(max_keepalive_connections=None, max_connections=None)
+        # litellm.client_session = httpx.Client(limits=httpx_limits)
+        # litellm.aclient_session = httpx.AsyncClient(limits=httpx_limits)
 
     def _get_api_key(self, api_key: str | None, api_key_env_var: str | None, base_url: str) -> str | None:
         if api_key:  # explicit cmd argument always takes precedence

--- a/nemo_skills/inference/model/code_execution.py
+++ b/nemo_skills/inference/model/code_execution.py
@@ -22,7 +22,7 @@ from nemo_skills.code_execution import extract_code_to_execute, format_code_outp
 from nemo_skills.code_execution.sandbox import Sandbox
 from nemo_skills.utils import get_logger_name, nested_dataclass
 
-from .base import BaseModel
+from .base import BaseModel, CompletionType
 
 LOG = logging.getLogger(get_logger_name(__file__))
 
@@ -65,6 +65,7 @@ class CodeExecutionWrapper:
         max_code_executions: int | None = None,  # if not None, will override self.config.max_code_executions
         stream: bool = False,
         extra_body: dict = None,
+        completion_type: CompletionType = None,
     ):
         # Handle OpenAI-style dictionary prompts
         is_openai_format = not isinstance(prompt, str)
@@ -75,6 +76,7 @@ class CodeExecutionWrapper:
         if stream:
             return self._stream_single(
                 prompt=prompt,
+                completion_type=completion_type,
                 code_begin=code_begin,
                 code_end=code_end,
                 code_output_begin=code_output_begin,
@@ -108,6 +110,7 @@ class CodeExecutionWrapper:
         stop_phrases = stop_phrases or []
 
         request = {
+            "completion_type": completion_type,
             "prompt": new_prompt,
             "tokens_to_generate": tokens_to_generate,
             "temperature": temperature,
@@ -252,6 +255,7 @@ class CodeExecutionWrapper:
         max_code_executions: int | None = None,
         stream: bool = False,
         extra_body: dict = None,
+        completion_type: CompletionType = None,
     ) -> list[dict]:
         """For any generation parameter you can specify a list of values that needs to match the number of prompts.
 
@@ -261,6 +265,7 @@ class CodeExecutionWrapper:
             raise NotImplementedError("top_logprobs is not supported yet.")
 
         kwargs = {
+            "completion_type": completion_type,
             "code_begin": code_begin,
             "code_end": code_end,
             "code_output_begin": code_output_begin,
@@ -308,6 +313,7 @@ class CodeExecutionWrapper:
         timeout: float | int | None = 14400,  # None is 10min,
         max_code_executions: int | None = None,
         extra_body: dict = None,
+        completion_type: CompletionType = None,
     ):
         """
         Helper method, that implements streaming generation.
@@ -322,6 +328,7 @@ class CodeExecutionWrapper:
         stop_phrases = stop_phrases or []
 
         request = {
+            "completion_type": completion_type,
             "temperature": temperature,
             "top_p": top_p,
             "top_k": top_k,

--- a/nemo_skills/inference/model/parallel_thinking.py
+++ b/nemo_skills/inference/model/parallel_thinking.py
@@ -27,7 +27,7 @@ from typing import Dict, List, Optional, Union
 from nemo_skills.prompt.utils import get_prompt
 from nemo_skills.utils import get_logger_name, nested_dataclass, remove_thinking
 
-from .base import BaseModel
+from .base import BaseModel, CompletionType
 
 LOG = logging.getLogger(get_logger_name(__file__))
 
@@ -52,7 +52,7 @@ class ParallelThinkingConfig:
     remove_thinking: bool = True  # Remove thinking tokens from the solution key
     thinking_begin: str = "<think>"
     thinking_end: str = "</think>"
-    use_completions_api: bool = False
+    completion_type: CompletionType = CompletionType.chat
     tokenizer: str | None = None
     chat_template_kwargs: dict | None = None  # extra parameters to pass to the tokenizer's apply_chat_template method
 
@@ -83,7 +83,7 @@ class ParallelThinkingTask:
         self.orig_prompt_filler = orig_prompt_filler
         self.cfg = cfg
 
-        if self.cfg.use_completions_api:
+        if self.cfg.completion_type == CompletionType.text:
             tokenizer = self.cfg.tokenizer or self.model.model_name_or_path
         else:
             tokenizer = None

--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -145,7 +145,6 @@ class ToolCallingWrapper:
             tool_calls = generation.get("tool_calls", [])
             if tool_calls:
                 tool_calls = [tool_call.model_dump() for tool_call in tool_calls]
-                LOG.info("!!!", tool_calls)
                 tool_calls_output_messages = await self._execute_tool_calls(
                     tool_calls, request_id=request_id, completion_type=completion_type
                 )

--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -145,6 +145,7 @@ class ToolCallingWrapper:
             tool_calls = generation.get("tool_calls", [])
             if tool_calls:
                 tool_calls = [tool_call.model_dump() for tool_call in tool_calls]
+                LOG.info("!!!", tool_calls)
                 tool_calls_output_messages = await self._execute_tool_calls(
                     tool_calls, request_id=request_id, completion_type=completion_type
                 )

--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -77,6 +77,7 @@ class ToolCallingWrapper:
         try:
             tool_args = json.loads(tool_args)
         except json.decoder.JSONDecodeError as e:
+            LOG.error(f"Tool arguments are not in JSON format: {tool_args}")
             LOG.exception(e)
             return {"error": "Tool argument parsing failed."}
 

--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -148,6 +148,7 @@ class ToolCallingWrapper:
                 tool_calls_output_messages = await self._execute_tool_calls(
                     tool_calls, request_id=request_id, completion_type=completion_type
                 )
+                print("Sending tool calls", tool_calls_output_messages)
                 conversation.extend(tool_calls_output_messages)
 
                 result_steps["num_tool_calls"].append(len(tool_calls))

--- a/nemo_skills/inference/model/vllm.py
+++ b/nemo_skills/inference/model/vllm.py
@@ -138,3 +138,10 @@ class VLLMModel(BaseModel):
             request["allowed_openai_params"] = ["reasoning_effort"]
             request["reasoning_effort"] = reasoning_effort
         return request
+
+    def _build_responses_request_params(self, input, **kwargs) -> dict:
+        # Parameters are the same as chat completion request params
+        # Instead, messages is renamed to input
+        responses_params = self._build_chat_request_params(input=input, **kwargs)
+        responses_params["input"] = responses_params.pop("messages")
+        return responses_params

--- a/nemo_skills/inference/model/vllm.py
+++ b/nemo_skills/inference/model/vllm.py
@@ -141,7 +141,8 @@ class VLLMModel(BaseModel):
 
     def _build_responses_request_params(self, input, **kwargs) -> dict:
         # Parameters are the same as chat completion request params
-        # Instead, messages is renamed to input
-        responses_params = self._build_chat_request_params(input=input, **kwargs)
+        # For now, we hack this by renaming messages to input
+        # Until we need more parameters for responses API
+        responses_params = self._build_chat_request_params(messages=input, **kwargs)
         responses_params["input"] = responses_params.pop("messages")
         return responses_params

--- a/nemo_skills/mcp/adapters.py
+++ b/nemo_skills/mcp/adapters.py
@@ -103,7 +103,7 @@ def format_tool_response_by_completion_type(tool_call, result, completion_type: 
     elif completion_type == CompletionType.responses:
         return {
             "type": "function_call_output",
-            "call_id": tool_call["id"],
+            "call_id": tool_call["call_id"],
             "output": json.dumps(result) if not isinstance(result, str) else result,
         }
     else:

--- a/nemo_skills/training/openrlhf/math_reward.py
+++ b/nemo_skills/training/openrlhf/math_reward.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import json
 import os
 
@@ -57,7 +58,9 @@ def reward_func(queries: list[str], prompts: list[str], prompt_metadata: list[di
     judge_prompts = [prompt.fill(dp) for dp in data_points]
     if len(judge_prompts) > 0:
         # Too slow, but we are no longer supporting openrlhf anyways.
-        outputs = [llm.generate_sync(prompt=jp, stop_phrases=prompt.stop_phrases) for jp in judge_prompts]
+        outputs = [
+            asyncio.run(llm.generate_async(prompt=jp, stop_phrases=prompt.stop_phrases)) for jp in judge_prompts
+        ]
     else:
         outputs = []
     judgements = []

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -26,7 +26,7 @@ huggingface_hub
 hydra-core
 ipython
 iso639-lang
-litellm[caching] < 1.75.0  # some bug with asyncio.run hanging forever
+litellm[caching] == 1.77.5
 math-verify[antlr4_9_3]
 mcp
 nemo_run @ git+https://github.com/NVIDIA/NeMo-Run

--- a/tests/slurm-tests/gpt_oss_python_aime25/run_test.py
+++ b/tests/slurm-tests/gpt_oss_python_aime25/run_test.py
@@ -24,7 +24,7 @@ def eval_gpt_oss_python(workspace, cluster, expname_prefix, wandb_project):
             "++inference.temperature=1.0 "
             "++inference.top_p=1.0 "
             "++prompt_config=gpt-oss/math "
-            "++use_completions_api=true "
+            "++inference.completion_type=text "
             "++code_tags=gpt-oss "
             "++code_execution=true "
             "++server.code_execution.max_code_executions=100 "


### PR DESCRIPTION
* Adding responses api type (currently for vllm only)
* Deprecating `use_completions_api` in favour of `completion_type`.
* Removing all the sync logic.

Running example:
```
ns eval \
  --benchmarks aime25:2 \
  --cluster slurm \
  --model /hf_models/gpt-oss-20b \
  --server_gpus 8 \
  --server_type vllm \
  --output_dir /workspace/aime-responses \
  ++tool_modules="[nemo_skills.mcp.servers.python_tool::PythonTool]" \
  ++inference.tokens_to_generate=100000 \
  ++inference.completion_type=responses \
  --with_sandbox
```

### Limitations with VLLM+GPT-OSS:
* VLLM fails to parse most of the tool calls. Most of the times putting <channel> in tool name
* Usually first tool succeeds, but when calling tool for the second time, vllm usually fails even worse: it returns the tool call as a text reasoning content.