### PR TITLE
Completions API fix - replace max_completion_tokens with max_tokens

### DIFF
--- a/nemo_skills/inference/model/openai.py
+++ b/nemo_skills/inference/model/openai.py
@@ -76,13 +76,11 @@ class OpenAIModel(BaseModel):
         )
         if "tokens_to_generate" in kwargs:
             tokens_to_generate = kwargs.pop("tokens_to_generate")
-            kwargs["max_completion_tokens"] = tokens_to_generate
+            kwargs["max_tokens"] = tokens_to_generate
         if "random_seed" in kwargs:
             kwargs["seed"] = kwargs.pop("random_seed")
         if "stop_phrases" in kwargs:
             kwargs["stop"] = kwargs.pop("stop_phrases")
-        if "max_completion_tokens" in kwargs:
-            kwargs["max_tokens"] = kwargs.pop("max_completion_tokens")
         return dict(kwargs)
 
     def _build_chat_request_params(


### PR DESCRIPTION
Trying to query Completions API endpoint caused the following error:
`litellm.exceptions.UnsupportedParamsError: litellm.UnsupportedParamsError: text-completion-openai does not support parameters: ['max_completion_tokens'], for model=nvidia/NVIDIA-Nemotron-Nano-9B-v2-Base. `

According to [Completions API docs](https://platform.openai.com/docs/api-reference/completions/create#completions-create-max_tokens), there's no `max_completion_tokens` parameter, `max_tokens` is expected instead. 

This PR replaces `max_completion_tokens` with `max_tokens` in litellm query parameters. There's already a [similar fix](https://github.com/NVIDIA-NeMo/Skills/blob/a33e05e31ad3d82a321cf8e3a618f63f21f44230/nemo_skills/inference/model/openai.py#L162) for Requests API.

Script for testing:
```
ns eval \
    --server_type=openai \
    --model=nvidia/NVIDIA-Nemotron-Nano-9B-v2-Base \
    --server_address=<MY_ENDPOINT> \
    --benchmarks=mmlu \
    --output_dir=<MY_OUTPUT_DIR> \
    ++inference.endpoint_type=text \
    ++inference.tokens_to_generate=100 \
 ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized token parameter mapping to use the API's max_tokens key for completion requests, ensuring consistent token-limit behavior.
  * No changes to public interfaces; existing signatures and external behavior remain compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->