### PR TITLE
Slurm tests for code execution timeouts

### DIFF
--- a/tests/slurm-tests/code_execution_timeouts/check_results.py
+++ b/tests/slurm-tests/code_execution_timeouts/check_results.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from utils import assert_all, soft_assert
+
+# Reasonable number of timeouts per file
+MAX_TIMEOUTS_PER_FILE = 10
+
+
+def parse_timeout_counts(eval_file: Path) -> int:
+    """Return the total sandbox timeout count from the async jsonl output."""
+
+    total_timeouts = 0
+    with eval_file.open("rt", encoding="utf-8") as fin:
+        for line in fin:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            soft_assert("num_code_timeouts" in row, f"num_code_timeouts not found in {line}")
+            total_timeouts += row.get("num_code_timeouts", 0)
+    return total_timeouts
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", required=True)
+    args = parser.parse_args()
+
+    eval_dir = Path(args.workspace) / "eval-results" / "hmmt_feb25"
+    timeout_files = sorted(
+        eval_dir.glob("output-rs*.jsonl"), key=lambda p: int(re.search(r"output-rs(\d+)\.jsonl", p.name).group(1))
+    )
+
+    soft_assert(timeout_files, f"No output-rs*.jsonl files found under {eval_dir}")
+
+    total_timeouts = 0
+    for output_path in timeout_files:
+        file_timeouts = parse_timeout_counts(output_path)
+        total_timeouts += file_timeouts
+        print(f"{output_path.name}: num_code_timeouts={file_timeouts}")
+
+    if timeout_files:
+        print(f"Total sandbox_code_timeouts across files: {total_timeouts}")
+        allowed_timeouts = MAX_TIMEOUTS_PER_FILE * len(timeout_files)
+        soft_assert(
+            total_timeouts <= allowed_timeouts,
+            (
+                "Sandbox timeouts regressed: "
+                f"observed {total_timeouts}, allowed <= {allowed_timeouts} "
+                f"({len(timeout_files)} files * {MAX_TIMEOUTS_PER_FILE} max each)"
+            ),
+        )
+
+    assert_all()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/slurm-tests/code_execution_timeouts/run_test.py
+++ b/tests/slurm-tests/code_execution_timeouts/run_test.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+
+from nemo_skills.pipeline.cli import eval, prepare_data, run_cmd, wrap_arguments
+
+
+def eval_gpt_oss_hmmt(
+    workspace: str, cluster: str, expname_prefix: str, wandb_project: str | None, num_jobs: int
+) -> str:
+    """Submit hmmt_feb25 evaluation with code execution enabled."""
+
+    eval(
+        ctx=wrap_arguments(
+            "++inference.tokens_to_generate=120000 "
+            "++inference.temperature=1.0 "
+            "++inference.top_p=1.0 "
+            "++max_concurrent_requests=1024 "
+            "++prompt_config=gpt-oss/math "
+            "++code_tags=gpt-oss "
+            "++code_execution=true "
+            "++server.code_execution.max_code_executions=100 "
+            "++server.code_execution.code_execution_timeout=120 "
+            "++use_completions_api=true "
+            "++chat_template_kwargs.reasoning_effort=high "
+            "++chat_template_kwargs.builtin_tools=[python] "
+        ),
+        cluster=cluster,
+        benchmarks="hmmt_feb25:16",
+        model="openai/gpt-oss-120b",
+        server_gpus=8,
+        num_jobs=num_jobs,
+        server_type="vllm",
+        output_dir=workspace,
+        server_args="--async-scheduling",
+        with_sandbox=True,
+        expname=expname_prefix,
+        wandb_project=wandb_project,
+        wandb_name=expname_prefix,
+    )
+
+    return expname_prefix
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", required=True)
+    parser.add_argument("--cluster", required=True)
+    parser.add_argument("--expname_prefix", required=True)
+    parser.add_argument("--wandb_project", default="nemo-skills-slurm-ci")
+    args = parser.parse_args()
+
+    prepare_data(ctx=wrap_arguments("hmmt_feb25"))
+
+    # Run with 1 sandbox per random seed AND with 1 sandbox for 16 random seeds
+    for num_jobs in [-1, 1]:
+        expname_suffix = f"{num_jobs=}"
+
+        eval_expname = eval_gpt_oss_hmmt(
+            workspace=args.workspace + expname_suffix,
+            cluster=args.cluster,
+            expname_prefix=args.expname_prefix + expname_suffix,
+            wandb_project=args.wandb_project,
+            num_jobs=num_jobs,
+        )
+
+        checker_cmd = (
+            "python tests/slurm-tests/hmmt_code_timeout_baseline/check_results.py "
+            f"--workspace {args.workspace + expname_suffix} "
+        )
+
+        run_cmd(
+            ctx=wrap_arguments(checker_cmd),
+            cluster=args.cluster,
+            expname=args.expname_prefix + expname_suffix + "-check-results",
+            log_dir=f"{args.workspace + expname_suffix}/check-results-logs",
+            run_after=eval_expname,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/slurm-tests/run_all.sh
+++ b/tests/slurm-tests/run_all.sh
@@ -11,4 +11,6 @@ sleep 10
 python tests/slurm-tests/qwen3_4b_evals/run_test.py --cluster $CLUSTER --workspace /workspace/nemo-skills-slurm-ci/$CURRENT_DATE/qwen3_4b_evals --expname_prefix qwen3_4b_evals_$CURRENT_DATE &
 sleep 10
 python tests/slurm-tests/omr_simple_recipe/run_test.py --cluster $CLUSTER --backend nemo-rl --workspace /workspace/nemo-skills-slurm-ci/$CURRENT_DATE/omr_simple_recipe/nemo-rl --expname_prefix omr_simple_recipe_nemo_rl_$CURRENT_DATE &
+sleep 10
+python tests/slurm-tests/code_execution_timeouts/run_test.py --cluster $CLUSTER --workspace /workspace/nemo-skills-slurm-ci/$CURRENT_DATE/code_execution_timeouts --expname_prefix code_execution_timeouts_$CURRENT_DATE &
 wait


### PR DESCRIPTION
This PR adds slurm tests for code execution timeouts.
The tests launch evaluation of gpt-oss-120b model with python code execution on hmmt_feb25 with 16 random seeds and num_jobs=1, calculates total number of timeouts based on `output-rs*.jsonl` and checks if it exceed 160 (on average there are 5-6 timeouts per random seed, usually resulting in 80-90 total timeouts).