### PR TITLE
fix(pipeline): separate tasks for local executor to prevent app_id collisions

### DIFF
--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -547,8 +547,12 @@ def eval(
                     installation_command=installation_command,
                     skip_hf_home_check=skip_hf_home_check,
                 )
-                prev_tasks = [new_task]
-                all_tasks.append(new_task)
+                if isinstance(new_task, list):
+                    prev_tasks = new_task
+                    all_tasks.extend(new_task)
+                else:
+                    prev_tasks = [new_task]
+                    all_tasks.append(new_task)
                 # only last dependent job will be here, which is what we want
                 job_id_to_tasks[idx] = prev_tasks
         # scheduling judge jobs if needed

--- a/nemo_skills/pipeline/utils/exp.py
+++ b/nemo_skills/pipeline/utils/exp.py
@@ -691,15 +691,26 @@ def add_task(
     else:
         if heterogeneous:
             executors[0].het_group_indices = het_group_indices
-        return exp.add(
-            [
-                run.Script(inline=command, metadata=(metadata if idx == 0 else None))
+        if cluster_config["executor"] == "none":
+            return [
+                exp.add(
+                    run.Script(inline=command, metadata=(metadata if idx == 0 else None)),
+                    executor=executors[idx],
+                    name="nemo-run",
+                    dependencies=task_dependencies if idx == 0 else None,
+                )
                 for idx, command in enumerate(commands)
-            ],
-            executor=executors,
-            name="nemo-run",
-            dependencies=task_dependencies,
-        )
+            ]
+        else:
+            return exp.add(
+                [
+                    run.Script(inline=command, metadata=(metadata if idx == 0 else None))
+                    for idx, command in enumerate(commands)
+                ],
+                executor=executors,
+                name="nemo-run",
+                dependencies=task_dependencies,
+            )
 
 
 def run_exp(exp, cluster_config, sequential=False, dry_run=False):


### PR DESCRIPTION
This PR fixes a `AssertionError: no app_id collisions expected` crash that occurs when running pipelines locally (`executor="none"`) with multiple tasks in a single job step.

**Problem**
When `cluster_config["executor"]` is set to `"none"`, the `nemo_run` local scheduler (via `torchx`) does not support bundling multiple commands into a single job entry the same way Slurm/remote executors do. Submitting them as a bundled list causes internal App ID collisions during the `schedule` phase.

**Changes**

  * **`nemo_skills/pipeline/utils/exp.py`**: Added logic to check if the executor is `"none"`. If so, it now iterates through the commands and adds them as individual jobs to the experiment (returning a list of jobs) instead of bundling them.
  * **`nemo_skills/pipeline/eval.py`**: Updated the `eval` function to handle `add_task` returning a list of jobs. It now checks the type of `new_task` and uses `.extend()` for lists or `.append()` for single objects when updating the task tracking lists.

**Related Error Traceback**

```
  File "/home/user/.local/lib/python3.10/site-packages/nemo_run/run/torchx_backend/schedulers/local.py", line 106, in schedule
    app_id = super().schedule(dryrun_info=dryrun_info)
  File "/home/user/.local/lib/python3.10/site-packages/torchx/schedulers/local_scheduler.py", line 791, in schedule
    app_id not in self._apps
AssertionError: no app_id collisions expected since uuid4 suffix is used
```

Fixes: #1108 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task dependency tracking to properly handle batch task submissions as multiple dependent tasks.
  * Improved multi-command execution handling for independent cluster mode by submitting each command separately with correct dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->