### PR TITLE
Fix fail to run Nemo Skills when need trust remote code

### DIFF
--- a/nemo_skills/prompt/utils.py
+++ b/nemo_skills/prompt/utils.py
@@ -112,7 +112,7 @@ class Prompt:
         if self.tokenizer:
             # assuming it's the object already if not str
             if isinstance(self.tokenizer, str):
-                self.tokenizer = AutoTokenizer.from_pretrained(self.tokenizer)
+                self.tokenizer = AutoTokenizer.from_pretrained(self.tokenizer, trust_remote_code=True)
 
     def build_filled_example(self, example_dict: Dict[str, Any]) -> str:
         """Builds a filled example string based on the example dictionary."""


### PR DESCRIPTION
I think Nemo-Skills is run by users only internally w/ control, thus not make it configurable. Please ping me if this is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tokenizer initialization to enable remote code execution support when loading tokenizers from string identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->