### PR TITLE
Increase sandbox client timeouts and skip code re-execution on timeout

### DIFF
--- a/nemo_skills/code_execution/local_sandbox/local_sandbox_server.py
+++ b/nemo_skills/code_execution/local_sandbox/local_sandbox_server.py
@@ -409,7 +409,7 @@ def execute_ipython_session(generated_code, session_id, timeout=30, traceback_ve
                 "process_status": "timeout",
                 "stdout": postprocess_output(result.get("stdout", ""), traceback_verbosity),
                 "stderr": postprocess_output(
-                    result.get("stderr", "") + f"\nExecution timed out after {timeout} seconds\n", traceback_verbosity
+                    result.get("stderr", "") + f"Execution timed out after {timeout} seconds\n", traceback_verbosity
                 ),
                 "new_session_created": new_session_created,
             }
@@ -519,7 +519,7 @@ def execute_python(generated_code, std_input, timeout, language):
         except ProcessLookupError:
             pass
         process.wait(timeout=1)  # reap, no extra timeout needed
-        return {"process_status": "timeout", "stdout": "", "stderr": "Timed out\n"}
+        return {"process_status": "timeout", "stdout": "", "stderr": f"Execution timed out after {timeout} seconds\n"}
 
 
 def execute_lean4(generated_code, timeout):
@@ -563,7 +563,7 @@ def execute_lean4(generated_code, timeout):
         # Now we can safely get any output that was generated before the kill.
         stdout, stderr = proc.communicate()
 
-        final_stderr = stderr.decode("utf-8") + "Timed out\n"
+        final_stderr = stderr.decode("utf-8") + f"Execution timed out after {timeout} seconds\n"
         return {
             "process_status": "timeout",
             "stdout": stdout.decode("utf-8"),
@@ -599,7 +599,7 @@ def execute_shell(command, timeout):
         process_status = "completed" if result.returncode == 0 else "error"
         return {"process_status": process_status, "stdout": result.stdout, "stderr": result.stderr}
     except subprocess.TimeoutExpired:
-        return {"process_status": "timeout", "stdout": "", "stderr": "Timed out\n"}
+        return {"process_status": "timeout", "stdout": "", "stderr": f"Execution timed out after {timeout} seconds\n"}
     finally:
         if tmp_path and os.path.exists(tmp_path):
             os.remove(tmp_path)

--- a/nemo_skills/code_execution/sandbox.py
+++ b/nemo_skills/code_execution/sandbox.py
@@ -173,7 +173,7 @@ class Sandbox(abc.ABC):
         try:
             output = await self._send_request(request, timeout)
         except httpx.TimeoutException:
-            output = {"process_status": "timeout", "stdout": "", "stderr": "Timed out\n"}
+            output = {"process_status": "timeout", "stdout": "", "stderr": "Client timed out\n"}
         new_session_created = output.pop("new_session_created", False)
 
         # Rebuild state by re-executing history first, then execute the new code.
@@ -202,7 +202,7 @@ class Sandbox(abc.ABC):
                     try:
                         restore_output = await self._send_request(restore_request, timeout)
                     except httpx.TimeoutException:
-                        restore_output = {"process_status": "timeout", "stdout": "", "stderr": "Timed out\n"}
+                        restore_output = {"process_status": "timeout", "stdout": "", "stderr": "Client timed out\n"}
 
                     if restore_output.get("process_status") != "completed":
                         LOG.error(
@@ -246,7 +246,7 @@ class Sandbox(abc.ABC):
                 try:
                     output = await self._send_request(exec_request, timeout)
                 except httpx.TimeoutException:
-                    output = {"process_status": "timeout", "stdout": "", "stderr": "Timed out during re-execution\n"}
+                    output = {"process_status": "timeout", "stdout": "", "stderr": "Client timed out\n"}
 
         # Append to history if successful execution (process_status == 'completed')
         if output.get("process_status") == "completed" and request_session_id_str is not None:

--- a/tests/test_code_execution.py
+++ b/tests/test_code_execution.py
@@ -110,7 +110,7 @@ async def test_timeout_error(language):
     code = """import time\ntime.sleep(1)\nprint("done")"""
 
     output, session_id = await sandbox.execute_code(code, timeout=1, language=language)
-    assert output == {"process_status": "timeout", "stdout": "", "stderr": "Timed out\n"}
+    assert output == {"process_status": "timeout", "stdout": "", "stderr": "Execution timed out after 1 seconds\n"}
 
     output, session_id = await sandbox.execute_code(code, timeout=2, session_id=session_id, language=language)
     assert output == {"process_status": "completed", "stderr": "", "stdout": "done\n"}


### PR DESCRIPTION
Separated this PR from slurm tests and sandbox server polling updates to iterate faster.

This PR:
- Increases http timeout to separate client and server timeouts. Previously, all timeouts were client-side.
- Modifies client timeout message to distinguish it from server timeout.
- Skips code re-execution on server timeout, because this leads to double timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unintended code execution after a prior timeout by skipping restore/run when a previous run timed out.

* **Chores**
  * Increased request timeouts (SSH-tunneled and direct HTTP) to improve reliability.
  * Standardized timeout reporting: HTTP paths emit “Client timed out”; local execution messages include the timeout value (e.g., “Execution timed out after X seconds”).

* **Tests**
  * Updated timeout expectation to match new execution timeout message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->