### PR TITLE
Introduce regex for small differences of formatting from judge

### DIFF
--- a/nemo_skills/evaluation/metrics/utils.py
+++ b/nemo_skills/evaluation/metrics/utils.py
@@ -36,9 +36,9 @@ def read_predictions(predictions, line_idx, file_handles):
 
 def is_correct_judgement(judgement, return_none=False) -> Union[bool, None]:
     # Match both plain "Judgement:" and markdown bold "**Judgement**:" formats, this happens for gpt-4o which is AA Judge model.
-    match = re.search(r'\*{0,2}Judgement\*{0,2}\s*:', judgement, re.IGNORECASE)
+    match = re.search(r"\*{0,2}Judgement\*{0,2}\s*:", judgement, re.IGNORECASE)
     if match:
-        verdict = judgement[match.end():].strip()
+        verdict = judgement[match.end() :].strip()
         if verdict.lower().startswith("yes"):
             return True
         elif verdict.lower().startswith("no"):


### PR DESCRIPTION
## Problem
The gpt-4o LLM judge sometimes returns responses with markdown bold formatting:
**Judgement**: yes
However, the `is_correct_judgement` function only looked for Judgement: (plain text), causing these valid positive judgements to be incorrectly marked as False.

## Solution
Updated the regex pattern in `is_correct_judgement` to handle both plain and markdown-formatted responses:
```python
# Before
if "Judgement:" in judgement:
    verdict = judgement.split("Judgement:")[-1].strip()


# After  
match = re.search(r'\*{0,2}Judgement\*{0,2}\s*:', judgement, re.IGNORECASE)
if match:
    verdict = judgement[match.end():].strip()
```
The new pattern matches:
Judgement: (plain)
*Judgement*: (italic)
**Judgement**: (bold)
Impact
Tested on HLE benchmark results - judge_correct nearly doubled:
Subset	Before	After	Δ
hle (overall)	5.70%	10.24%	+4.54%
hle-Math	8.91%	16.39%	+7.48%
hle-Engineering	3.13%	6.25%	+3.12%
hle-Chemistry	4.95%	7.92%	+2.97%