### PR TITLE
Prompting fix to improve LCB score for GPTOSS

### DIFF
--- a/nemo_skills/dataset/livecodebench/__init__.py
+++ b/nemo_skills/dataset/livecodebench/__init__.py
@@ -16,4 +16,4 @@
 DATASET_GROUP = "code"
 METRICS_TYPE = "livecodebench"
 EVAL_SPLIT = "test_v6_2408_2505"
-GENERATION_ARGS = "++prompt_config=gpt-oss/livecodebench ++eval_type=livecodebench"
+GENERATION_ARGS = "++prompt_config=eval/livecodebench/python_codegen ++eval_type=livecodebench"

--- a/nemo_skills/prompt/config/eval/livecodebench/python_codegen_reasoning.yaml
+++ b/nemo_skills/prompt/config/eval/livecodebench/python_codegen_reasoning.yaml
@@ -1,4 +1,11 @@
 user: |-
   You are a helpful and harmless assistant. You should think step-by-step before responding to the instruction below.
 
+  Please use python programming language only.
+
+  You must use ```python for just the final solution code block with the following format:
+  ```python
+  # Your code here
+  ```
+
   {question}


### PR DESCRIPTION
## Objective of prompt change

When we evaluated GPTOSS using Nemo-Skills on LCB, we noticed the following error appeared frequently.

```
\"AttributeError(\\\"'_io.StringIO' object has no attribute 'buffer'\\\")\"
```

After inspecting the generated code, we noticed the following line of code was resulting into the above error.

```
data = sys.stdin.buffer.read().split()
```

So, we updated prompt for GPTOSS that instructs the model not to generate code that leads to an AttributeError. 

### Impact of prompt change

The updates give the following scores on **LCB v5 (2407-2412) [315 samples]**, also known as **AA split**:

### GPT-OSS-120B
```
------------------------------ livecodebench ------------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 315         | 17531      | 1083        | 86.98% ± 0.92%
pass@10           | 315         | 17531      | 1083        | 93.02%        


---------------------------- livecodebench-hard ---------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 135         | 31470      | 1083        | 75.85% ± 1.27%
pass@10           | 135         | 31470      | 1083        | 87.41%        


--------------------------- livecodebench-medium --------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 102         | 10700      | 849         | 93.04% ± 1.49%
pass@10           | 102         | 10700      | 849         | 96.08%        


---------------------------- livecodebench-easy ---------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 78          | 2336       | 247         | 98.33% ± 1.22%
pass@10           | 78          | 2336       | 247         | 98.72%
```

**NS Eval command:**
```
ns eval \
    --cluster=$cluster \
    --model=$model_dir \
    --server_type=vllm \
    --server_args="--enable-log-requests --async-scheduling --tensor-parallel-size 8" \
    --server_nodes=1 \
    --server_gpus=8 \
    --benchmarks=livecodebench:10 \
    --split="test_v5_2407_2412" \
    --expname="${model_name}-lcb-ns-eval" \
    --output_dir=$output_dir \
    ++prompt_config="gpt-oss/livecodebench" \
    ++inference.endpoint_type=chat \
    ++inference.extra_body.reasoning_effort=high \
    ++inference.temperature=1.0 \
    ++inference.top_p=1.0 \
    ++inference.top_k=-1 \
    ++max_concurrent_requests=1024 \
    ++skip_filled=True \
    ++eval_config.timeout=10
```

### GPT-OSS-20B
```
------------------------------ livecodebench ------------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 315         | 32616      | 1090        | 82.79% ± 0.91%
pass@10           | 315         | 32616      | 1090        | 91.11%        


---------------------------- livecodebench-hard ---------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 135         | 57098      | 1090        | 66.59% ± 1.96%
pass@10           | 135         | 57098      | 1090        | 82.22%        


--------------------------- livecodebench-medium --------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 102         | 22206      | 1090        | 92.25% ± 1.34%
pass@10           | 102         | 22206      | 1090        | 97.06%        


---------------------------- livecodebench-easy ---------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 78          | 3859       | 734         | 98.46% ± 0.54%
pass@10           | 78          | 3859       | 734         | 98.72% 
```

### Qwen3-32B
```
------------------------------ livecodebench ------------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 315         | 12735      | 1169        | 66.98% ± 1.41%
pass@10           | 315         | 12735      | 1169        | 80.32%        


---------------------------- livecodebench-hard ---------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 135         | 18759      | 1149        | 39.41% ± 1.87%
pass@10           | 135         | 18759      | 1149        | 60.00%        


--------------------------- livecodebench-medium --------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 102         | 11311      | 1169        | 79.80% ± 1.80%
pass@10           | 102         | 11311      | 1169        | 93.14%        


---------------------------- livecodebench-easy ---------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 78          | 4171       | 837         | 97.95% ± 1.08%
pass@10           | 78          | 4171       | 837         | 98.72%
```

### NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
```
------------------------------ livecodebench ------------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 315         | 28483      | 1649        | 66.86% ± 2.30%
pass@10           | 315         | 28483      | 1649        | 80.95%        


---------------------------- livecodebench-hard ---------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 135         | 44079      | 1649        | 43.11% ± 3.40%
pass@10           | 135         | 44079      | 1649        | 62.96%        


--------------------------- livecodebench-medium --------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 102         | 21548      | 1649        | 77.06% ± 2.78%
pass@10           | 102         | 21548      | 1649        | 91.18%        


---------------------------- livecodebench-easy ---------------------------
evaluation_mode   | num_entries | avg_tokens | gen_seconds | accuracy      
pass@1[avg-of-10] | 78          | 10557      | 1649        | 94.62% ± 2.69%
pass@10           | 78          | 10557      | 1649        | 98.72%
```