### PR TITLE
SWE-bench: don't pass external environment variables into Apptainer containers

### DIFF
--- a/nemo_skills/inference/eval/swebench.py
+++ b/nemo_skills/inference/eval/swebench.py
@@ -355,7 +355,7 @@ class SweBenchGenerationTask(GenerationTask):
 
         # Launch Apptainer container and execute the command
         apptainer_cmd = (
-            f"apptainer exec --writable-tmpfs --no-mount home,tmp,bind-paths "
+            f"apptainer exec --writable-tmpfs --cleanenv --no-mount home,tmp,bind-paths "
             f"--mount type=bind,src=/nemo_run/code,dst=/nemo_run/code "
             f"--mount type=bind,src=/root,dst=/root_mount,ro "
             f"--mount type=bind,src={self.output_dir},dst=/trajectories_mount "


### PR DESCRIPTION
With this PR, environment variables from the Nemo-Skills container are no longer passed through to the Apptainer containers. This was a security risk, as this gave the agent access to potentially sensitive info.

If an environment variable does need to be passed into the Apptainer containers, one can use the `APPTAINERENV_` prefix. For example, setting an environment variable in the cluster config as `APPTAINERENV_KEY=value` will make it available inside of Apptainer as `KEY=value`. See the [Apptainer docs](https://apptainer.org/docs/user/main/environment_and_metadata.html#apptainerenv-prefix) for more info.

The Slurm SWE-bench tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container environment isolation during evaluation execution by ensuring a clean environment is maintained, preventing potential environment contamination issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->