### PR TITLE
Unified server to work with models not supported by vLLM

### DIFF
--- a/nemo_skills/inference/server/serve_unified.py
+++ b/nemo_skills/inference/server/serve_unified.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CLI wrapper for the Unified NeMo Inference Server.
+
+This module provides a command-line interface compatible with nemo-skills
+server deployment patterns. It translates standard vllm-style CLI arguments
+to the unified server configuration.
+
+Usage via NeMo-Skills:
+
+    # SALM backend (speech-augmented language model)
+    ns eval \\
+        --server_type vllm \\
+        --server_gpus 1 \\
+        --model /path/to/model \\
+        --server_entrypoint "-m nemo_skills.inference.server.serve_unified" \\
+        --server_args "--backend salm"
+
+    # TTS backend (text-to-speech)
+    ns eval \\
+        --server_type vllm \\
+        --server_gpus 1 \\
+        --model /path/to/tts_model \\
+        --server_entrypoint "-m nemo_skills.inference.server.serve_unified" \\
+        --server_args "--backend tts --codec_model /path/to/codec"
+
+    # S2S backend (speech-to-speech)
+    ns eval \\
+        --server_type vllm \\
+        --server_gpus 1 \\
+        --model /path/to/s2s_model \\
+        --server_entrypoint "-m nemo_skills.inference.server.serve_unified" \\
+        --server_args "--backend s2s"
+
+Environment Variables:
+    UNIFIED_SERVER_HOST: Server host (default: 0.0.0.0)
+    UNIFIED_SERVER_PORT: Server port (default: 8000)
+    UNIFIED_SERVER_BACKEND: Backend type (default: salm)
+    UNIFIED_SERVER_MODEL_PATH: Path to model
+    UNIFIED_SERVER_CODEC_MODEL_PATH: Path to codec model
+    UNIFIED_SERVER_BATCH_SIZE: Batch size (default: 8)
+    UNIFIED_SERVER_BATCH_TIMEOUT: Batch timeout (default: 0.1)
+    DEBUG: Enable debug mode
+"""
+
+import argparse
+import inspect
+import os
+import shutil
+import sys
+from typing import Optional
+
+
+def setup_pythonpath(code_path: Optional[str] = None):
+    """Set up PYTHONPATH for NeMo and the unified server.
+
+    Args:
+        code_path: Single path or colon-separated paths to add to PYTHONPATH
+    """
+    paths_to_add = []
+
+    # Add explicit code path(s) if provided (supports colon-separated paths)
+    if code_path:
+        for path in code_path.split(":"):
+            if path and path not in paths_to_add:
+                paths_to_add.append(path)
+
+    # Add recipes path for unified server imports
+    # Look for the recipes directory relative to this file
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # Try to find ns_eval root (go up from nemo_skills/inference/server/)
+    ns_eval_root = os.path.dirname(os.path.dirname(os.path.dirname(this_dir)))
+    if os.path.exists(os.path.join(ns_eval_root, "recipes")):
+        paths_to_add.append(ns_eval_root)
+
+    # Also check /nemo_run/code pattern used in containers
+    if os.path.exists("/nemo_run/code"):
+        paths_to_add.append("/nemo_run/code")
+
+    # Update PYTHONPATH
+    current_path = os.environ.get("PYTHONPATH", "")
+    for path in paths_to_add:
+        if path not in current_path.split(":"):
+            current_path = f"{path}:{current_path}" if current_path else path
+
+    os.environ["PYTHONPATH"] = current_path
+
+    # Also add to sys.path for immediate imports
+    for path in paths_to_add:
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+def apply_safetensors_patch(hack_path: Optional[str]):
+    """Apply safetensors patch if provided (for some NeMo models)."""
+    if not hack_path or not os.path.exists(hack_path):
+        return
+
+    try:
+        import safetensors.torch as st_torch
+
+        dest_path = inspect.getfile(st_torch)
+        os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+        shutil.copyfile(hack_path, dest_path)
+        print(f"[serve_unified] Applied safetensors patch: {hack_path} -> {dest_path}")
+    except Exception as e:
+        print(f"[serve_unified] Warning: Failed to apply safetensors patch: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Unified NeMo Inference Server CLI wrapper",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    # Standard vllm-style arguments (for nemo-skills compatibility)
+    parser.add_argument("--model", required=True, help="Path to the model")
+    parser.add_argument("--num_gpus", type=int, default=1, help="Number of GPUs to use")
+    parser.add_argument("--port", type=int, default=8000, help="Server port")
+
+    # Backend selection
+    parser.add_argument(
+        "--backend",
+        default="salm",
+        choices=["salm", "tts", "s2s", "s2s_incremental", "s2s_session"],
+        help="Backend type: salm (speech-augmented LM), tts (text-to-speech), s2s (speech-to-speech offline), s2s_incremental (frame-by-frame processing), s2s_session (session-aware multi-turn)",
+    )
+
+    # Backend-specific model paths
+    parser.add_argument("--codec_model", default=None, help="Path to codec model (required for TTS, optional for S2S)")
+
+    # Server configuration
+    parser.add_argument("--host", default="0.0.0.0", help="Server host")
+    parser.add_argument("--batch_size", type=int, default=8, help="Maximum batch size")
+    parser.add_argument(
+        "--batch_timeout", type=float, default=0.1, help="Batch timeout in seconds (0 for no batching delay)"
+    )
+
+    # Generation defaults
+    parser.add_argument("--max_new_tokens", type=int, default=512, help="Max tokens to generate")
+    parser.add_argument("--temperature", type=float, default=1.0, help="Generation temperature")
+    parser.add_argument("--top_p", type=float, default=1.0, help="Top-p sampling")
+
+    # Model configuration
+    parser.add_argument("--device", default="cuda", help="Device to use")
+    parser.add_argument("--dtype", default="bfloat16", help="Model dtype")
+
+    # Backend-specific options
+    parser.add_argument("--prompt_format", default=None, help="Prompt format (SALM backend)")
+    parser.add_argument(
+        "--phoneme_input_type", default="predicted", help="Phoneme input type: predicted or gt (TTS backend)"
+    )
+    parser.add_argument(
+        "--decoder_only_model", action="store_true", help="Use decoder-only model architecture (TTS backend)"
+    )
+    parser.add_argument("--use_local_transformer", action="store_true", help="Use local transformer (TTS backend)")
+    parser.add_argument("--top_k", type=int, default=None, help="Top-k sampling (TTS backend)")
+
+    # Environment setup
+    parser.add_argument("--code_path", default=None, help="Path to NeMo source code to add to PYTHONPATH")
+    parser.add_argument("--hack_path", default=None, help="Path to safetensors/torch.py patch file")
+
+    # S2S backend options
+    parser.add_argument(
+        "--ignore_system_prompt",
+        action="store_true",
+        help="Ignore system prompts from requests (for models that don't support them)",
+    )
+    parser.add_argument(
+        "--silence_padding_sec",
+        type=float,
+        default=5.0,
+        help="Seconds of silence to append after audio (S2S backends)",
+    )
+
+    # S2S Incremental backend options
+    parser.add_argument(
+        "--config_path",
+        default=None,
+        help="Path to YAML config file (s2s_incremental backend)",
+    )
+    parser.add_argument(
+        "--llm_checkpoint_path",
+        default=None,
+        help="Path to LLM checkpoint (s2s_incremental backend)",
+    )
+    parser.add_argument(
+        "--tts_checkpoint_path",
+        default=None,
+        help="Path to TTS checkpoint (s2s_incremental backend)",
+    )
+    parser.add_argument(
+        "--speaker_reference",
+        default=None,
+        help="Path to speaker reference audio for TTS (s2s_incremental backend)",
+    )
+    parser.add_argument(
+        "--num_frames_per_inference",
+        type=int,
+        default=1,
+        help="Frames per inference step (s2s_incremental backend)",
+    )
+    parser.add_argument(
+        "--no_decode_audio",
+        action="store_true",
+        help="Disable audio output (s2s_incremental backend)",
+    )
+
+    # Session management options (s2s_session backend)
+    parser.add_argument(
+        "--session_ttl",
+        type=float,
+        default=300.0,
+        help="Session time-to-live in seconds (s2s_session backend)",
+    )
+    parser.add_argument(
+        "--max_sessions",
+        type=int,
+        default=100,
+        help="Maximum number of concurrent sessions (s2s_session backend)",
+    )
+    parser.add_argument(
+        "--session_artifacts_dir",
+        type=str,
+        default=None,
+        help="Directory to save session artifacts (input/output audio, JSON). Default: /tmp/s2s_sessions",
+    )
+    parser.add_argument(
+        "--no_save_session_artifacts",
+        action="store_true",
+        help="Disable saving session artifacts to disk",
+    )
+    parser.add_argument(
+        "--output_frame_alignment",
+        action="store_true",
+        help="Include per-frame alignment data in debug output (user/agent/ASR per frame)",
+    )
+
+    # Debug
+    parser.add_argument("--debug", action="store_true", help="Enable debug mode")
+
+    # Parse known args, allowing extra args to be passed through
+    args, extra_args = parser.parse_known_args()
+
+    # Setup environment
+    setup_pythonpath(args.code_path)
+    apply_safetensors_patch(args.hack_path)
+
+    # Set environment variables
+    os.environ["UNIFIED_SERVER_HOST"] = args.host
+    os.environ["UNIFIED_SERVER_PORT"] = str(args.port)
+    os.environ["UNIFIED_SERVER_BACKEND"] = args.backend
+    os.environ["UNIFIED_SERVER_MODEL_PATH"] = args.model
+    os.environ["UNIFIED_SERVER_BATCH_SIZE"] = str(args.batch_size)
+    os.environ["UNIFIED_SERVER_BATCH_TIMEOUT"] = str(args.batch_timeout)
+    os.environ["UNIFIED_SERVER_MAX_NEW_TOKENS"] = str(args.max_new_tokens)
+    os.environ["UNIFIED_SERVER_TEMPERATURE"] = str(args.temperature)
+    os.environ["UNIFIED_SERVER_TOP_P"] = str(args.top_p)
+
+    if args.codec_model:
+        os.environ["UNIFIED_SERVER_CODEC_MODEL_PATH"] = args.codec_model
+
+    if args.debug:
+        os.environ["DEBUG"] = "1"
+
+    # Set CUDA devices
+    os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(args.num_gpus))
+
+    # Build extra config for backend-specific options
+    extra_config = {}
+
+    if args.prompt_format:
+        extra_config["prompt_format"] = args.prompt_format
+
+    if args.backend == "tts":
+        extra_config["decoder_only_model"] = args.decoder_only_model
+        extra_config["phoneme_input_type"] = args.phoneme_input_type
+        extra_config["use_local_transformer"] = args.use_local_transformer
+        if args.top_k:
+            extra_config["top_k"] = args.top_k
+
+    # S2S backend options
+    if args.backend in ("s2s", "s2s_incremental", "s2s_session"):
+        extra_config["ignore_system_prompt"] = args.ignore_system_prompt
+        if args.silence_padding_sec != 5.0:
+            extra_config["silence_padding_sec"] = args.silence_padding_sec
+
+    # S2S Incremental/Session backend options (shared config)
+    if args.backend in ("s2s_incremental", "s2s_session"):
+        if args.config_path:
+            extra_config["config_path"] = args.config_path
+        if args.llm_checkpoint_path:
+            extra_config["llm_checkpoint_path"] = args.llm_checkpoint_path
+        if args.tts_checkpoint_path:
+            extra_config["tts_checkpoint_path"] = args.tts_checkpoint_path
+        if args.speaker_reference:
+            extra_config["speaker_reference"] = args.speaker_reference
+        if args.num_frames_per_inference != 1:
+            extra_config["num_frames_per_inference"] = args.num_frames_per_inference
+        if args.no_decode_audio:
+            extra_config["decode_audio"] = False
+        # Artifacts and alignment (available for both backends)
+        if args.session_artifacts_dir:
+            extra_config["session_artifacts_dir"] = args.session_artifacts_dir
+        extra_config["save_session_artifacts"] = not args.no_save_session_artifacts
+        extra_config["output_frame_alignment"] = args.output_frame_alignment
+
+    # S2S Session backend options
+    if args.backend == "s2s_session":
+        extra_config["session_ttl"] = args.session_ttl
+        extra_config["max_sessions"] = args.max_sessions
+
+    # Print configuration
+    print("=" * 60)
+    print("[serve_unified] Starting Unified NeMo Inference Server")
+    print("=" * 60)
+    print(f"  Backend: {args.backend}")
+    print(f"  Model: {args.model}")
+    if args.codec_model:
+        print(f"  Codec Model: {args.codec_model}")
+    print(f"  Port: {args.port}")
+    print(f"  GPUs: {args.num_gpus}")
+    print(f"  Batch Size: {args.batch_size}")
+    print(f"  Batch Timeout: {args.batch_timeout}s")
+    print(f"  Device: {args.device}")
+    print(f"  Dtype: {args.dtype}")
+    if args.backend in ("s2s_incremental", "s2s_session"):
+        if args.config_path:
+            print(f"  Config Path: {args.config_path}")
+        if args.llm_checkpoint_path:
+            print(f"  LLM Checkpoint: {args.llm_checkpoint_path}")
+        if args.speaker_reference:
+            print(f"  Speaker Reference: {args.speaker_reference}")
+        print(f"  Frames per Inference: {args.num_frames_per_inference}")
+        print(f"  Decode Audio: {not args.no_decode_audio}")
+        print(f"  Save Artifacts: {not args.no_save_session_artifacts}")
+        if args.session_artifacts_dir:
+            print(f"  Artifacts Dir: {args.session_artifacts_dir}")
+        else:
+            print("  Artifacts Dir: /tmp/s2s_sessions (default)")
+        print(f"  Output Frame Alignment: {args.output_frame_alignment}")
+    if args.backend == "s2s_session":
+        print(f"  Session TTL: {args.session_ttl}s")
+        print(f"  Max Sessions: {args.max_sessions}")
+    if extra_config:
+        print(f"  Extra Config: {extra_config}")
+    print("=" * 60)
+
+    # Import and run the unified server
+    try:
+        import uvicorn
+
+        from recipes.multimodal.server.unified_server import create_app
+
+        app = create_app(
+            backend_type=args.backend,
+            model_path=args.model,
+            codec_model_path=args.codec_model or "",
+            batch_size=args.batch_size,
+            batch_timeout=args.batch_timeout,
+            device=args.device,
+            dtype=args.dtype,
+            extra_config=extra_config if extra_config else None,
+        )
+
+        uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+
+    except ImportError as e:
+        print(f"[serve_unified] Error: Failed to import unified server: {e}")
+        print("[serve_unified] Make sure the recipes.multimodal.server package is in PYTHONPATH")
+        sys.exit(1)
+    except Exception as e:
+        print(f"[serve_unified] Error: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/multimodal/server/__init__.py
+++ b/recipes/multimodal/server/__init__.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unified NeMo Inference Server package.
+
+Provides a pluggable FastAPI server that supports multiple NeMo model backends:
+- SALM: Speech-Augmented Language Model (text output from text/audio input)
+- TTS: Text-to-Speech (audio output from text input)
+- S2S: Speech-to-Speech (text+audio output from audio input)
+"""
+
+from .backends import (
+    BackendConfig,
+    GenerationRequest,
+    GenerationResult,
+    InferenceBackend,
+    get_backend,
+)
+
+__all__ = [
+    "InferenceBackend",
+    "GenerationRequest",
+    "GenerationResult",
+    "BackendConfig",
+    "get_backend",
+]

