### PR TITLE
fix(executor): for get_executor, 0 gpus is made same as None gpus

### DIFF
--- a/nemo_skills/pipeline/utils/exp.py
+++ b/nemo_skills/pipeline/utils/exp.py
@@ -212,7 +212,7 @@ def get_executor(
         partition: SLURM partition override. If omitted, inferred from `gpus_per_node`
             and `cluster_config`.
         qos: SLURM QOS.
-        time_min: Minimum time in minutes to request (e.g., for backfill).
+        time_min: Minimum time to request (e.g., for backfill). Needs to be in"HH:MM:SS" format
         dependencies: SLURM job handles to depend on. The dependency type is taken from
             `cluster_config['dependency_type']` (default: "afterany").
         extra_package_dirs: Additional directories to package with the code for remote


### PR DESCRIPTION
Without this fix, and after the recent PR with [this change](https://github.com/NVIDIA-NeMo/Skills/pull/888/files#diff-cb0455130637d57fce3399660326921ba502e01dec77aa414e459021e03635f1R598) which makes `num_gpus` always an integer (cc @gwarmstrong), the check `if .. is not None` resulted in passing `num_gpus=-1` in e.g. case local execution on a machine without GPU.

I opted to make change here because from the prospective of upstream Nemo-Run, they consider `num_gpus` to be [0/None interchangeably](https://github.com/NVIDIA-NeMo/Run/blob/d271d3c7026f1f254aa86bfdfcb360ea04427522/nemo_run/core/execution/docker.py#L263) for the sake of requesting devices.

### Collateral changes

Vibe-added docstring (asked to look around and it seemed to get it right) for the sake of documenting that.