### PR TITLE
Support environment variable expansion in mount paths

### DIFF
--- a/nemo_skills/pipeline/utils/mounts.py
+++ b/nemo_skills/pipeline/utils/mounts.py
@@ -418,8 +418,14 @@ def get_mounts_from_config(cluster_config: dict):
         if ":" not in mount:
             raise ValueError(f"Invalid mount format: {mount}. The mount path must be separated by a colon.")
 
+        # First, expand any ${VAR} style environment variables in the entire mount string
+        # This allows partial path substitution like /path/${USER}/subdir
+        if "$" in mount:
+            mount = os.path.expandvars(mount)
+
         mount_source, mount_target = mount.split(":")
 
+        # Then handle {VAR} style for full path replacement (legacy support)
         if mount_source[0] == "{" and mount_source[-1] == "}":
             # Resolve the environment variable for the mount source
             mount_source = mount_source[1:-1]


### PR DESCRIPTION
## Summary
  This change adds support for `${VAR}` style environment variable expansion in mount paths,
  consistent with how `ssh_tunnel` fields are processed.

  ## Problem
  Previously, only dict fields like `ssh_tunnel.user` and `ssh_tunnel.job_dir` supported `${VAR}`
  expansion via `os.path.expandvars()`. Mount list items only supported `{VAR}` format for full-path
   replacement (e.g., `{DATA_PATH}:/data` where `DATA_PATH` contains the entire source path).

  This inconsistency meant users couldn't create user-agnostic cluster configurations with partial
  path substitution in mounts.

  ## Solution
  Added `os.path.expandvars()` call in `get_mounts_from_config()` (at
  `nemo_skills/pipeline/utils/mounts.py:421-424`) to expand `${VAR}` patterns before processing
  mount paths.