--- a/recipes/multimodal/server/backends/__init__.py
+++ b/recipes/multimodal/server/backends/__init__.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Backend implementations for the Unified NeMo Inference Server.
+
+Available backends:
+- salm: Speech-Augmented Language Model (text output from text/audio input)
+- tts: Text-to-Speech using MagpieTTS (audio output from text input)
+- s2s: Speech-to-Speech using DuplexS2S offline (text output from audio input)
+- s2s_incremental: Speech-to-Speech using NemotronVoiceChat incremental (text+audio from audio)
+- s2s_session: Speech-to-Speech with session support for multi-turn conversations
+"""
+
+from .base import BackendConfig, GenerationRequest, GenerationResult, InferenceBackend, Modality
+
+__all__ = [
+    "InferenceBackend",
+    "GenerationRequest",
+    "GenerationResult",
+    "BackendConfig",
+    "Modality",
+    "get_backend",
+    "list_backends",
+]
+
+# Registry of available backends
+BACKEND_REGISTRY = {
+    "salm": ("salm_backend", "SALMBackend"),
+    "tts": ("tts_backend", "TTSBackend"),
+    "s2s": ("s2s_backend", "S2SBackend"),
+    "s2s_incremental": ("s2s_incremental_backend", "S2SIncrementalBackend"),
+    "s2s_session": ("s2s_session_backend", "S2SSessionBackend"),
+}
+
+
+def list_backends() -> list:
+    """Return list of available backend names."""
+    return list(BACKEND_REGISTRY.keys())
+
+
+def get_backend(backend_name: str) -> type:
+    """
+    Get backend class by name with lazy loading.
+
+    Args:
+        backend_name: One of 'salm', 'tts', 's2s'
+
+    Returns:
+        Backend class (not instance)
+
+    Raises:
+        ValueError: If backend name is unknown
+        ImportError: If backend dependencies are not available
+    """
+    if backend_name not in BACKEND_REGISTRY:
+        available = ", ".join(BACKEND_REGISTRY.keys())
+        raise ValueError(f"Unknown backend: '{backend_name}'. Available backends: {available}")
+
+    module_name, class_name = BACKEND_REGISTRY[backend_name]
+
+    import importlib
+
+    try:
+        module = importlib.import_module(f".{module_name}", package=__name__)
+        return getattr(module, class_name)
+    except ImportError as e:
+        raise ImportError(
+            f"Failed to import backend '{backend_name}'. Make sure required dependencies are installed. Error: {e}"
+        ) from e

--- a/recipes/multimodal/server/backends/base.py
+++ b/recipes/multimodal/server/backends/base.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Abstract base class for inference backends.
+
+All model backends (SALM, TTS, S2S, etc.) must implement this interface
+to be usable with the unified inference server.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Set
+
+
+class Modality(str, Enum):
+    """Supported input/output modalities."""
+
+    TEXT = "text"
+    AUDIO_IN = "audio_in"
+    AUDIO_OUT = "audio_out"
+
+
+@dataclass
+class BackendConfig:
+    """Base configuration for all backends."""
+
+    model_path: str
+    device: str = "cuda"
+    dtype: str = "bfloat16"
+
+    # Generation defaults
+    max_new_tokens: int = 512
+    temperature: float = 1.0
+    top_p: float = 1.0
+    top_k: Optional[int] = None
+
+    # Additional model-specific configs passed through
+    extra_config: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "BackendConfig":
+        """Create config from dictionary, extracting known fields."""
+        known_fields = {f.name for f in cls.__dataclass_fields__.values()}
+        known = {k: v for k, v in d.items() if k in known_fields and k != "extra_config"}
+        extra = {k: v for k, v in d.items() if k not in known_fields}
+        return cls(**known, extra_config=extra)
+
+
+@dataclass
+class GenerationRequest:
+    """
+    A single generation request.
+
+    Supports text and/or audio inputs depending on the backend's capabilities.
+    """
+
+    # Text inputs
+    text: Optional[str] = None
+    system_prompt: Optional[str] = None
+    user_prompt: Optional[str] = None
+
+    # Audio input (raw bytes or file path)
+    audio_bytes: Optional[bytes] = None
+    audio_path: Optional[str] = None
+    sample_rate: int = 16000
+
+    # Multi-turn audio inputs (list of audio bytes or paths)
+    audio_bytes_list: Optional[List[bytes]] = None
+    audio_paths: Optional[List[str]] = None
+
+    # Generation parameters (override backend defaults)
+    max_new_tokens: Optional[int] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    seed: Optional[int] = None
+
+    # Additional parameters
+    extra_params: Dict[str, Any] = field(default_factory=dict)
+
+    # Request tracking
+    request_id: Optional[str] = None
+
+
+@dataclass
+class GenerationResult:
+    """
+    Result from a generation request.
+
+    Contains text output and optionally audio output, plus metadata.
+    """
+
+    # Text output
+    text: str = ""
+
+    # Audio output (raw bytes, can be encoded to base64 for JSON)
+    audio_bytes: Optional[bytes] = None
+    audio_sample_rate: int = 16000
+    audio_format: str = "wav"
+
+    # Metadata
+    request_id: Optional[str] = None
+    num_tokens_generated: int = 0
+    generation_time_ms: float = 0.0
+
+    # Debug info (optional, backend-specific)
+    debug_info: Optional[Dict[str, Any]] = None
+
+    # Error handling
+    error: Optional[str] = None
+
+    def is_success(self) -> bool:
+        return self.error is None
+
+
+class InferenceBackend(ABC):
+    """
+    Abstract base class for inference backends.
+
+    Implementations must provide:
+    - load_model(): Initialize the model from config
+    - generate(): Run inference on a batch of requests
+    - supported_modalities: What input/output types are supported
+
+    The unified server uses this interface to handle any backend uniformly.
+    """
+
+    def __init__(self, config: BackendConfig):
+        """
+        Initialize the backend with configuration.
+
+        Args:
+            config: Backend configuration including model path and generation defaults
+        """
+        self.config = config
+        self._model = None
+        self._is_loaded = False
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the backend name (e.g., 'salm', 'tts', 's2s')."""
+        pass
+
+    @property
+    @abstractmethod
+    def supported_modalities(self) -> Set[Modality]:
+        """
+        Return the set of supported modalities.
+
+        Examples:
+        - SALM: {TEXT, AUDIO_IN} - text output from text/audio input
+        - TTS: {TEXT, AUDIO_OUT} - audio output from text input
+        - S2S: {TEXT, AUDIO_IN, AUDIO_OUT} - audio+text output from audio input
+        """
+        pass
+
+    @abstractmethod
+    def load_model(self) -> None:
+        """
+        Load and initialize the model.
+
+        Should set self._model and self._is_loaded = True on success.
+        Called once during server startup.
+
+        Raises:
+            RuntimeError: If model loading fails
+        """
+        pass
+
+    @abstractmethod
+    def generate(self, requests: List[GenerationRequest]) -> List[GenerationResult]:
+        """
+        Run inference on a batch of requests.
+
+        Args:
+            requests: List of generation requests to process
+
+        Returns:
+            List of generation results, one per request (same order)
+
+        Note:
+            - Implementations should handle batching internally
+            - Each result should have request_id matching the input
+            - On error, set result.error instead of raising
+        """
+        pass
+
+    @property
+    def is_loaded(self) -> bool:
+        """Check if the model is loaded and ready."""
+        return self._is_loaded
+
+    def health_check(self) -> Dict[str, Any]:
+        """
+        Return health status information.
+
+        Override to add backend-specific health info.
+        """
+        return {
+            "backend": self.name,
+            "model_loaded": self._is_loaded,
+            "model_path": self.config.model_path,
+            "device": self.config.device,
+            "modalities": [m.value for m in self.supported_modalities],
+        }
+
+    def get_generation_params(self, request: GenerationRequest) -> Dict[str, Any]:
+        """
+        Get effective generation parameters, merging request with config defaults.
+        """
+        return {
+            "max_new_tokens": request.max_new_tokens or self.config.max_new_tokens,
+            "temperature": request.temperature or self.config.temperature,
+            "top_p": request.top_p or self.config.top_p,
+            "top_k": request.top_k or self.config.top_k,
+        }
+
+    def validate_request(self, request: GenerationRequest) -> Optional[str]:
+        """
+        Validate a request against supported modalities.
+
+        Returns:
+            Error message if invalid, None if valid
+        """
+        modalities = self.supported_modalities
+
+        has_text_input = request.text is not None
+        has_audio_input = request.audio_bytes is not None or request.audio_path is not None
+
+        # Check input modalities
+        if has_audio_input and Modality.AUDIO_IN not in modalities:
+            return f"Backend '{self.name}' does not support audio input"
+
+        if not has_text_input and not has_audio_input:
+            return "Request must have either text or audio input"
+
+        return None

