### PR TITLE
Preventing iteration error in case no judge tasks were generated

### DIFF
--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -441,8 +441,11 @@ def eval(
                 ),
                 **judge_pipeline_args,
             )
-            benchmark_to_judge_tasks[benchmark] = judge_tasks
-            all_tasks.extend(judge_tasks)
+            # _generate can return None when there are no jobs to run (e.g., outputs already exist)
+            # Only record and extend when tasks are present to avoid NoneType errors
+            if judge_tasks:
+                benchmark_to_judge_tasks[benchmark] = judge_tasks
+                all_tasks.extend(judge_tasks)
 
         group_metric_files = defaultdict(list)
         group_tasks = defaultdict(list)


### PR DESCRIPTION
Got `TypeError: 'NoneType' object is not iterable`  error when rerunning slurm tests. This PR will prevent such errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes during evaluation when no judge tasks are produced (e.g., outputs already exist).
  * Only records and queues tasks when actual tasks are present, avoiding NoneType issues.
  * Preserves existing behavior and results when valid tasks are available.
  * Improves reliability for repeated or incremental runs, reducing interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->