### PR TITLE
Removing print from serve_riva_nim

### DIFF
--- a/nemo_skills/inference/server/serve_riva_nim.py
+++ b/nemo_skills/inference/server/serve_riva_nim.py
@@ -108,7 +108,8 @@ def main():
         "Starting Riva NIM with ports: HTTP=%s, GRPC=%s, TRITON(g/h/m)=(%s,%s,%s)"
         % (http_port, grpc_port, triton_grpc_port, triton_http_port, triton_metrics_port)
     )
-    print(env)
+    sanitized = {k: v for k, v in env.items() if k.startswith(("NIM_", "CONTAINER_ID"))}
+    print(f"Environment (sanitized): {sanitized}")
     subprocess.run(cmd, shell=True, check=True, env=env)
 
 


### PR DESCRIPTION
Printing the whole env is not a good idea in general.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved server logging output by filtering environment variables to display only relevant configuration information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->