### PR TITLE
Update help string for `num_gpus` in pipelines

### DIFF
--- a/nemo_skills/pipeline/convert.py
+++ b/nemo_skills/pipeline/convert.py
@@ -174,8 +174,8 @@ def convert(
         help="Optional number of samples to use from the calibration dataset (if dtype=fp8)",
     ),
     expname: str = typer.Option("conversion", help="NeMo-Run experiment name"),
-    num_nodes: int = typer.Option(1),
-    num_gpus: int = typer.Option(...),
+    num_nodes: int = typer.Option(1, help="Number of nodes to use"),
+    num_gpus: int = typer.Option(..., help="Number of GPUs per node"),
     partition: str = typer.Option(
         None, help="Can specify if need interactive jobs or a specific non-default partition"
     ),

--- a/nemo_skills/pipeline/megatron_lm/train.py
+++ b/nemo_skills/pipeline/megatron_lm/train.py
@@ -113,7 +113,7 @@ def train_megatron_lm(
         ..., help="Path to the json file containing information about per-split training data"
     ),
     num_nodes: int = typer.Option(1, help="Number of nodes"),
-    num_gpus: int = typer.Option(..., help="Number of GPUs"),
+    num_gpus: int = typer.Option(..., help="Number of GPUs per node"),
     num_training_jobs: int = typer.Option(1, help="Number of training jobs"),
     wandb_project: str = typer.Option("nemo-skills", help="Weights & Biases project name"),
     wandb_group: str = typer.Option(None, help="Weights & Biases group name."),

--- a/nemo_skills/pipeline/nemo_rl/grpo.py
+++ b/nemo_skills/pipeline/nemo_rl/grpo.py
@@ -232,7 +232,7 @@ def grpo_nemo_rl(
     training_data: str = typer.Option(None, help="Path to the training data"),
     validation_data: Optional[str] = typer.Option(None, help="Path to the validation data"),
     num_nodes: int = typer.Option(1, help="Number of nodes"),
-    num_gpus: int = typer.Option(..., help="Number of GPUs"),
+    num_gpus: int = typer.Option(..., help="Number of GPUs per node"),
     num_training_jobs: int = typer.Option(1, help="Number of training jobs"),
     conversion_step: str = typer.Option(
         default="last",

--- a/nemo_skills/pipeline/nemo_rl/sft.py
+++ b/nemo_skills/pipeline/nemo_rl/sft.py
@@ -229,7 +229,7 @@ def sft_nemo_rl(
     training_data: str = typer.Option(None, help="Path to the training data"),
     validation_data: Optional[str] = typer.Option(None, help="Path to the validation data"),
     num_nodes: int = typer.Option(1, help="Number of nodes"),
-    num_gpus: int = typer.Option(..., help="Number of GPUs"),
+    num_gpus: int = typer.Option(..., help="Number of GPUs per node"),
     num_training_jobs: int = typer.Option(1, help="Number of training jobs"),
     conversion_step: str = typer.Option(
         default="last",

--- a/nemo_skills/pipeline/prepare_data.py
+++ b/nemo_skills/pipeline/prepare_data.py
@@ -48,7 +48,7 @@ def prepare_data(
     partition: str = typer.Option(None, help="Slurm partition to use"),
     qos: str = typer.Option(None, help="Specify Slurm QoS, e.g. to request interactive nodes"),
     time_min: str = typer.Option(None, help="Time-min slurm parameter"),
-    num_gpus: int | None = typer.Option(None, help="Number of GPUs to use"),
+    num_gpus: int | None = typer.Option(None, help="Number of GPUs per node to use"),
     num_nodes: int = typer.Option(1, help="Number of nodes to use"),
     mount_paths: str = typer.Option(None, help="Comma separated list of paths to mount"),
     run_after: List[str] = typer.Option(None, help="List of expnames that this job depends on before starting"),

--- a/nemo_skills/pipeline/verl/ppo.py
+++ b/nemo_skills/pipeline/verl/ppo.py
@@ -239,7 +239,7 @@ def ppo_verl(
     prompt_data: str = typer.Option(None, help="Path to the prompt data"),
     eval_data: str = typer.Option(None, help="Path to the eval data"),
     num_nodes: int = typer.Option(1, help="Number of nodes"),
-    num_gpus: int = typer.Option(..., help="Number of GPUs"),
+    num_gpus: int = typer.Option(..., help="Number of GPUs per node"),
     num_training_jobs: int = typer.Option(1, help="Number of training jobs"),
     server_model: str = typer.Option(None, help="Path to the model or model name in API"),
     server_address: str = typer.Option(


### PR DESCRIPTION
Clarify that `num_gpus` is the number of GPUs per node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified help text for GPU configuration parameters across CLI commands to specify "Number of GPUs per node" instead of "Number of GPUs," improving clarity on distributed training setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->