### PR TITLE
Remove debugging prints from python tool

### DIFF
--- a/nemo_skills/mcp/servers/python_tool.py
+++ b/nemo_skills/mcp/servers/python_tool.py
@@ -123,8 +123,6 @@ class PythonTool(MCPClientTool):
         merged_extra.setdefault("timeout", self._config.get("exec_timeout_s", 10))
         merged_extra["session_id"] = self.requests_to_sessions[request_id]
         result = await self._client.call_tool(tool=tool_name, args=arguments, extra_args=merged_extra)
-        print("!!!", result)
-        print("@@@", self.requests_to_sessions)
         self.requests_to_sessions[request_id] = result["session_id"]
         output = f"{result['output_dict']['stdout']}{result['output_dict']['stderr']}"
         if output.endswith("\n"):  # there is always a trailing newline, removing it


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Removed unintended debug messages during Python tool execution, reducing console/log noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->