--- a/recipes/multimodal/server/session_manager.py
+++ b/recipes/multimodal/server/session_manager.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Session manager for S2S session backend.
+
+Manages session state (LLM KV cache, frame index, etc.) across HTTP requests
+to enable multi-turn conversations.
+"""
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import torch
+
+
+@dataclass
+class TurnData:
+    """Data for a single turn in a conversation."""
+
+    turn_idx: int
+    user_audio_bytes: Optional[bytes] = None  # Input audio from user
+    agent_audio_bytes: Optional[bytes] = None  # Output audio from agent
+    agent_text: str = ""  # Text response for this turn
+    user_duration_sec: float = 0.0  # Duration of user audio
+    agent_duration_sec: float = 0.0  # Duration of agent audio
+
+
+@dataclass
+class SessionState:
+    """State that persists between turns in a session."""
+
+    session_id: str
+
+    # LLM state
+    llm_cache: Any = None  # DynamicCache (for non-Mamba models)
+    input_embeds_history: Any = None  # List of embeddings (for Mamba models)
+    frame_idx: int = 0
+
+    # Token history (for turn-taking logic)
+    gen_text: Optional[torch.Tensor] = None
+    gen_asr_text: Optional[torch.Tensor] = None
+
+    # Audio buffer state
+    audio_buffer: Optional[torch.Tensor] = None
+    buffer_fill_level: int = 0
+
+    # Turn tracking
+    turn_count: int = 0
+
+    # Per-turn data for session audio generation
+    turns: List[TurnData] = field(default_factory=list)
+
+    # Timestamps
+    created_at: float = field(default_factory=time.time)
+    last_accessed: float = field(default_factory=time.time)
+
+    def touch(self):
+        """Update last_accessed timestamp."""
+        self.last_accessed = time.time()
+
+
+class SessionManager:
+    """
+    Manages session state for S2S multi-turn conversations.
+
+    Thread-safe implementation with TTL-based cleanup.
+    """
+
+    def __init__(self, ttl_seconds: float = 300.0, max_sessions: int = 100):
+        """
+        Initialize SessionManager.
+
+        Args:
+            ttl_seconds: Time-to-live for sessions in seconds (default: 5 minutes)
+            max_sessions: Maximum number of concurrent sessions
+        """
+        self.ttl_seconds = ttl_seconds
+        self.max_sessions = max_sessions
+        self.sessions: Dict[str, SessionState] = {}
+        self._lock = threading.RLock()
+
+    def create_session(self, session_id: Optional[str] = None) -> SessionState:
+        """
+        Create a new session.
+
+        Args:
+            session_id: Optional session ID. If None, generates a UUID.
+
+        Returns:
+            New SessionState object
+        """
+        with self._lock:
+            if session_id is None:
+                session_id = str(uuid.uuid4())
+
+            # Clean up expired sessions first
+            self._cleanup_expired_locked()
+
+            # Evict oldest if at capacity
+            if len(self.sessions) >= self.max_sessions:
+                self._evict_oldest_locked()
+
+            state = SessionState(session_id=session_id)
+            self.sessions[session_id] = state
+            print(f"[SessionManager] Created session: {session_id}")
+            return state
+
+    def get_session(self, session_id: str) -> Optional[SessionState]:
+        """
+        Get existing session by ID.
+
+        Args:
+            session_id: Session ID to look up
+
+        Returns:
+            SessionState if found and not expired, None otherwise
+        """
+        with self._lock:
+            state = self.sessions.get(session_id)
+            if state is None:
+                return None
+
+            # Check if expired
+            if time.time() - state.last_accessed > self.ttl_seconds:
+                print(f"[SessionManager] Session expired: {session_id}")
+                del self.sessions[session_id]
+                return None
+
+            state.touch()
+            return state
+
+    def get_or_create_session(self, session_id: Optional[str] = None) -> SessionState:
+        """
+        Get existing session or create new one.
+
+        Args:
+            session_id: Session ID. If None, creates new session.
+
+        Returns:
+            SessionState (existing or new)
+        """
+        if session_id:
+            state = self.get_session(session_id)
+            if state is not None:
+                return state
+
+        return self.create_session(session_id)
+
+    def save_session(self, session_id: str, state: SessionState):
+        """
+        Save/update session state.
+
+        Args:
+            session_id: Session ID
+            state: SessionState to save
+        """
+        with self._lock:
+            state.touch()
+            self.sessions[session_id] = state
+
+    def delete_session(self, session_id: str) -> bool:
+        """
+        Delete a session.
+
+        Args:
+            session_id: Session ID to delete
+
+        Returns:
+            True if session was deleted, False if not found
+        """
+        with self._lock:
+            if session_id in self.sessions:
+                del self.sessions[session_id]
+                print(f"[SessionManager] Deleted session: {session_id}")
+                return True
+            return False
+
+    def get_session_info(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Get session info without full state.
+
+        Args:
+            session_id: Session ID
+
+        Returns:
+            Dict with session metadata or None
+        """
+        with self._lock:
+            state = self.sessions.get(session_id)
+            if state is None:
+                return None
+
+            return {
+                "session_id": state.session_id,
+                "frame_idx": state.frame_idx,
+                "turn_count": state.turn_count,
+                "created_at": state.created_at,
+                "last_accessed": state.last_accessed,
+                "has_llm_cache": state.llm_cache is not None,
+                "has_input_embeds_history": state.input_embeds_history is not None
+                and len(state.input_embeds_history) > 0,
+            }
+
+    def list_sessions(self) -> list:
+        """List all active session IDs."""
+        with self._lock:
+            return list(self.sessions.keys())
+
+    def cleanup_expired(self):
+        """Clean up expired sessions (called periodically)."""
+        with self._lock:
+            self._cleanup_expired_locked()
+
+    def _cleanup_expired_locked(self):
+        """Clean up expired sessions (must hold lock)."""
+        now = time.time()
+        expired = [sid for sid, state in self.sessions.items() if now - state.last_accessed > self.ttl_seconds]
+        for sid in expired:
+            print(f"[SessionManager] Cleaning up expired session: {sid}")
+            del self.sessions[sid]
+
+    def _evict_oldest_locked(self):
+        """Evict oldest session to make room (must hold lock)."""
+        if not self.sessions:
+            return
+
+        oldest_id = min(self.sessions.keys(), key=lambda sid: self.sessions[sid].last_accessed)
+        print(f"[SessionManager] Evicting oldest session: {oldest_id}")
+        del self.sessions[oldest_id]
+
+    def __len__(self) -> int:
+        """Return number of active sessions."""
+        with self._lock:
+            return len(self.sessions)

