### PR TITLE
style: make code style consistent with spacing

### DIFF
--- a/nemo_skills/pipeline/nemo_rl/grpo.py
+++ b/nemo_skills/pipeline/nemo_rl/grpo.py
@@ -178,8 +178,8 @@ def get_checkpoint_convert_cmd(output_dir, final_hf_path, step, backend):
     else:
         raise ValueError("Invalid backend: must be 'fsdp' or 'megatron'")
 
-    cmd += f"   --training-folder={output_dir} "
-    cmd += f"   --hf-ckpt-path={final_hf_path} "
+    cmd += f" --training-folder={output_dir} "
+    cmd += f" --hf-ckpt-path={final_hf_path} "
     if step != "last":
         try:
             step = int(step)
@@ -203,11 +203,11 @@ def get_checkpoint_average_cmd(output_dir, average_steps, backend, remove_checkp
     steps = [int(x.strip()) for x in average_steps.split(",") if x.strip()]
     steps_str = " ".join(map(str, steps))
 
-    cmd += f"--checkpoint_dir {output_dir} "
-    cmd += f"--steps {steps_str} "
-    cmd += f"   --backend={backend} "
+    cmd += f" --checkpoint_dir {output_dir} "
+    cmd += f" --steps {steps_str} "
+    cmd += f" --backend={backend} "
     if remove_checkpoints_after_average:
-        cmd += "--remove_checkpoints_after_average "
+        cmd += " --remove_checkpoints_after_average "
 
     return cmd
 

--- a/nemo_skills/pipeline/nemo_rl/sft.py
+++ b/nemo_skills/pipeline/nemo_rl/sft.py
@@ -175,8 +175,8 @@ def get_checkpoint_convert_cmd(output_dir, final_hf_path, step, backend):
     else:
         raise ValueError("Invalid backend: must be 'fsdp' or 'megatron'")
 
-    cmd += f"   --training-folder={output_dir} "
-    cmd += f"   --hf-ckpt-path={final_hf_path} "
+    cmd += f" --training-folder={output_dir} "
+    cmd += f" --hf-ckpt-path={final_hf_path} "
     if step != "last":
         try:
             step = int(step)
@@ -200,11 +200,11 @@ def get_checkpoint_average_cmd(output_dir, average_steps, backend, remove_checkp
     steps = [int(x.strip()) for x in average_steps.split(",") if x.strip()]
     steps_str = " ".join(map(str, steps))
 
-    cmd += f"--checkpoint_dir {output_dir} "
-    cmd += f"--steps {steps_str} "
-    cmd += f"   --backend={backend} "
+    cmd += f" --checkpoint_dir {output_dir} "
+    cmd += f" --steps {steps_str} "
+    cmd += f" --backend={backend} "
     if remove_checkpoints_after_average:
-        cmd += "--remove_checkpoints_after_average "
+        cmd += " --remove_checkpoints_after_average "
 
     return cmd
 


### PR DESCRIPTION
Make code style consistent with spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized spacing in generated CLI commands for checkpoint conversion and averaging across RL and SFT pipelines, improving consistency and readability.
  * Cleans up extra/trailing spaces before flags and ensures a single leading space per flag in constructed commands.
  * Enhances clarity in logs and when copying commands from output.
  * No functional changes; behavior, options, and results remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->