### PR TITLE
Addding BFCL headers

### DIFF
--- a/nemo_skills/dataset/bfcl_v3/utils.py
+++ b/nemo_skills/dataset/bfcl_v3/utils.py
@@ -1,3 +1,17 @@
+# Copyright 2023 https://github.com/ShishirPatil/gorilla
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nemo_skills/inference/eval/bfcl_utils.py
+++ b/nemo_skills/inference/eval/bfcl_utils.py
@@ -1,3 +1,18 @@
+# Copyright 2023 https://github.com/ShishirPatil/gorilla
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Added license header from BFCL. Keeping both the license headers. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Documentation
  - Added explicit Gorilla and NVIDIA Apache 2.0 license notices to relevant source files to improve transparency and compliance.

- Chores
  - Standardized license headers across modules; consolidated legal text for consistency.
  - No changes to functionality, APIs, or behavior; build and runtime remain unaffected.
  - No action required for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->