--- a/recipes/multimodal/server/unified_server.py
+++ b/recipes/multimodal/server/unified_server.py
@@ -1,0 +1,745 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unified NeMo Inference Server with OpenAI-compatible API.
+
+Supports multiple NeMo model backends:
+- SALM: Speech-Augmented Language Model
+- TTS: Text-to-Speech (MagpieTTS)
+- S2S: Speech-to-Speech (Duplex)
+
+Exposes only /v1/chat/completions endpoint for OpenAI compatibility.
+
+Usage:
+    python unified_server.py --backend s2s --model /path/to/model
+"""
+
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+
+from .backends import BackendConfig, GenerationRequest, GenerationResult, get_backend
+from .session_manager import SessionManager
+
+# Configuration from environment
+HOST = os.getenv("UNIFIED_SERVER_HOST", "0.0.0.0")
+PORT = int(os.getenv("UNIFIED_SERVER_PORT", "8000"))
+BACKEND_TYPE = os.getenv("UNIFIED_SERVER_BACKEND", "salm")
+MODEL_PATH = os.getenv("UNIFIED_SERVER_MODEL_PATH", "")
+CODEC_MODEL_PATH = os.getenv("UNIFIED_SERVER_CODEC_MODEL_PATH", "")
+
+# Batching configuration
+BATCH_SIZE = int(os.getenv("UNIFIED_SERVER_BATCH_SIZE", "8"))
+BATCH_TIMEOUT = float(os.getenv("UNIFIED_SERVER_BATCH_TIMEOUT", "0.1"))
+
+# Generation defaults
+MAX_NEW_TOKENS = int(os.getenv("UNIFIED_SERVER_MAX_NEW_TOKENS", "512"))
+TEMPERATURE = float(os.getenv("UNIFIED_SERVER_TEMPERATURE", "1.0"))
+TOP_P = float(os.getenv("UNIFIED_SERVER_TOP_P", "1.0"))
+
+# Debug
+DEBUG = os.getenv("DEBUG", "").lower() in ("true", "1", "yes", "on")
+
+
+@dataclass
+class PendingRequest:
+    """Container for a pending batched request."""
+
+    request: GenerationRequest
+    future: asyncio.Future
+    timestamp: float
+
+
+class RequestBatcher:
+    """Manages request batching with configurable delay."""
+
+    def __init__(self, backend, batch_size: int, batch_timeout: float):
+        self.backend = backend
+        self.batch_size = batch_size
+        self.batch_timeout = batch_timeout
+        self.pending_requests: List[PendingRequest] = []
+        self.lock = asyncio.Lock()
+        self.timeout_task: Optional[asyncio.Task] = None
+        self.processing = False
+
+        # Stats
+        self.total_requests = 0
+        self.total_batches = 0
+
+    async def add_request(self, request: GenerationRequest) -> GenerationResult:
+        """Add a request and wait for result."""
+        future = asyncio.Future()
+        pending = PendingRequest(request=request, future=future, timestamp=time.time())
+
+        async with self.lock:
+            self.pending_requests.append(pending)
+
+            # Check if we should process immediately
+            if len(self.pending_requests) >= self.batch_size:
+                if DEBUG:
+                    print(f"[Batcher] Batch full ({self.batch_size}), processing immediately")
+                asyncio.create_task(self._process_batch())
+            elif self.batch_timeout == 0:
+                # No delay mode
+                asyncio.create_task(self._process_batch())
+            elif self.timeout_task is None or self.timeout_task.done():
+                # Schedule timeout
+                self.timeout_task = asyncio.create_task(self._timeout_handler())
+
+        return await future
+
+    async def _timeout_handler(self):
+        """Handle batch timeout."""
+        await asyncio.sleep(self.batch_timeout)
+        async with self.lock:
+            if self.pending_requests and not self.processing:
+                if DEBUG:
+                    print(f"[Batcher] Timeout, processing {len(self.pending_requests)} requests")
+                asyncio.create_task(self._process_batch())
+
+    async def _process_batch(self):
+        """Process pending requests as a batch."""
+        async with self.lock:
+            if not self.pending_requests or self.processing:
+                return
+
+            self.processing = True
+            batch = self.pending_requests[: self.batch_size]
+            self.pending_requests = self.pending_requests[self.batch_size :]
+
+        try:
+            # Extract requests
+            requests = [p.request for p in batch]
+
+            if DEBUG:
+                print(f"[Batcher] Processing batch of {len(requests)} requests")
+
+            # Run inference in thread pool to not block event loop
+            loop = asyncio.get_event_loop()
+            results = await loop.run_in_executor(None, self.backend.generate, requests)
+
+            # Complete futures
+            for pending, result in zip(batch, results):
+                if not pending.future.done():
+                    pending.future.set_result(result)
+
+            # Update stats
+            self.total_requests += len(batch)
+            self.total_batches += 1
+
+        except Exception as e:
+            # Set exception for all pending requests
+            for pending in batch:
+                if not pending.future.done():
+                    pending.future.set_exception(e)
+        finally:
+            async with self.lock:
+                self.processing = False
+                # Process more if pending
+                if self.pending_requests:
+                    if self.batch_timeout == 0 or len(self.pending_requests) >= self.batch_size:
+                        asyncio.create_task(self._process_batch())
+                    elif self.timeout_task is None or self.timeout_task.done():
+                        self.timeout_task = asyncio.create_task(self._timeout_handler())
+
+
+# Global state
+backend_instance = None
+request_batcher = None
+session_manager = None
+server_config = {}
+
+
+def extract_audio_from_messages(messages: List[Dict[str, Any]]) -> List[bytes]:
+    """Extract all audio bytes from OpenAI-format messages.
+
+    Looks for audio_url in message content with format:
+    {"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,..."}}
+
+    Returns a list of audio bytes (one per audio_url found), preserving message order.
+    """
+    audio_list = []
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "audio_url":
+                    audio_url = item.get("audio_url", {})
+                    url = audio_url.get("url", "")
+                    # Parse data URL: data:audio/wav;base64,<base64_data>
+                    match = re.match(r"data:audio/\w+;base64,(.+)", url)
+                    if match:
+                        audio_list.append(base64.b64decode(match.group(1)))
+    return audio_list
+
+
+def extract_text_from_messages(messages: List[Dict[str, Any]]) -> str:
+    """Extract text content from OpenAI-format messages."""
+    texts = []
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, str):
+            if content:
+                texts.append(content)
+        elif isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    text = item.get("text", "")
+                    if text:
+                        texts.append(text)
+                elif isinstance(item, str):
+                    texts.append(item)
+    return " ".join(texts)
+
+
+def extract_system_prompt(messages: List[Dict[str, Any]]) -> Optional[str]:
+    """Extract system prompt from messages."""
+    for message in messages:
+        if message.get("role") == "system":
+            content = message.get("content")
+            if isinstance(content, str):
+                return content
+            elif isinstance(content, list):
+                texts = [
+                    item.get("text", "") for item in content if isinstance(item, dict) and item.get("type") == "text"
+                ]
+                return " ".join(texts) if texts else None
+    return None
+
+
+def create_app(
+    backend_type: str = BACKEND_TYPE,
+    model_path: str = MODEL_PATH,
+    codec_model_path: str = CODEC_MODEL_PATH,
+    batch_size: int = BATCH_SIZE,
+    batch_timeout: float = BATCH_TIMEOUT,
+    device: str = "cuda",
+    dtype: str = "bfloat16",
+    extra_config: Dict[str, Any] = None,
+) -> FastAPI:
+    """Create and configure the FastAPI app."""
+    global backend_instance, request_batcher, session_manager, server_config
+
+    # Extract server-level config from extra_config
+    ignore_system_prompt = extra_config.pop("ignore_system_prompt", False) if extra_config else False
+    session_ttl = extra_config.pop("session_ttl", 300.0) if extra_config else 300.0
+    max_sessions = extra_config.pop("max_sessions", 100) if extra_config else 100
+
+    app = FastAPI(
+        title="Unified NeMo Inference Server",
+        description=f"OpenAI-compatible API for NeMo model inference ({backend_type} backend)",
+        version="1.0.0",
+    )
+
+    # Store config
+    server_config = {
+        "backend_type": backend_type,
+        "model_path": model_path,
+        "codec_model_path": codec_model_path,
+        "batch_size": batch_size,
+        "batch_timeout": batch_timeout,
+        "device": device,
+        "dtype": dtype,
+        "ignore_system_prompt": ignore_system_prompt,
+        "session_ttl": session_ttl,
+        "max_sessions": max_sessions,
+    }
+
+    @app.on_event("startup")
+    async def startup():
+        global backend_instance, request_batcher, session_manager
+
+        # Build backend config
+        config_dict = {
+            "model_path": model_path,
+            "device": device,
+            "dtype": dtype,
+            "max_new_tokens": MAX_NEW_TOKENS,
+            "temperature": TEMPERATURE,
+            "top_p": TOP_P,
+        }
+
+        # Add backend-specific config
+        if codec_model_path:
+            config_dict["codec_model_path"] = codec_model_path
+
+        if extra_config:
+            config_dict.update(extra_config)
+
+        config = BackendConfig.from_dict(config_dict)
+
+        # Get and instantiate backend
+        print(f"[Server] Initializing {backend_type} backend...")
+        BackendClass = get_backend(backend_type)
+        backend_instance = BackendClass(config)
+
+        # Load model
+        backend_instance.load_model()
+
+        # Create batcher
+        request_batcher = RequestBatcher(backend_instance, batch_size, batch_timeout)
+
+        # Initialize session manager for session-aware backends
+        if backend_type == "s2s_session":
+            session_manager = SessionManager(ttl_seconds=session_ttl, max_sessions=max_sessions)
+            print(f"[Server] Session manager initialized (TTL: {session_ttl}s, max: {max_sessions})")
+
+        print("[Server] Ready!")
+        print(f"  Backend: {backend_type}")
+        print(f"  Model: {model_path}")
+        print(f"  Batch size: {batch_size}")
+        print(f"  Batch timeout: {batch_timeout}s")
+        if ignore_system_prompt:
+            print("  System prompts: IGNORED")
+
+    @app.get("/")
+    async def root():
+        """Root endpoint with server info."""
+        endpoints = ["/v1/chat/completions", "/health"]
+        if backend_type == "s2s_session":
+            endpoints.extend(["/v1/sessions", "/v1/sessions/{session_id}"])
+        return {
+            "service": "Unified NeMo Inference Server",
+            "version": "1.0.0",
+            "backend": server_config.get("backend_type"),
+            "model": server_config.get("model_path"),
+            "endpoints": endpoints,
+        }
+
+    # Session management endpoints (only for s2s_session backend)
+    @app.get("/v1/sessions")
+    async def list_sessions():
+        """List all active sessions."""
+        if session_manager is None:
+            raise HTTPException(status_code=404, detail="Session management not enabled for this backend")
+        return {
+            "sessions": session_manager.list_sessions(),
+            "count": len(session_manager),
+            "ttl_seconds": session_manager.ttl_seconds,
+        }
+
+    @app.get("/v1/sessions/{session_id}")
+    async def get_session(session_id: str):
+        """Get session info."""
+        if session_manager is None:
+            raise HTTPException(status_code=404, detail="Session management not enabled for this backend")
+        info = session_manager.get_session_info(session_id)
+        if info is None:
+            raise HTTPException(status_code=404, detail=f"Session not found: {session_id}")
+        return info
+
+    @app.delete("/v1/sessions/{session_id}")
+    async def delete_session(session_id: str):
+        """Delete a session and generate final session audio."""
+        if session_manager is None:
+            raise HTTPException(status_code=404, detail="Session management not enabled for this backend")
+
+        # Get session state before deleting
+        session_state = session_manager.get_session(session_id)
+        if session_state is None:
+            raise HTTPException(status_code=404, detail=f"Session not found: {session_id}")
+
+        # Call on_session_close to generate session audio
+        close_result = {}
+        if backend_instance is not None and hasattr(backend_instance, "on_session_close"):
+            try:
+                close_result = backend_instance.on_session_close(session_state)
+            except Exception as e:
+                print(f"[Server] Error in on_session_close: {e}")
+                import traceback
+
+                traceback.print_exc()
+
+        # Now delete the session
+        session_manager.delete_session(session_id)
+
+        return {"success": True, "session_id": session_id, **close_result}
+
+    @app.get("/health")
+    async def health():
+        """Health check endpoint."""
+        if backend_instance is None:
+            return JSONResponse(status_code=503, content={"status": "not_ready", "error": "Backend not initialized"})
+
+        health_info = backend_instance.health_check()
+        health_info["status"] = "healthy" if backend_instance.is_loaded else "not_ready"
+        health_info["timestamp"] = datetime.now().isoformat()
+
+        return health_info
+
+    @app.get("/v1/models")
+    async def list_models():
+        """OpenAI-compatible models endpoint."""
+        model_id = server_config.get("model_path", "unknown") if server_config else "unknown"
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": model_id,
+                    "object": "model",
+                    "created": int(time.time()),
+                    "owned_by": "nvidia",
+                }
+            ],
+        }
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Dict[str, Any]):
+        """OpenAI-compatible chat completions endpoint with audio support.
+
+        Accepts messages in OpenAI format with audio_url for audio content:
+        {
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": [
+                    {"type": "text", "text": "..."},
+                    {"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,..."}}
+                ]}
+            ],
+            "max_tokens": 512,
+            "temperature": 1.0,
+            "extra_body": {"session_id": "optional-session-id"}
+        }
+        """
+        if backend_instance is None or not backend_instance.is_loaded:
+            raise HTTPException(status_code=503, detail="Model not loaded")
+
+        try:
+            messages = request.get("messages", [])
+            if not messages:
+                raise HTTPException(status_code=400, detail="No messages provided")
+
+            # Extract session_id from extra_body (for s2s_session backend)
+            extra_body = request.get("extra_body", {})
+            session_id = extra_body.get("session_id") if isinstance(extra_body, dict) else None
+
+            # Extract components from messages
+            audio_bytes_list = extract_audio_from_messages(messages)
+            text = extract_text_from_messages(messages)
+            system_prompt = extract_system_prompt(messages)
+
+            # Honor ignore_system_prompt setting
+            if server_config.get("ignore_system_prompt", False):
+                system_prompt = None
+
+            # Get generation parameters
+            max_tokens = request.get("max_tokens", MAX_NEW_TOKENS)
+            temperature = request.get("temperature", TEMPERATURE)
+            top_p = request.get("top_p", TOP_P)
+            seed = request.get("seed")
+
+            # Create generation request
+            # Use audio_bytes_list for multi-turn, or single audio_bytes for backwards compat
+            gen_request = GenerationRequest(
+                text=text if text else None,
+                system_prompt=system_prompt,
+                audio_bytes=audio_bytes_list[0] if len(audio_bytes_list) == 1 else None,
+                audio_bytes_list=audio_bytes_list if len(audio_bytes_list) > 1 else None,
+                max_new_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                seed=seed,
+                request_id=hashlib.md5(f"{time.time()}".encode()).hexdigest()[:8],
+            )
+
+            # Validate request
+            error = backend_instance.validate_request(gen_request)
+            if error:
+                raise HTTPException(status_code=400, detail=error)
+
+            # Handle s2s_session backend with session support
+            if backend_type == "s2s_session" and session_manager is not None:
+                # Get or create session
+                session_state = session_manager.get_or_create_session(session_id)
+                session_id = session_state.session_id
+
+                # Run inference with session in thread pool
+                loop = asyncio.get_event_loop()
+                result, updated_session = await loop.run_in_executor(
+                    None,
+                    backend_instance.generate_with_session,
+                    gen_request,
+                    session_state,
+                )
+
+                # Save updated session state
+                if updated_session is not None:
+                    session_manager.save_session(session_id, updated_session)
+            else:
+                # Process through batcher (non-session path)
+                result = await request_batcher.add_request(gen_request)
+                session_id = None
+
+            if not result.is_success():
+                raise HTTPException(status_code=500, detail=result.error)
+
+            # Build OpenAI-compatible response
+            response_id = f"chatcmpl-{hashlib.md5(str(time.time()).encode()).hexdigest()[:8]}"
+
+            # Build message content
+            message_content = result.text or ""
+
+            # Save outputs to files before sending response (in case client times out)
+            import json as json_lib
+            import os
+            from datetime import datetime
+
+            save_dir = os.environ.get(
+                "AUDIO_SAVE_DIR", "/lustre/fsw/portfolios/llmservice/users/vmendelev/tmp/voicebench_test"
+            )
+            os.makedirs(save_dir, exist_ok=True)
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            base_filename = f"response_{timestamp}_{response_id}"
+
+            saved_audio_path = None
+            saved_json_path = None
+
+            # Save JSON with text and debug info
+            try:
+                saved_json_path = os.path.join(save_dir, f"{base_filename}.json")
+                json_output = {
+                    "response_id": response_id,
+                    "timestamp": timestamp,
+                    "text": message_content,
+                    "debug_info": result.debug_info,
+                    "generation_time_ms": result.generation_time_ms,
+                    "num_tokens_generated": result.num_tokens_generated,
+                }
+                with open(saved_json_path, "w") as f:
+                    json_lib.dump(json_output, f, indent=2)
+                print(f"[Server] JSON saved to: {saved_json_path}")
+            except Exception as e:
+                print(f"[Server] Warning: Failed to save JSON: {e}")
+
+            # Include audio output if available (base64 encoded)
+            audio_output = None
+            if result.audio_bytes:
+                # Save audio file
+                try:
+                    saved_audio_path = os.path.join(save_dir, f"{base_filename}.wav")
+                    with open(saved_audio_path, "wb") as f:
+                        f.write(result.audio_bytes)
+                    print(f"[Server] Audio saved to: {saved_audio_path} ({len(result.audio_bytes)} bytes)")
+                except Exception as e:
+                    print(f"[Server] Warning: Failed to save audio: {e}")
+
+                audio_output = {
+                    "data": base64.b64encode(result.audio_bytes).decode("utf-8"),
+                    "format": result.audio_format or "wav",
+                    "sample_rate": result.audio_sample_rate,
+                    "expires_at": int(time.time()) + 3600,  # 1 hour expiry
+                    "transcript": result.text or "",  # Text transcript of the audio
+                }
+
+            # Embed debug_info in content as JSON (OpenAI-compatible)
+            final_content = message_content
+            if result.debug_info:
+                final_content = f"{message_content}\n<debug_info>{json.dumps(result.debug_info)}</debug_info>"
+
+            response = {
+                "id": response_id,
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": server_config.get("model_path"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": final_content,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": -1,
+                    "completion_tokens": result.num_tokens_generated or -1,
+                    "total_tokens": -1,
+                },
+            }
+
+            # Add audio to response if available
+            if audio_output:
+                response["choices"][0]["message"]["audio"] = audio_output
+
+            # Add debug info at top level too (for non-litellm clients)
+            if result.debug_info:
+                response["debug_info"] = result.debug_info
+
+            # Add saved file paths if available
+            if saved_audio_path:
+                response["saved_audio_path"] = saved_audio_path
+            if saved_json_path:
+                response["saved_json_path"] = saved_json_path
+
+            # Add session_id for session-aware backends
+            if session_id:
+                response["session_id"] = session_id
+
+            return response
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            import traceback
+
+            traceback.print_exc()
+            raise HTTPException(status_code=500, detail=str(e))
+
+    return app
+
+
+def main():
+    """Run the server from command line."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Unified NeMo Inference Server")
+    parser.add_argument(
+        "--backend",
+        default=BACKEND_TYPE,
+        choices=["salm", "tts", "s2s", "s2s_incremental", "s2s_session"],
+        help="Backend type to use",
+    )
+    parser.add_argument("--model", default=MODEL_PATH, help="Path to model")
+    parser.add_argument("--codec_model", default=CODEC_MODEL_PATH, help="Path to codec model (for TTS/S2S)")
+    parser.add_argument("--host", default=HOST, help="Server host")
+    parser.add_argument("--port", type=int, default=PORT, help="Server port")
+    parser.add_argument("--batch_size", type=int, default=BATCH_SIZE, help="Batch size")
+    parser.add_argument(
+        "--batch_timeout", type=float, default=BATCH_TIMEOUT, help="Batch timeout in seconds (0 for no delay)"
+    )
+    parser.add_argument("--device", default="cuda", help="Device to use")
+    parser.add_argument("--dtype", default="bfloat16", help="Model dtype")
+    parser.add_argument("--debug", action="store_true", help="Enable debug mode")
+
+    # Backend-specific arguments
+    parser.add_argument("--prompt_format", default=None, help="Prompt format (SALM)")
+    parser.add_argument("--phoneme_input_type", default="predicted", help="Phoneme input type (TTS)")
+    parser.add_argument("--decoder_only_model", action="store_true", help="Use decoder-only model (TTS)")
+    parser.add_argument(
+        "--ignore_system_prompt",
+        action="store_true",
+        help="Ignore system prompts from requests (for models that don't support them)",
+    )
+    parser.add_argument(
+        "--silence_padding_sec",
+        type=float,
+        default=5.0,
+        help="Seconds of silence to append after audio (S2S backend)",
+    )
+
+    # S2S Incremental backend arguments
+    parser.add_argument(
+        "--config_path",
+        type=str,
+        default=None,
+        help="Path to YAML config file (s2s_incremental backend)",
+    )
+    parser.add_argument(
+        "--llm_checkpoint_path",
+        type=str,
+        default=None,
+        help="Path to LLM checkpoint (s2s_incremental backend)",
+    )
+    parser.add_argument(
+        "--tts_checkpoint_path",
+        type=str,
+        default=None,
+        help="Path to TTS checkpoint (s2s_incremental backend)",
+    )
+    parser.add_argument(
+        "--speaker_reference",
+        type=str,
+        default=None,
+        help="Path to speaker reference audio for TTS (s2s_incremental backend)",
+    )
+    parser.add_argument(
+        "--num_frames_per_inference",
+        type=int,
+        default=1,
+        help="Frames per inference step (s2s_incremental backend)",
+    )
+    parser.add_argument(
+        "--decode_audio",
+        action="store_true",
+        default=True,
+        help="Enable audio output via TTS (s2s_incremental backend)",
+    )
+    parser.add_argument(
+        "--no_decode_audio",
+        action="store_true",
+        help="Disable audio output (s2s_incremental backend)",
+    )
+
+    args = parser.parse_args()
+
+    if args.debug:
+        global DEBUG
+        DEBUG = True
+
+    # Build extra config from backend-specific args
+    extra_config = {}
+    if args.prompt_format:
+        extra_config["prompt_format"] = args.prompt_format
+    if args.phoneme_input_type:
+        extra_config["phoneme_input_type"] = args.phoneme_input_type
+    if args.decoder_only_model:
+        extra_config["decoder_only_model"] = True
+    if args.silence_padding_sec != 5.0:  # Only add if different from default
+        extra_config["silence_padding_sec"] = args.silence_padding_sec
+    extra_config["ignore_system_prompt"] = args.ignore_system_prompt
+
+    # S2S Incremental backend config
+    if args.config_path:
+        extra_config["config_path"] = args.config_path
+    if args.llm_checkpoint_path:
+        extra_config["llm_checkpoint_path"] = args.llm_checkpoint_path
+    if args.tts_checkpoint_path:
+        extra_config["tts_checkpoint_path"] = args.tts_checkpoint_path
+    if args.speaker_reference:
+        extra_config["speaker_reference"] = args.speaker_reference
+    if args.num_frames_per_inference != 1:
+        extra_config["num_frames_per_inference"] = args.num_frames_per_inference
+    if args.no_decode_audio:
+        extra_config["decode_audio"] = False
+
+    app = create_app(
+        backend_type=args.backend,
+        model_path=args.model,
+        codec_model_path=args.codec_model,
+        batch_size=args.batch_size,
+        batch_timeout=args.batch_timeout,
+        device=args.device,
+        dtype=args.dtype,
+        extra_config=extra_config if extra_config else None,
+    )
+
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a simple FastAPI server to which anybody can add a backend to comply with nemo-skills client-server approach. I already have some backends, and will push them later.
If somebody has a better idea how to make it easier to run nemo-skills with early research models not supported by vLLM or SGLANG  -- please suggest. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added unified inference server with OpenAI-compatible API supporting multiple backends (SALM, TTS, S2S)
  * Introduced session management for multi-turn conversations with TTL-based lifecycle
  * Added health check and model listing endpoints
  * Enabled audio input/output processing and configurable batch request handling
  * Support for saving response metadata and audio artifacts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->