### PR TITLE
fix(generation): fixes the logic defining eval and generation module

### DIFF
--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -345,8 +345,9 @@ def generate(
     if generation_module is None:
         generation_module = GENERATION_MODULE_MAP[generation_type or GenerationType.generate]
 
-    if os.sep in generation_module:
-        generation_task = import_from_path(generation_module)
+    if generation_module.endswith(".py") or os.sep in generation_module:
+        path_suffix = ".py" if not generation_module.endswith(".py") else ""
+        generation_task = import_from_path(generation_module + path_suffix)
     else:
         generation_task = importlib.import_module(generation_module)
     if not hasattr(generation_task, "GENERATION_TASK_CLASS"):

--- a/nemo_skills/pipeline/utils/eval.py
+++ b/nemo_skills/pipeline/utils/eval.py
@@ -458,8 +458,11 @@ def prepare_eval_commands(
                 job_benchmarks.add(benchmark)
 
                 effective_generation_module = generation_module or benchmark_args.generation_module
-                if effective_generation_module and os.sep in effective_generation_module:
-                    generation_task = import_from_path(effective_generation_module)
+                if effective_generation_module and (
+                    effective_generation_module.endswith(".py") or os.sep in effective_generation_module
+                ):
+                    path_suffix = ".py" if not effective_generation_module.endswith(".py") else ""
+                    generation_task = import_from_path(effective_generation_module + path_suffix)
                 else:
                     generation_task = importlib.import_module(effective_generation_module)
                 if not hasattr(generation_task, "GENERATION_TASK_CLASS"):

--- a/nemo_skills/pipeline/utils/generation.py
+++ b/nemo_skills/pipeline/utils/generation.py
@@ -209,13 +209,14 @@ def get_generation_cmd(
     )
     cmd = "export HYDRA_FULL_ERROR=1 && "
     # Handle file paths vs module names
-    if os.sep in script:
+    common_args = f"++skip_filled=True ++input_file={input_file} ++output_file={output_file}"
+    if script.endswith(".py") or os.sep in script:
         # It's a file path, run it directly with .py extension
         script_path = script if script.endswith(".py") else f"{script}.py"
-        cmd += f"python {script_path} ++skip_filled=True ++input_file={input_file} ++output_file={output_file} "
+        cmd += f"python {script_path} {common_args} "
     else:
         # It's a module name, use -m flag
-        cmd += f"python -m {script} ++skip_filled=True ++input_file={input_file} ++output_file={output_file} "
+        cmd += f"python -m {script} {common_args} "
     job_end_cmd = ""
 
     if random_seed is not None and input_dir is None:  # if input_dir is not None, we default to greedy generations


### PR DESCRIPTION
This slightly changes the logic of determining if the requested module is referred as a file, so that from now it would assume that anything with `".py"` on the end, regardless of the existence of `os.sep`, is considered a file. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of Python script references so file paths and .py endings are reliably recognized when loading generation modules.

* **Refactoring**
  * Consolidated generation command construction to remove duplication and ensure consistent behavior across different execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->