### PR TITLE
Bulk improvements nemo skills pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Nemo-Skills is a collection of pipelines to improve "skills" of large language models (LLMs). We support everything needed for LLM development, from synthetic data generation, to model training, to evaluation on a wide range of benchmarks. Start developing on a local workstation and move to a large-scale Slurm cluster with just a one-line change.
 
+
 Here are some of the features we support:
 
 - [Flexible LLM inference](https://nvidia-nemo.github.io/Skills/pipelines/generation/):


### PR DESCRIPTION
This PR aimed to 

[1] Add one unified file for all audio related metrics [WER, CER, BLUE, WER/CER PnC, PC rate, Hallutination] Done https://github.com/NVIDIA-NeMo/Skills/pull/1093
[2] Eval step updates for custom audio preprocessing
[3] Convenient way for benchmark addition: Documentation and ns prepare command update
[4] Viewing metrics in wandb