### PR TITLE
add multilingual aime25, gqpa and lcb

### DIFF
--- a/nemo_skills/dataset/aime25-de-prompt-de/__init__.py
+++ b/nemo_skills/dataset/aime25-de-prompt-de/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'multilingual/math_de'
+DATASET_GROUP = 'math'
+METRICS_TYPE = "math_multilingual"
+EVAL_ARGS = "++eval_type=math"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/aime25-de-prompt-de/prepare.py
+++ b/nemo_skills/dataset/aime25-de-prompt-de/prepare.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+from pathlib import Path
+
+if __name__ == "__main__":
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    original_file = str(data_dir / "test.txt")
+    output_file = str(data_dir / "test.jsonl")
+    shutil.copy(original_file, output_file)

--- a/nemo_skills/dataset/aime25-de-prompt-en/__init__.py
+++ b/nemo_skills/dataset/aime25-de-prompt-en/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'generic/math'
+DATASET_GROUP = 'math'
+METRICS_TYPE = "math_multilingual"
+EVAL_ARGS = "++eval_type=math"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/aime25-de-prompt-en/prepare.py
+++ b/nemo_skills/dataset/aime25-de-prompt-en/prepare.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+from pathlib import Path
+
+if __name__ == "__main__":
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    original_file = str(data_dir / "test.txt")
+    output_file = str(data_dir / "test.jsonl")
+    shutil.copy(original_file, output_file)

--- a/nemo_skills/dataset/aime25-es-prompt-en/__init__.py
+++ b/nemo_skills/dataset/aime25-es-prompt-en/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'generic/math'
+DATASET_GROUP = 'math'
+METRICS_TYPE = "math_multilingual"
+EVAL_ARGS = "++eval_type=math"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/aime25-es-prompt-en/prepare.py
+++ b/nemo_skills/dataset/aime25-es-prompt-en/prepare.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+from pathlib import Path
+
+if __name__ == "__main__":
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    original_file = str(data_dir / "test.txt")
+    output_file = str(data_dir / "test.jsonl")
+    shutil.copy(original_file, output_file)

--- a/nemo_skills/dataset/aime25-es-prompt-es/__init__.py
+++ b/nemo_skills/dataset/aime25-es-prompt-es/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'multilingual/math_es'
+DATASET_GROUP = 'math'
+METRICS_TYPE = "math_multilingual"
+EVAL_ARGS = "++eval_type=math"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/aime25-es-prompt-es/prepare.py
+++ b/nemo_skills/dataset/aime25-es-prompt-es/prepare.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+from pathlib import Path
+
+if __name__ == "__main__":
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    original_file = str(data_dir / "test.txt")
+    output_file = str(data_dir / "test.jsonl")
+    shutil.copy(original_file, output_file)

--- a/nemo_skills/dataset/aime25-fr-prompt-en/__init__.py
+++ b/nemo_skills/dataset/aime25-fr-prompt-en/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'generic/math'
+DATASET_GROUP = 'math'
+METRICS_TYPE = "math_multilingual"
+EVAL_ARGS = "++eval_type=math"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/aime25-fr-prompt-en/prepare.py
+++ b/nemo_skills/dataset/aime25-fr-prompt-en/prepare.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+from pathlib import Path
+
+if __name__ == "__main__":
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    original_file = str(data_dir / "test.txt")
+    output_file = str(data_dir / "test.jsonl")
+    shutil.copy(original_file, output_file)

--- a/nemo_skills/dataset/aime25-fr-prompt-fr/__init__.py
+++ b/nemo_skills/dataset/aime25-fr-prompt-fr/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'multilingual/math_fr'
+DATASET_GROUP = 'math'
+METRICS_TYPE = "math_multilingual"
+EVAL_ARGS = "++eval_type=math"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/aime25-fr-prompt-fr/prepare.py
+++ b/nemo_skills/dataset/aime25-fr-prompt-fr/prepare.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+from pathlib import Path
+
+if __name__ == "__main__":
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    original_file = str(data_dir / "test.txt")
+    output_file = str(data_dir / "test.jsonl")
+    shutil.copy(original_file, output_file)

--- a/nemo_skills/dataset/aime25-ja-prompt-en/__init__.py
+++ b/nemo_skills/dataset/aime25-ja-prompt-en/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'generic/math'
+DATASET_GROUP = 'math'
+METRICS_TYPE = "math_multilingual"
+EVAL_ARGS = "++eval_type=math"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/aime25-ja-prompt-en/prepare.py
+++ b/nemo_skills/dataset/aime25-ja-prompt-en/prepare.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+from pathlib import Path
+
+if __name__ == "__main__":
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    original_file = str(data_dir / "test.txt")
+    output_file = str(data_dir / "test.jsonl")
+    shutil.copy(original_file, output_file)

--- a/nemo_skills/dataset/aime25-ja-prompt-ja/__init__.py
+++ b/nemo_skills/dataset/aime25-ja-prompt-ja/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'multilingual/math_ja'
+DATASET_GROUP = 'math'
+METRICS_TYPE = "math_multilingual"
+EVAL_ARGS = "++eval_type=math"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/aime25-ja-prompt-ja/prepare.py
+++ b/nemo_skills/dataset/aime25-ja-prompt-ja/prepare.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+from pathlib import Path
+
+if __name__ == "__main__":
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    original_file = str(data_dir / "test.txt")
+    output_file = str(data_dir / "test.jsonl")
+    shutil.copy(original_file, output_file)

--- a/nemo_skills/dataset/gpqa-de-prompt-de/__init__.py
+++ b/nemo_skills/dataset/gpqa-de-prompt-de/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+PROMPT_CONFIG = "multilingual/general-boxed_de"
+DATASET_GROUP = "multichoice"
+METRICS_TYPE = "multichoice_multilingual"
+EVAL_ARGS = "++eval_type=multichoice"
+EVAL_SPLIT = "diamond"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/gpqa-de-prompt-de/prepare.py
+++ b/nemo_skills/dataset/gpqa-de-prompt-de/prepare.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import random
+import re
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from nemo_skills.dataset.utils import get_mcq_fields
+
+"""
+Preprocessing adapted from https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/gpqa/generative/utils.py
+"""
+
+
+def preprocess(text):
+    if text is None:
+        return " "
+    text = text.strip()
+    text = text.replace(" [title]", ". ")
+    text = text.replace("  ", " ")
+    return text
+
+
+def format_entry(entry):
+    choices = [
+        preprocess(entry["Incorrect Answer 1"]),
+        preprocess(entry["Incorrect Answer 2"]),
+        preprocess(entry["Incorrect Answer 3"]),
+        preprocess(entry["Correct Answer"]),
+    ]
+    
+    random.shuffle(choices)
+    correct_answer_index = choices.index(preprocess(entry["Correct Answer"]))
+    return {
+        "expected_answer": f"{chr(65 + correct_answer_index)}",
+        "explanation": preprocess(entry["Explanation"]),
+        "subset_for_metrics": entry["Subdomain"],
+        "difficulty": (
+            re.split(r'\s*\(', entry["Writer's Difficulty Estimate"])[0]
+            if entry["Writer's Difficulty Estimate"] is not None
+            else None
+        ),
+        **get_mcq_fields(entry["Question"], choices),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout)
+            fout.write("\n")
+
+
+def save_data(split, random_seed):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    output_file = data_dir / f"{split}.jsonl"
+    random.seed(random_seed)
+
+    dataset = load_dataset("Idavidrein/gpqa", f"gpqa_{split}")["train"]
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--split",
+        default="all",
+        choices=("all", "extended", "main", "diamond"),
+        help="Dataset split to process.",
+    )
+    parser.add_argument("--random_seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.split == "all":
+        for split in ["extended", "main", "diamond"]:
+            save_data(split, args.random_seed)
+    else:
+        save_data(args.split, args.random_seed)
+        

--- a/nemo_skills/dataset/gpqa-de-prompt-en/__init__.py
+++ b/nemo_skills/dataset/gpqa-de-prompt-en/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+PROMPT_CONFIG = "generic/general-boxed"
+DATASET_GROUP = "multichoice"
+METRICS_TYPE = "multichoice_multilingual"
+EVAL_ARGS = "++eval_type=multichoice"
+EVAL_SPLIT = "diamond"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/gpqa-de-prompt-en/prepare.py
+++ b/nemo_skills/dataset/gpqa-de-prompt-en/prepare.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import random
+import re
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from nemo_skills.dataset.utils import get_mcq_fields
+
+"""
+Preprocessing adapted from https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/gpqa/generative/utils.py
+"""
+
+
+def preprocess(text):
+    if text is None:
+        return " "
+    text = text.strip()
+    text = text.replace(" [title]", ". ")
+    text = text.replace("  ", " ")
+    return text
+
+
+def format_entry(entry):
+    choices = [
+        preprocess(entry["Incorrect Answer 1"]),
+        preprocess(entry["Incorrect Answer 2"]),
+        preprocess(entry["Incorrect Answer 3"]),
+        preprocess(entry["Correct Answer"]),
+    ]
+    
+    random.shuffle(choices)
+    correct_answer_index = choices.index(preprocess(entry["Correct Answer"]))
+    return {
+        "expected_answer": f"{chr(65 + correct_answer_index)}",
+        "explanation": preprocess(entry["Explanation"]),
+        "subset_for_metrics": entry["Subdomain"],
+        "difficulty": (
+            re.split(r'\s*\(', entry["Writer's Difficulty Estimate"])[0]
+            if entry["Writer's Difficulty Estimate"] is not None
+            else None
+        ),
+        **get_mcq_fields(entry["Question"], choices),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout)
+            fout.write("\n")
+
+
+def save_data(split, random_seed):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    output_file = data_dir / f"{split}.jsonl"
+    random.seed(random_seed)
+
+    dataset = load_dataset("Idavidrein/gpqa", f"gpqa_{split}")["train"]
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--split",
+        default="all",
+        choices=("all", "extended", "main", "diamond"),
+        help="Dataset split to process.",
+    )
+    parser.add_argument("--random_seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.split == "all":
+        for split in ["extended", "main", "diamond"]:
+            save_data(split, args.random_seed)
+    else:
+        save_data(args.split, args.random_seed)
+        

--- a/nemo_skills/dataset/gpqa-es-prompt-en/__init__.py
+++ b/nemo_skills/dataset/gpqa-es-prompt-en/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+PROMPT_CONFIG = "generic/general-boxed"
+DATASET_GROUP = "multichoice"
+METRICS_TYPE = "multichoice_multilingual"
+EVAL_ARGS = "++eval_type=multichoice"
+EVAL_SPLIT = "diamond"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/gpqa-es-prompt-en/prepare.py
+++ b/nemo_skills/dataset/gpqa-es-prompt-en/prepare.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import random
+import re
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from nemo_skills.dataset.utils import get_mcq_fields
+
+"""
+Preprocessing adapted from https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/gpqa/generative/utils.py
+"""
+
+
+def preprocess(text):
+    if text is None:
+        return " "
+    text = text.strip()
+    text = text.replace(" [title]", ". ")
+    text = text.replace("  ", " ")
+    return text
+
+
+def format_entry(entry):
+    choices = [
+        preprocess(entry["Incorrect Answer 1"]),
+        preprocess(entry["Incorrect Answer 2"]),
+        preprocess(entry["Incorrect Answer 3"]),
+        preprocess(entry["Correct Answer"]),
+    ]
+    
+    random.shuffle(choices)
+    correct_answer_index = choices.index(preprocess(entry["Correct Answer"]))
+    return {
+        "expected_answer": f"{chr(65 + correct_answer_index)}",
+        "explanation": preprocess(entry["Explanation"]),
+        "subset_for_metrics": entry["Subdomain"],
+        "difficulty": (
+            re.split(r'\s*\(', entry["Writer's Difficulty Estimate"])[0]
+            if entry["Writer's Difficulty Estimate"] is not None
+            else None
+        ),
+        **get_mcq_fields(entry["Question"], choices),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout)
+            fout.write("\n")
+
+
+def save_data(split, random_seed):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    output_file = data_dir / f"{split}.jsonl"
+    random.seed(random_seed)
+
+    dataset = load_dataset("Idavidrein/gpqa", f"gpqa_{split}")["train"]
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--split",
+        default="all",
+        choices=("all", "extended", "main", "diamond"),
+        help="Dataset split to process.",
+    )
+    parser.add_argument("--random_seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.split == "all":
+        for split in ["extended", "main", "diamond"]:
+            save_data(split, args.random_seed)
+    else:
+        save_data(args.split, args.random_seed)
+        

--- a/nemo_skills/dataset/gpqa-es-prompt-es/__init__.py
+++ b/nemo_skills/dataset/gpqa-es-prompt-es/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+PROMPT_CONFIG = "multilingual/general-boxed_es"
+DATASET_GROUP = "multichoice"
+METRICS_TYPE = "multichoice_multilingual"
+EVAL_ARGS = "++eval_type=multichoice"
+EVAL_SPLIT = "diamond"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/gpqa-es-prompt-es/prepare.py
+++ b/nemo_skills/dataset/gpqa-es-prompt-es/prepare.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import random
+import re
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from nemo_skills.dataset.utils import get_mcq_fields
+
+"""
+Preprocessing adapted from https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/gpqa/generative/utils.py
+"""
+
+
+def preprocess(text):
+    if text is None:
+        return " "
+    text = text.strip()
+    text = text.replace(" [title]", ". ")
+    text = text.replace("  ", " ")
+    return text
+
+
+def format_entry(entry):
+    choices = [
+        preprocess(entry["Incorrect Answer 1"]),
+        preprocess(entry["Incorrect Answer 2"]),
+        preprocess(entry["Incorrect Answer 3"]),
+        preprocess(entry["Correct Answer"]),
+    ]
+    
+    random.shuffle(choices)
+    correct_answer_index = choices.index(preprocess(entry["Correct Answer"]))
+    return {
+        "expected_answer": f"{chr(65 + correct_answer_index)}",
+        "explanation": preprocess(entry["Explanation"]),
+        "subset_for_metrics": entry["Subdomain"],
+        "difficulty": (
+            re.split(r'\s*\(', entry["Writer's Difficulty Estimate"])[0]
+            if entry["Writer's Difficulty Estimate"] is not None
+            else None
+        ),
+        **get_mcq_fields(entry["Question"], choices),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout)
+            fout.write("\n")
+
+
+def save_data(split, random_seed):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    output_file = data_dir / f"{split}.jsonl"
+    random.seed(random_seed)
+
+    dataset = load_dataset("Idavidrein/gpqa", f"gpqa_{split}")["train"]
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--split",
+        default="all",
+        choices=("all", "extended", "main", "diamond"),
+        help="Dataset split to process.",
+    )
+    parser.add_argument("--random_seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.split == "all":
+        for split in ["extended", "main", "diamond"]:
+            save_data(split, args.random_seed)
+    else:
+        save_data(args.split, args.random_seed)
+        

--- a/nemo_skills/dataset/gpqa-fr-prompt-en/__init__.py
+++ b/nemo_skills/dataset/gpqa-fr-prompt-en/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+PROMPT_CONFIG = "generic/general-boxed"
+DATASET_GROUP = "multichoice"
+METRICS_TYPE = "multichoice_multilingual"
+EVAL_ARGS = "++eval_type=multichoice"
+EVAL_SPLIT = "diamond"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/gpqa-fr-prompt-en/prepare.py
+++ b/nemo_skills/dataset/gpqa-fr-prompt-en/prepare.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import random
+import re
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from nemo_skills.dataset.utils import get_mcq_fields
+
+"""
+Preprocessing adapted from https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/gpqa/generative/utils.py
+"""
+
+
+def preprocess(text):
+    if text is None:
+        return " "
+    text = text.strip()
+    text = text.replace(" [title]", ". ")
+    text = text.replace("  ", " ")
+    return text
+
+
+def format_entry(entry):
+    choices = [
+        preprocess(entry["Incorrect Answer 1"]),
+        preprocess(entry["Incorrect Answer 2"]),
+        preprocess(entry["Incorrect Answer 3"]),
+        preprocess(entry["Correct Answer"]),
+    ]
+    
+    random.shuffle(choices)
+    correct_answer_index = choices.index(preprocess(entry["Correct Answer"]))
+    return {
+        "expected_answer": f"{chr(65 + correct_answer_index)}",
+        "explanation": preprocess(entry["Explanation"]),
+        "subset_for_metrics": entry["Subdomain"],
+        "difficulty": (
+            re.split(r'\s*\(', entry["Writer's Difficulty Estimate"])[0]
+            if entry["Writer's Difficulty Estimate"] is not None
+            else None
+        ),
+        **get_mcq_fields(entry["Question"], choices),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout)
+            fout.write("\n")
+
+
+def save_data(split, random_seed):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    output_file = data_dir / f"{split}.jsonl"
+    random.seed(random_seed)
+
+    dataset = load_dataset("Idavidrein/gpqa", f"gpqa_{split}")["train"]
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--split",
+        default="all",
+        choices=("all", "extended", "main", "diamond"),
+        help="Dataset split to process.",
+    )
+    parser.add_argument("--random_seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.split == "all":
+        for split in ["extended", "main", "diamond"]:
+            save_data(split, args.random_seed)
+    else:
+        save_data(args.split, args.random_seed)
+        

--- a/nemo_skills/dataset/gpqa-fr-prompt-fr/__init__.py
+++ b/nemo_skills/dataset/gpqa-fr-prompt-fr/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+PROMPT_CONFIG = "multilingual/general-boxed_fr"
+DATASET_GROUP = "multichoice"
+METRICS_TYPE = "multichoice_multilingual"
+EVAL_ARGS = "++eval_type=multichoice"
+EVAL_SPLIT = "diamond"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/gpqa-fr-prompt-fr/prepare.py
+++ b/nemo_skills/dataset/gpqa-fr-prompt-fr/prepare.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import random
+import re
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from nemo_skills.dataset.utils import get_mcq_fields
+
+"""
+Preprocessing adapted from https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/gpqa/generative/utils.py
+"""
+
+
+def preprocess(text):
+    if text is None:
+        return " "
+    text = text.strip()
+    text = text.replace(" [title]", ". ")
+    text = text.replace("  ", " ")
+    return text
+
+
+def format_entry(entry):
+    choices = [
+        preprocess(entry["Incorrect Answer 1"]),
+        preprocess(entry["Incorrect Answer 2"]),
+        preprocess(entry["Incorrect Answer 3"]),
+        preprocess(entry["Correct Answer"]),
+    ]
+    
+    random.shuffle(choices)
+    correct_answer_index = choices.index(preprocess(entry["Correct Answer"]))
+    return {
+        "expected_answer": f"{chr(65 + correct_answer_index)}",
+        "explanation": preprocess(entry["Explanation"]),
+        "subset_for_metrics": entry["Subdomain"],
+        "difficulty": (
+            re.split(r'\s*\(', entry["Writer's Difficulty Estimate"])[0]
+            if entry["Writer's Difficulty Estimate"] is not None
+            else None
+        ),
+        **get_mcq_fields(entry["Question"], choices),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout)
+            fout.write("\n")
+
+
+def save_data(split, random_seed):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    output_file = data_dir / f"{split}.jsonl"
+    random.seed(random_seed)
+
+    dataset = load_dataset("Idavidrein/gpqa", f"gpqa_{split}")["train"]
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--split",
+        default="all",
+        choices=("all", "extended", "main", "diamond"),
+        help="Dataset split to process.",
+    )
+    parser.add_argument("--random_seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.split == "all":
+        for split in ["extended", "main", "diamond"]:
+            save_data(split, args.random_seed)
+    else:
+        save_data(args.split, args.random_seed)
+        

--- a/nemo_skills/dataset/gpqa-ja-prompt-en/__init__.py
+++ b/nemo_skills/dataset/gpqa-ja-prompt-en/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+PROMPT_CONFIG = "generic/general-boxed"
+DATASET_GROUP = "multichoice"
+METRICS_TYPE = "multichoice_multilingual"
+EVAL_ARGS = "++eval_type=multichoice"
+EVAL_SPLIT = "diamond"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/gpqa-ja-prompt-en/prepare.py
+++ b/nemo_skills/dataset/gpqa-ja-prompt-en/prepare.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import random
+import re
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from nemo_skills.dataset.utils import get_mcq_fields
+
+"""
+Preprocessing adapted from https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/gpqa/generative/utils.py
+"""
+
+
+def preprocess(text):
+    if text is None:
+        return " "
+    text = text.strip()
+    text = text.replace(" [title]", ". ")
+    text = text.replace("  ", " ")
+    return text
+
+
+def format_entry(entry):
+    choices = [
+        preprocess(entry["Incorrect Answer 1"]),
+        preprocess(entry["Incorrect Answer 2"]),
+        preprocess(entry["Incorrect Answer 3"]),
+        preprocess(entry["Correct Answer"]),
+    ]
+    
+    random.shuffle(choices)
+    correct_answer_index = choices.index(preprocess(entry["Correct Answer"]))
+    return {
+        "expected_answer": f"{chr(65 + correct_answer_index)}",
+        "explanation": preprocess(entry["Explanation"]),
+        "subset_for_metrics": entry["Subdomain"],
+        "difficulty": (
+            re.split(r'\s*\(', entry["Writer's Difficulty Estimate"])[0]
+            if entry["Writer's Difficulty Estimate"] is not None
+            else None
+        ),
+        **get_mcq_fields(entry["Question"], choices),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout)
+            fout.write("\n")
+
+
+def save_data(split, random_seed):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    output_file = data_dir / f"{split}.jsonl"
+    random.seed(random_seed)
+
+    dataset = load_dataset("Idavidrein/gpqa", f"gpqa_{split}")["train"]
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--split",
+        default="all",
+        choices=("all", "extended", "main", "diamond"),
+        help="Dataset split to process.",
+    )
+    parser.add_argument("--random_seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.split == "all":
+        for split in ["extended", "main", "diamond"]:
+            save_data(split, args.random_seed)
+    else:
+        save_data(args.split, args.random_seed)
+        

--- a/nemo_skills/dataset/gpqa-ja-prompt-ja/__init__.py
+++ b/nemo_skills/dataset/gpqa-ja-prompt-ja/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+PROMPT_CONFIG = "multilingual/general-boxed_ja"
+DATASET_GROUP = "multichoice"
+METRICS_TYPE = "multichoice_multilingual"
+EVAL_ARGS = "++eval_type=multichoice"
+EVAL_SPLIT = "diamond"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/gpqa-ja-prompt-ja/prepare.py
+++ b/nemo_skills/dataset/gpqa-ja-prompt-ja/prepare.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import random
+import re
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from nemo_skills.dataset.utils import get_mcq_fields
+
+"""
+Preprocessing adapted from https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/gpqa/generative/utils.py
+"""
+
+
+def preprocess(text):
+    if text is None:
+        return " "
+    text = text.strip()
+    text = text.replace(" [title]", ". ")
+    text = text.replace("  ", " ")
+    return text
+
+
+def format_entry(entry):
+    choices = [
+        preprocess(entry["Incorrect Answer 1"]),
+        preprocess(entry["Incorrect Answer 2"]),
+        preprocess(entry["Incorrect Answer 3"]),
+        preprocess(entry["Correct Answer"]),
+    ]
+    
+    random.shuffle(choices)
+    correct_answer_index = choices.index(preprocess(entry["Correct Answer"]))
+    return {
+        "expected_answer": f"{chr(65 + correct_answer_index)}",
+        "explanation": preprocess(entry["Explanation"]),
+        "subset_for_metrics": entry["Subdomain"],
+        "difficulty": (
+            re.split(r'\s*\(', entry["Writer's Difficulty Estimate"])[0]
+            if entry["Writer's Difficulty Estimate"] is not None
+            else None
+        ),
+        **get_mcq_fields(entry["Question"], choices),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout)
+            fout.write("\n")
+
+
+def save_data(split, random_seed):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    output_file = data_dir / f"{split}.jsonl"
+    random.seed(random_seed)
+
+    dataset = load_dataset("Idavidrein/gpqa", f"gpqa_{split}")["train"]
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--split",
+        default="all",
+        choices=("all", "extended", "main", "diamond"),
+        help="Dataset split to process.",
+    )
+    parser.add_argument("--random_seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.split == "all":
+        for split in ["extended", "main", "diamond"]:
+            save_data(split, args.random_seed)
+    else:
+        save_data(args.split, args.random_seed)
+        

--- a/nemo_skills/dataset/livecodebench-de-prompt-de/__init__.py
+++ b/nemo_skills/dataset/livecodebench-de-prompt-de/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'eval/livecodebench/python_codegen_de'
+DATASET_GROUP = 'code'
+METRICS_TYPE = 'livecodebench'
+# EVAL_SPLIT = 'test_v5_2408_2502'
+# EVAL_SPLIT = 'test_v5_2407_2412'
+EVAL_SPLIT = 'test_v5_2407_2503'
+
+# EVAL_ARGS = "++eval_type=livecodebench ++eval_config.dataset=livecodebench"
+EVAL_ARGS = "++eval_type=livecodebench"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/livecodebench-de-prompt-de/prepare.py
+++ b/nemo_skills/dataset/livecodebench-de-prompt-de/prepare.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from datasets import load_dataset
+from dateutil.relativedelta import relativedelta
+
+
+class PromptConstants:
+    # reference: https://github.com/QwenLM/Qwen2.5-Coder/blob/main/qwencoder-eval/reasoning/livecode_bench_cot/lcb_runner_cq/prompts/code_generation.py#L31
+    FORMATTING_MESSAGE_WITH_STARTER_CODE = "You will use the following starter code to write the solution to the problem and enclose your code within delimiters."
+    FORMATTING_WITHOUT_STARTER_CODE = "Read the inputs from stdin solve the problem and write the answer to stdout (do not directly test on the sample inputs). Enclose your code within delimiters as follows. Ensure that when the python program runs, it reads the inputs, runs the algorithm and writes output to STDOUT."
+
+
+def parse_data(release_version='release_latest'):
+    data = load_dataset(
+        "livecodebench/code_generation_lite", split="test", version_tag=release_version, trust_remote_code=True
+    )
+    # data has the following fields
+    # question_title: str
+    # question_content: str
+    # platform: Platform
+    # question_id: str
+    # contest_id: str
+    # contest_date: datetime
+    # starter_code: str
+    # difficulty: Difficulty
+    # public_test_cases: list[Test]
+    # private_test_cases: list[Test]
+    # metadata: dict
+    return data
+
+
+def get_first_last_day(year_month_str):
+    try:
+        date_obj = datetime.strptime(year_month_str, "%Y-%m")
+        first_day = date_obj.date().replace(day=1)
+        last_day = (date_obj + relativedelta(months=1, days=-1)).date()
+        return first_day, last_day
+    except ValueError:
+        raise ValueError("Invalid date format. Please use '%Y-%m'.")
+
+
+def parse_month_range(start_date, end_date):
+    try:
+        start_date, _ = get_first_last_day(start_date)
+        _, end_date = get_first_last_day(end_date)
+        return start_date, end_date
+    except ValueError as e:
+        raise ValueError(str(e))
+
+
+def clean_data(dataset):
+    def map_fn(data):
+        question = data["question_content"] + "\n\n"
+        if data["starter_code"]:
+            question += f"{PromptConstants.FORMATTING_MESSAGE_WITH_STARTER_CODE}\n"
+            question += f"```python\n{data['starter_code']}\n```\n\n"
+        else:
+            question += f"{PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n\n"
+            question += f"```python\n# YOUR CODE HERE\n```\n\n"
+
+        data["task_id"] = data["question_id"]
+        data['question'] = question.replace('    ', '\t')
+        return data
+
+    remove_columns = [
+        'question_title',
+        'contest_id',
+        'public_test_cases',
+        'private_test_cases',
+        'metadata',
+        'question_content',
+        'platform',
+        'question_id',
+        'starter_code',
+    ]
+    dataset = dataset.map(map_fn, remove_columns=remove_columns)
+    return dataset
+
+
+def prepare(start_date, end_date, release_version, output_dir):
+    start_date, end_date = parse_month_range(start_date, end_date)
+    start_yymm = start_date.strftime("%y%m")
+    end_yymm = end_date.strftime("%y%m")
+    output_file_path = os.path.join(output_dir, f"test_{release_version}_{start_yymm}_{end_yymm}.jsonl")
+
+    assert release_version in ["v1", "v2", "v3", "v4", "v5", "v6"]
+
+    data = parse_data(release_version=f"release_{release_version}")
+    data = clean_data(data)
+    print("Len of data: ", len(data))
+
+    print("Writing to file...")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with open(output_file_path, 'w') as f:
+        for problem in data:
+            input_date = datetime.strptime(problem['contest_date'], '%Y-%m-%dT%H:%M:%S').date()
+            if start_date <= input_date <= end_date:
+                json.dump(
+                    {
+                        "task_id": problem["task_id"],
+                        "question": problem["question"],
+                        "difficulty": problem["difficulty"],
+                        "subset_for_metrics": problem["difficulty"],
+                        "release_version": release_version,
+                    },
+                    f,
+                )
+                f.write('\n')
+
+
+DEFAULT_SPLITS = [
+    ('v5', '2024-08', '2025-02'),  # previous default
+    # ('v5', '2024-07', '2024-12'),  # aai split
+    # ('v6', '2024-08', '2025-05'),  # current default in lb
+]
+
+
+if __name__ == '__main__':
+    # Write an argparse to a json file, read it in and parse it
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_dir', type=str, default=str(Path(__file__).parent))
+    parser.add_argument('--release_version', type=str, default='all')
+    parser.add_argument('--start_date', type=str, default='all', help="End date in YYYY-MM format")
+    parser.add_argument('--end_date', type=str, default='all', help="End date in YYYY-MM format")
+
+    args = parser.parse_args()
+
+    if args.release_version == 'all' and args.start_date == 'all' and args.end_date == 'all':
+        # Prepare all splits
+        for release_version, start_date, end_date in DEFAULT_SPLITS:
+            print(f"Processing data for {release_version} from {start_date} to {end_date}")
+            prepare(start_date, end_date, release_version, args.output_dir)
+    else:
+        if args.release_version == 'all' or args.start_date == 'all' or args.end_date == 'all':
+            raise ValueError(
+                "If preparing a custom split, you must specify all "
+                "--release_version, --start_date, and --end_date arguments."
+            )
+        prepare(args.start_date, args.end_date, args.release_version, args.output_dir)
+
+    # test_v5_2408_2502.jsonl: 279 samples
+    # test_v5_2410_2502.jsonl: 166 samples
+    # test_v5_2410_2504.jsonl: 166 samples
+    # test_v6_2408_2502.jsonl: 374 samples
+    # test_v6_2410_2502.jsonl: 261 samples
+    # test_v6_2410_2504.jsonl: 341 samples

--- a/nemo_skills/dataset/livecodebench-de-prompt-en/__init__.py
+++ b/nemo_skills/dataset/livecodebench-de-prompt-en/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'eval/livecodebench/python_codegen'
+DATASET_GROUP = 'code'
+METRICS_TYPE = 'livecodebench'
+# EVAL_SPLIT = 'test_v5_2408_2502'
+# EVAL_SPLIT = 'test_v5_2407_2412'
+EVAL_SPLIT = 'test_v5_2407_2503'
+# EVAL_ARGS = "++eval_type=livecodebench ++eval_config.dataset=livecodebench"
+EVAL_ARGS = "++eval_type=livecodebench"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/livecodebench-de-prompt-en/prepare.py
+++ b/nemo_skills/dataset/livecodebench-de-prompt-en/prepare.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from datasets import load_dataset
+from dateutil.relativedelta import relativedelta
+
+
+class PromptConstants:
+    # reference: https://github.com/QwenLM/Qwen2.5-Coder/blob/main/qwencoder-eval/reasoning/livecode_bench_cot/lcb_runner_cq/prompts/code_generation.py#L31
+    FORMATTING_MESSAGE_WITH_STARTER_CODE = "You will use the following starter code to write the solution to the problem and enclose your code within delimiters."
+    FORMATTING_WITHOUT_STARTER_CODE = "Read the inputs from stdin solve the problem and write the answer to stdout (do not directly test on the sample inputs). Enclose your code within delimiters as follows. Ensure that when the python program runs, it reads the inputs, runs the algorithm and writes output to STDOUT."
+
+
+def parse_data(release_version='release_latest'):
+    data = load_dataset(
+        "livecodebench/code_generation_lite", split="test", version_tag=release_version, trust_remote_code=True
+    )
+    # data has the following fields
+    # question_title: str
+    # question_content: str
+    # platform: Platform
+    # question_id: str
+    # contest_id: str
+    # contest_date: datetime
+    # starter_code: str
+    # difficulty: Difficulty
+    # public_test_cases: list[Test]
+    # private_test_cases: list[Test]
+    # metadata: dict
+    return data
+
+
+def get_first_last_day(year_month_str):
+    try:
+        date_obj = datetime.strptime(year_month_str, "%Y-%m")
+        first_day = date_obj.date().replace(day=1)
+        last_day = (date_obj + relativedelta(months=1, days=-1)).date()
+        return first_day, last_day
+    except ValueError:
+        raise ValueError("Invalid date format. Please use '%Y-%m'.")
+
+
+def parse_month_range(start_date, end_date):
+    try:
+        start_date, _ = get_first_last_day(start_date)
+        _, end_date = get_first_last_day(end_date)
+        return start_date, end_date
+    except ValueError as e:
+        raise ValueError(str(e))
+
+
+def clean_data(dataset):
+    def map_fn(data):
+        question = data["question_content"] + "\n\n"
+        if data["starter_code"]:
+            question += f"{PromptConstants.FORMATTING_MESSAGE_WITH_STARTER_CODE}\n"
+            question += f"```python\n{data['starter_code']}\n```\n\n"
+        else:
+            question += f"{PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n\n"
+            question += f"```python\n# YOUR CODE HERE\n```\n\n"
+
+        data["task_id"] = data["question_id"]
+        data['question'] = question.replace('    ', '\t')
+        return data
+
+    remove_columns = [
+        'question_title',
+        'contest_id',
+        'public_test_cases',
+        'private_test_cases',
+        'metadata',
+        'question_content',
+        'platform',
+        'question_id',
+        'starter_code',
+    ]
+    dataset = dataset.map(map_fn, remove_columns=remove_columns)
+    return dataset
+
+
+def prepare(start_date, end_date, release_version, output_dir):
+    start_date, end_date = parse_month_range(start_date, end_date)
+    start_yymm = start_date.strftime("%y%m")
+    end_yymm = end_date.strftime("%y%m")
+    output_file_path = os.path.join(output_dir, f"test_{release_version}_{start_yymm}_{end_yymm}.jsonl")
+
+    assert release_version in ["v1", "v2", "v3", "v4", "v5", "v6"]
+
+    data = parse_data(release_version=f"release_{release_version}")
+    data = clean_data(data)
+    print("Len of data: ", len(data))
+
+    print("Writing to file...")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with open(output_file_path, 'w') as f:
+        for problem in data:
+            input_date = datetime.strptime(problem['contest_date'], '%Y-%m-%dT%H:%M:%S').date()
+            if start_date <= input_date <= end_date:
+                json.dump(
+                    {
+                        "task_id": problem["task_id"],
+                        "question": problem["question"],
+                        "difficulty": problem["difficulty"],
+                        "subset_for_metrics": problem["difficulty"],
+                        "release_version": release_version,
+                    },
+                    f,
+                )
+                f.write('\n')
+
+
+DEFAULT_SPLITS = [
+    ('v5', '2024-08', '2025-02'),  # previous default
+    # ('v5', '2024-07', '2024-12'),  # aai split
+    # ('v6', '2024-08', '2025-05'),  # current default in lb
+]
+
+
+if __name__ == '__main__':
+    # Write an argparse to a json file, read it in and parse it
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_dir', type=str, default=str(Path(__file__).parent))
+    parser.add_argument('--release_version', type=str, default='all')
+    parser.add_argument('--start_date', type=str, default='all', help="End date in YYYY-MM format")
+    parser.add_argument('--end_date', type=str, default='all', help="End date in YYYY-MM format")
+
+    args = parser.parse_args()
+
+    if args.release_version == 'all' and args.start_date == 'all' and args.end_date == 'all':
+        # Prepare all splits
+        for release_version, start_date, end_date in DEFAULT_SPLITS:
+            print(f"Processing data for {release_version} from {start_date} to {end_date}")
+            prepare(start_date, end_date, release_version, args.output_dir)
+    else:
+        if args.release_version == 'all' or args.start_date == 'all' or args.end_date == 'all':
+            raise ValueError(
+                "If preparing a custom split, you must specify all "
+                "--release_version, --start_date, and --end_date arguments."
+            )
+        prepare(args.start_date, args.end_date, args.release_version, args.output_dir)
+
+    # test_v5_2408_2502.jsonl: 279 samples
+    # test_v5_2410_2502.jsonl: 166 samples
+    # test_v5_2410_2504.jsonl: 166 samples
+    # test_v6_2408_2502.jsonl: 374 samples
+    # test_v6_2410_2502.jsonl: 261 samples
+    # test_v6_2410_2504.jsonl: 341 samples

--- a/nemo_skills/dataset/livecodebench-es-prompt-en/__init__.py
+++ b/nemo_skills/dataset/livecodebench-es-prompt-en/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'eval/livecodebench/python_codegen'
+DATASET_GROUP = 'code'
+METRICS_TYPE = 'livecodebench'
+# EVAL_SPLIT = 'test_v5_2408_2502'
+# EVAL_SPLIT = 'test_v5_2407_2412'
+EVAL_SPLIT = 'test_v5_2407_2503'
+# EVAL_ARGS = "++eval_type=livecodebench ++eval_config.dataset=livecodebench"
+EVAL_ARGS = "++eval_type=livecodebench"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/livecodebench-es-prompt-en/prepare.py
+++ b/nemo_skills/dataset/livecodebench-es-prompt-en/prepare.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from datasets import load_dataset
+from dateutil.relativedelta import relativedelta
+
+
+class PromptConstants:
+    # reference: https://github.com/QwenLM/Qwen2.5-Coder/blob/main/qwencoder-eval/reasoning/livecode_bench_cot/lcb_runner_cq/prompts/code_generation.py#L31
+    FORMATTING_MESSAGE_WITH_STARTER_CODE = "You will use the following starter code to write the solution to the problem and enclose your code within delimiters."
+    FORMATTING_WITHOUT_STARTER_CODE = "Read the inputs from stdin solve the problem and write the answer to stdout (do not directly test on the sample inputs). Enclose your code within delimiters as follows. Ensure that when the python program runs, it reads the inputs, runs the algorithm and writes output to STDOUT."
+
+
+def parse_data(release_version='release_latest'):
+    data = load_dataset(
+        "livecodebench/code_generation_lite", split="test", version_tag=release_version, trust_remote_code=True
+    )
+    # data has the following fields
+    # question_title: str
+    # question_content: str
+    # platform: Platform
+    # question_id: str
+    # contest_id: str
+    # contest_date: datetime
+    # starter_code: str
+    # difficulty: Difficulty
+    # public_test_cases: list[Test]
+    # private_test_cases: list[Test]
+    # metadata: dict
+    return data
+
+
+def get_first_last_day(year_month_str):
+    try:
+        date_obj = datetime.strptime(year_month_str, "%Y-%m")
+        first_day = date_obj.date().replace(day=1)
+        last_day = (date_obj + relativedelta(months=1, days=-1)).date()
+        return first_day, last_day
+    except ValueError:
+        raise ValueError("Invalid date format. Please use '%Y-%m'.")
+
+
+def parse_month_range(start_date, end_date):
+    try:
+        start_date, _ = get_first_last_day(start_date)
+        _, end_date = get_first_last_day(end_date)
+        return start_date, end_date
+    except ValueError as e:
+        raise ValueError(str(e))
+
+
+def clean_data(dataset):
+    def map_fn(data):
+        question = data["question_content"] + "\n\n"
+        if data["starter_code"]:
+            question += f"{PromptConstants.FORMATTING_MESSAGE_WITH_STARTER_CODE}\n"
+            question += f"```python\n{data['starter_code']}\n```\n\n"
+        else:
+            question += f"{PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n\n"
+            question += f"```python\n# YOUR CODE HERE\n```\n\n"
+
+        data["task_id"] = data["question_id"]
+        data['question'] = question.replace('    ', '\t')
+        return data
+
+    remove_columns = [
+        'question_title',
+        'contest_id',
+        'public_test_cases',
+        'private_test_cases',
+        'metadata',
+        'question_content',
+        'platform',
+        'question_id',
+        'starter_code',
+    ]
+    dataset = dataset.map(map_fn, remove_columns=remove_columns)
+    return dataset
+
+
+def prepare(start_date, end_date, release_version, output_dir):
+    start_date, end_date = parse_month_range(start_date, end_date)
+    start_yymm = start_date.strftime("%y%m")
+    end_yymm = end_date.strftime("%y%m")
+    output_file_path = os.path.join(output_dir, f"test_{release_version}_{start_yymm}_{end_yymm}.jsonl")
+
+    assert release_version in ["v1", "v2", "v3", "v4", "v5", "v6"]
+
+    data = parse_data(release_version=f"release_{release_version}")
+    data = clean_data(data)
+    print("Len of data: ", len(data))
+
+    print("Writing to file...")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with open(output_file_path, 'w') as f:
+        for problem in data:
+            input_date = datetime.strptime(problem['contest_date'], '%Y-%m-%dT%H:%M:%S').date()
+            if start_date <= input_date <= end_date:
+                json.dump(
+                    {
+                        "task_id": problem["task_id"],
+                        "question": problem["question"],
+                        "difficulty": problem["difficulty"],
+                        "subset_for_metrics": problem["difficulty"],
+                        "release_version": release_version,
+                    },
+                    f,
+                )
+                f.write('\n')
+
+
+DEFAULT_SPLITS = [
+    ('v5', '2024-08', '2025-02'),  # previous default
+    # ('v5', '2024-07', '2024-12'),  # aai split
+    # ('v6', '2024-08', '2025-05'),  # current default in lb
+]
+
+
+if __name__ == '__main__':
+    # Write an argparse to a json file, read it in and parse it
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_dir', type=str, default=str(Path(__file__).parent))
+    parser.add_argument('--release_version', type=str, default='all')
+    parser.add_argument('--start_date', type=str, default='all', help="End date in YYYY-MM format")
+    parser.add_argument('--end_date', type=str, default='all', help="End date in YYYY-MM format")
+
+    args = parser.parse_args()
+
+    if args.release_version == 'all' and args.start_date == 'all' and args.end_date == 'all':
+        # Prepare all splits
+        for release_version, start_date, end_date in DEFAULT_SPLITS:
+            print(f"Processing data for {release_version} from {start_date} to {end_date}")
+            prepare(start_date, end_date, release_version, args.output_dir)
+    else:
+        if args.release_version == 'all' or args.start_date == 'all' or args.end_date == 'all':
+            raise ValueError(
+                "If preparing a custom split, you must specify all "
+                "--release_version, --start_date, and --end_date arguments."
+            )
+        prepare(args.start_date, args.end_date, args.release_version, args.output_dir)
+
+    # test_v5_2408_2502.jsonl: 279 samples
+    # test_v5_2410_2502.jsonl: 166 samples
+    # test_v5_2410_2504.jsonl: 166 samples
+    # test_v6_2408_2502.jsonl: 374 samples
+    # test_v6_2410_2502.jsonl: 261 samples
+    # test_v6_2410_2504.jsonl: 341 samples

--- a/nemo_skills/dataset/livecodebench-es-prompt-es/__init__.py
+++ b/nemo_skills/dataset/livecodebench-es-prompt-es/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'eval/livecodebench/python_codegen_es'
+DATASET_GROUP = 'code'
+METRICS_TYPE = 'livecodebench'
+# EVAL_SPLIT = 'test_v5_2408_2502'
+# EVAL_SPLIT = 'test_v5_2407_2412'
+EVAL_SPLIT = 'test_v5_2407_2503'
+# EVAL_ARGS = "++eval_type=livecodebench ++eval_config.dataset=livecodebench"
+EVAL_ARGS = "++eval_type=livecodebench"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/livecodebench-es-prompt-es/prepare.py
+++ b/nemo_skills/dataset/livecodebench-es-prompt-es/prepare.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from datasets import load_dataset
+from dateutil.relativedelta import relativedelta
+
+
+class PromptConstants:
+    # reference: https://github.com/QwenLM/Qwen2.5-Coder/blob/main/qwencoder-eval/reasoning/livecode_bench_cot/lcb_runner_cq/prompts/code_generation.py#L31
+    FORMATTING_MESSAGE_WITH_STARTER_CODE = "You will use the following starter code to write the solution to the problem and enclose your code within delimiters."
+    FORMATTING_WITHOUT_STARTER_CODE = "Read the inputs from stdin solve the problem and write the answer to stdout (do not directly test on the sample inputs). Enclose your code within delimiters as follows. Ensure that when the python program runs, it reads the inputs, runs the algorithm and writes output to STDOUT."
+
+
+def parse_data(release_version='release_latest'):
+    data = load_dataset(
+        "livecodebench/code_generation_lite", split="test", version_tag=release_version, trust_remote_code=True
+    )
+    # data has the following fields
+    # question_title: str
+    # question_content: str
+    # platform: Platform
+    # question_id: str
+    # contest_id: str
+    # contest_date: datetime
+    # starter_code: str
+    # difficulty: Difficulty
+    # public_test_cases: list[Test]
+    # private_test_cases: list[Test]
+    # metadata: dict
+    return data
+
+
+def get_first_last_day(year_month_str):
+    try:
+        date_obj = datetime.strptime(year_month_str, "%Y-%m")
+        first_day = date_obj.date().replace(day=1)
+        last_day = (date_obj + relativedelta(months=1, days=-1)).date()
+        return first_day, last_day
+    except ValueError:
+        raise ValueError("Invalid date format. Please use '%Y-%m'.")
+
+
+def parse_month_range(start_date, end_date):
+    try:
+        start_date, _ = get_first_last_day(start_date)
+        _, end_date = get_first_last_day(end_date)
+        return start_date, end_date
+    except ValueError as e:
+        raise ValueError(str(e))
+
+
+def clean_data(dataset):
+    def map_fn(data):
+        question = data["question_content"] + "\n\n"
+        if data["starter_code"]:
+            question += f"{PromptConstants.FORMATTING_MESSAGE_WITH_STARTER_CODE}\n"
+            question += f"```python\n{data['starter_code']}\n```\n\n"
+        else:
+            question += f"{PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n\n"
+            question += f"```python\n# YOUR CODE HERE\n```\n\n"
+
+        data["task_id"] = data["question_id"]
+        data['question'] = question.replace('    ', '\t')
+        return data
+
+    remove_columns = [
+        'question_title',
+        'contest_id',
+        'public_test_cases',
+        'private_test_cases',
+        'metadata',
+        'question_content',
+        'platform',
+        'question_id',
+        'starter_code',
+    ]
+    dataset = dataset.map(map_fn, remove_columns=remove_columns)
+    return dataset
+
+
+def prepare(start_date, end_date, release_version, output_dir):
+    start_date, end_date = parse_month_range(start_date, end_date)
+    start_yymm = start_date.strftime("%y%m")
+    end_yymm = end_date.strftime("%y%m")
+    output_file_path = os.path.join(output_dir, f"test_{release_version}_{start_yymm}_{end_yymm}.jsonl")
+
+    assert release_version in ["v1", "v2", "v3", "v4", "v5", "v6"]
+
+    data = parse_data(release_version=f"release_{release_version}")
+    data = clean_data(data)
+    print("Len of data: ", len(data))
+
+    print("Writing to file...")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with open(output_file_path, 'w') as f:
+        for problem in data:
+            input_date = datetime.strptime(problem['contest_date'], '%Y-%m-%dT%H:%M:%S').date()
+            if start_date <= input_date <= end_date:
+                json.dump(
+                    {
+                        "task_id": problem["task_id"],
+                        "question": problem["question"],
+                        "difficulty": problem["difficulty"],
+                        "subset_for_metrics": problem["difficulty"],
+                        "release_version": release_version,
+                    },
+                    f,
+                )
+                f.write('\n')
+
+
+DEFAULT_SPLITS = [
+    ('v5', '2024-08', '2025-02'),  # previous default
+    # ('v5', '2024-07', '2024-12'),  # aai split
+    # ('v6', '2024-08', '2025-05'),  # current default in lb
+]
+
+
+if __name__ == '__main__':
+    # Write an argparse to a json file, read it in and parse it
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_dir', type=str, default=str(Path(__file__).parent))
+    parser.add_argument('--release_version', type=str, default='all')
+    parser.add_argument('--start_date', type=str, default='all', help="End date in YYYY-MM format")
+    parser.add_argument('--end_date', type=str, default='all', help="End date in YYYY-MM format")
+
+    args = parser.parse_args()
+
+    if args.release_version == 'all' and args.start_date == 'all' and args.end_date == 'all':
+        # Prepare all splits
+        for release_version, start_date, end_date in DEFAULT_SPLITS:
+            print(f"Processing data for {release_version} from {start_date} to {end_date}")
+            prepare(start_date, end_date, release_version, args.output_dir)
+    else:
+        if args.release_version == 'all' or args.start_date == 'all' or args.end_date == 'all':
+            raise ValueError(
+                "If preparing a custom split, you must specify all "
+                "--release_version, --start_date, and --end_date arguments."
+            )
+        prepare(args.start_date, args.end_date, args.release_version, args.output_dir)
+
+    # test_v5_2408_2502.jsonl: 279 samples
+    # test_v5_2410_2502.jsonl: 166 samples
+    # test_v5_2410_2504.jsonl: 166 samples
+    # test_v6_2408_2502.jsonl: 374 samples
+    # test_v6_2410_2502.jsonl: 261 samples
+    # test_v6_2410_2504.jsonl: 341 samples

--- a/nemo_skills/dataset/livecodebench-fr-prompt-en/__init__.py
+++ b/nemo_skills/dataset/livecodebench-fr-prompt-en/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'eval/livecodebench/python_codegen'
+DATASET_GROUP = 'code'
+METRICS_TYPE = 'livecodebench'
+# EVAL_SPLIT = 'test_v5_2408_2502'
+# EVAL_SPLIT = 'test_v5_2407_2412'
+EVAL_SPLIT = 'test_v5_2407_2503'
+
+# EVAL_ARGS = "++eval_type=livecodebench ++eval_config.dataset=livecodebench"
+EVAL_ARGS = "++eval_type=livecodebench"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/livecodebench-fr-prompt-en/prepare.py
+++ b/nemo_skills/dataset/livecodebench-fr-prompt-en/prepare.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from datasets import load_dataset
+from dateutil.relativedelta import relativedelta
+
+
+class PromptConstants:
+    # reference: https://github.com/QwenLM/Qwen2.5-Coder/blob/main/qwencoder-eval/reasoning/livecode_bench_cot/lcb_runner_cq/prompts/code_generation.py#L31
+    FORMATTING_MESSAGE_WITH_STARTER_CODE = "You will use the following starter code to write the solution to the problem and enclose your code within delimiters."
+    FORMATTING_WITHOUT_STARTER_CODE = "Read the inputs from stdin solve the problem and write the answer to stdout (do not directly test on the sample inputs). Enclose your code within delimiters as follows. Ensure that when the python program runs, it reads the inputs, runs the algorithm and writes output to STDOUT."
+
+
+def parse_data(release_version='release_latest'):
+    data = load_dataset(
+        "livecodebench/code_generation_lite", split="test", version_tag=release_version, trust_remote_code=True
+    )
+    # data has the following fields
+    # question_title: str
+    # question_content: str
+    # platform: Platform
+    # question_id: str
+    # contest_id: str
+    # contest_date: datetime
+    # starter_code: str
+    # difficulty: Difficulty
+    # public_test_cases: list[Test]
+    # private_test_cases: list[Test]
+    # metadata: dict
+    return data
+
+
+def get_first_last_day(year_month_str):
+    try:
+        date_obj = datetime.strptime(year_month_str, "%Y-%m")
+        first_day = date_obj.date().replace(day=1)
+        last_day = (date_obj + relativedelta(months=1, days=-1)).date()
+        return first_day, last_day
+    except ValueError:
+        raise ValueError("Invalid date format. Please use '%Y-%m'.")
+
+
+def parse_month_range(start_date, end_date):
+    try:
+        start_date, _ = get_first_last_day(start_date)
+        _, end_date = get_first_last_day(end_date)
+        return start_date, end_date
+    except ValueError as e:
+        raise ValueError(str(e))
+
+
+def clean_data(dataset):
+    def map_fn(data):
+        question = data["question_content"] + "\n\n"
+        if data["starter_code"]:
+            question += f"{PromptConstants.FORMATTING_MESSAGE_WITH_STARTER_CODE}\n"
+            question += f"```python\n{data['starter_code']}\n```\n\n"
+        else:
+            question += f"{PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n\n"
+            question += f"```python\n# YOUR CODE HERE\n```\n\n"
+
+        data["task_id"] = data["question_id"]
+        data['question'] = question.replace('    ', '\t')
+        return data
+
+    remove_columns = [
+        'question_title',
+        'contest_id',
+        'public_test_cases',
+        'private_test_cases',
+        'metadata',
+        'question_content',
+        'platform',
+        'question_id',
+        'starter_code',
+    ]
+    dataset = dataset.map(map_fn, remove_columns=remove_columns)
+    return dataset
+
+
+def prepare(start_date, end_date, release_version, output_dir):
+    start_date, end_date = parse_month_range(start_date, end_date)
+    start_yymm = start_date.strftime("%y%m")
+    end_yymm = end_date.strftime("%y%m")
+    output_file_path = os.path.join(output_dir, f"test_{release_version}_{start_yymm}_{end_yymm}.jsonl")
+
+    assert release_version in ["v1", "v2", "v3", "v4", "v5", "v6"]
+
+    data = parse_data(release_version=f"release_{release_version}")
+    data = clean_data(data)
+    print("Len of data: ", len(data))
+
+    print("Writing to file...")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with open(output_file_path, 'w') as f:
+        for problem in data:
+            input_date = datetime.strptime(problem['contest_date'], '%Y-%m-%dT%H:%M:%S').date()
+            if start_date <= input_date <= end_date:
+                json.dump(
+                    {
+                        "task_id": problem["task_id"],
+                        "question": problem["question"],
+                        "difficulty": problem["difficulty"],
+                        "subset_for_metrics": problem["difficulty"],
+                        "release_version": release_version,
+                    },
+                    f,
+                )
+                f.write('\n')
+
+
+DEFAULT_SPLITS = [
+    ('v5', '2024-08', '2025-02'),  # previous default
+    # ('v5', '2024-07', '2024-12'),  # aai split
+    # ('v6', '2024-08', '2025-05'),  # current default in lb
+]
+
+
+if __name__ == '__main__':
+    # Write an argparse to a json file, read it in and parse it
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_dir', type=str, default=str(Path(__file__).parent))
+    parser.add_argument('--release_version', type=str, default='all')
+    parser.add_argument('--start_date', type=str, default='all', help="End date in YYYY-MM format")
+    parser.add_argument('--end_date', type=str, default='all', help="End date in YYYY-MM format")
+
+    args = parser.parse_args()
+
+    if args.release_version == 'all' and args.start_date == 'all' and args.end_date == 'all':
+        # Prepare all splits
+        for release_version, start_date, end_date in DEFAULT_SPLITS:
+            print(f"Processing data for {release_version} from {start_date} to {end_date}")
+            prepare(start_date, end_date, release_version, args.output_dir)
+    else:
+        if args.release_version == 'all' or args.start_date == 'all' or args.end_date == 'all':
+            raise ValueError(
+                "If preparing a custom split, you must specify all "
+                "--release_version, --start_date, and --end_date arguments."
+            )
+        prepare(args.start_date, args.end_date, args.release_version, args.output_dir)
+
+    # test_v5_2408_2502.jsonl: 279 samples
+    # test_v5_2410_2502.jsonl: 166 samples
+    # test_v5_2410_2504.jsonl: 166 samples
+    # test_v6_2408_2502.jsonl: 374 samples
+    # test_v6_2410_2502.jsonl: 261 samples
+    # test_v6_2410_2504.jsonl: 341 samples

--- a/nemo_skills/dataset/livecodebench-fr-prompt-fr/__init__.py
+++ b/nemo_skills/dataset/livecodebench-fr-prompt-fr/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'eval/livecodebench/python_codegen_fr'
+DATASET_GROUP = 'code'
+METRICS_TYPE = 'livecodebench'
+# EVAL_SPLIT = 'test_v5_2408_2502'
+# EVAL_SPLIT = 'test_v5_2407_2412'
+EVAL_SPLIT = 'test_v5_2407_2503'
+# EVAL_ARGS = "++eval_type=livecodebench ++eval_config.dataset=livecodebench"
+EVAL_ARGS = "++eval_type=livecodebench"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/livecodebench-fr-prompt-fr/prepare.py
+++ b/nemo_skills/dataset/livecodebench-fr-prompt-fr/prepare.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from datasets import load_dataset
+from dateutil.relativedelta import relativedelta
+
+
+class PromptConstants:
+    # reference: https://github.com/QwenLM/Qwen2.5-Coder/blob/main/qwencoder-eval/reasoning/livecode_bench_cot/lcb_runner_cq/prompts/code_generation.py#L31
+    FORMATTING_MESSAGE_WITH_STARTER_CODE = "You will use the following starter code to write the solution to the problem and enclose your code within delimiters."
+    FORMATTING_WITHOUT_STARTER_CODE = "Read the inputs from stdin solve the problem and write the answer to stdout (do not directly test on the sample inputs). Enclose your code within delimiters as follows. Ensure that when the python program runs, it reads the inputs, runs the algorithm and writes output to STDOUT."
+
+
+def parse_data(release_version='release_latest'):
+    data = load_dataset(
+        "livecodebench/code_generation_lite", split="test", version_tag=release_version, trust_remote_code=True
+    )
+    # data has the following fields
+    # question_title: str
+    # question_content: str
+    # platform: Platform
+    # question_id: str
+    # contest_id: str
+    # contest_date: datetime
+    # starter_code: str
+    # difficulty: Difficulty
+    # public_test_cases: list[Test]
+    # private_test_cases: list[Test]
+    # metadata: dict
+    return data
+
+
+def get_first_last_day(year_month_str):
+    try:
+        date_obj = datetime.strptime(year_month_str, "%Y-%m")
+        first_day = date_obj.date().replace(day=1)
+        last_day = (date_obj + relativedelta(months=1, days=-1)).date()
+        return first_day, last_day
+    except ValueError:
+        raise ValueError("Invalid date format. Please use '%Y-%m'.")
+
+
+def parse_month_range(start_date, end_date):
+    try:
+        start_date, _ = get_first_last_day(start_date)
+        _, end_date = get_first_last_day(end_date)
+        return start_date, end_date
+    except ValueError as e:
+        raise ValueError(str(e))
+
+
+def clean_data(dataset):
+    def map_fn(data):
+        question = data["question_content"] + "\n\n"
+        if data["starter_code"]:
+            question += f"{PromptConstants.FORMATTING_MESSAGE_WITH_STARTER_CODE}\n"
+            question += f"```python\n{data['starter_code']}\n```\n\n"
+        else:
+            question += f"{PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n\n"
+            question += f"```python\n# YOUR CODE HERE\n```\n\n"
+
+        data["task_id"] = data["question_id"]
+        data['question'] = question.replace('    ', '\t')
+        return data
+
+    remove_columns = [
+        'question_title',
+        'contest_id',
+        'public_test_cases',
+        'private_test_cases',
+        'metadata',
+        'question_content',
+        'platform',
+        'question_id',
+        'starter_code',
+    ]
+    dataset = dataset.map(map_fn, remove_columns=remove_columns)
+    return dataset
+
+
+def prepare(start_date, end_date, release_version, output_dir):
+    start_date, end_date = parse_month_range(start_date, end_date)
+    start_yymm = start_date.strftime("%y%m")
+    end_yymm = end_date.strftime("%y%m")
+    output_file_path = os.path.join(output_dir, f"test_{release_version}_{start_yymm}_{end_yymm}.jsonl")
+
+    assert release_version in ["v1", "v2", "v3", "v4", "v5", "v6"]
+
+    data = parse_data(release_version=f"release_{release_version}")
+    data = clean_data(data)
+    print("Len of data: ", len(data))
+
+    print("Writing to file...")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with open(output_file_path, 'w') as f:
+        for problem in data:
+            input_date = datetime.strptime(problem['contest_date'], '%Y-%m-%dT%H:%M:%S').date()
+            if start_date <= input_date <= end_date:
+                json.dump(
+                    {
+                        "task_id": problem["task_id"],
+                        "question": problem["question"],
+                        "difficulty": problem["difficulty"],
+                        "subset_for_metrics": problem["difficulty"],
+                        "release_version": release_version,
+                    },
+                    f,
+                )
+                f.write('\n')
+
+
+DEFAULT_SPLITS = [
+    ('v5', '2024-08', '2025-02'),  # previous default
+    # ('v5', '2024-07', '2024-12'),  # aai split
+    # ('v6', '2024-08', '2025-05'),  # current default in lb
+]
+
+
+if __name__ == '__main__':
+    # Write an argparse to a json file, read it in and parse it
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_dir', type=str, default=str(Path(__file__).parent))
+    parser.add_argument('--release_version', type=str, default='all')
+    parser.add_argument('--start_date', type=str, default='all', help="End date in YYYY-MM format")
+    parser.add_argument('--end_date', type=str, default='all', help="End date in YYYY-MM format")
+
+    args = parser.parse_args()
+
+    if args.release_version == 'all' and args.start_date == 'all' and args.end_date == 'all':
+        # Prepare all splits
+        for release_version, start_date, end_date in DEFAULT_SPLITS:
+            print(f"Processing data for {release_version} from {start_date} to {end_date}")
+            prepare(start_date, end_date, release_version, args.output_dir)
+    else:
+        if args.release_version == 'all' or args.start_date == 'all' or args.end_date == 'all':
+            raise ValueError(
+                "If preparing a custom split, you must specify all "
+                "--release_version, --start_date, and --end_date arguments."
+            )
+        prepare(args.start_date, args.end_date, args.release_version, args.output_dir)
+
+    # test_v5_2408_2502.jsonl: 279 samples
+    # test_v5_2410_2502.jsonl: 166 samples
+    # test_v5_2410_2504.jsonl: 166 samples
+    # test_v6_2408_2502.jsonl: 374 samples
+    # test_v6_2410_2502.jsonl: 261 samples
+    # test_v6_2410_2504.jsonl: 341 samples

--- a/nemo_skills/dataset/livecodebench-ja-prompt-en/__init__.py
+++ b/nemo_skills/dataset/livecodebench-ja-prompt-en/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'eval/livecodebench/python_codegen'
+DATASET_GROUP = 'code'
+METRICS_TYPE = 'livecodebench'
+# EVAL_SPLIT = 'test_v5_2408_2502'
+# EVAL_SPLIT = 'test_v5_2407_2412'
+EVAL_SPLIT = 'test_v5_2407_2503'
+
+# EVAL_ARGS = "++eval_type=livecodebench ++eval_config.dataset=livecodebench
+EVAL_ARGS = "++eval_type=livecodebench"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/livecodebench-ja-prompt-en/prepare.py
+++ b/nemo_skills/dataset/livecodebench-ja-prompt-en/prepare.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from datasets import load_dataset
+from dateutil.relativedelta import relativedelta
+
+
+class PromptConstants:
+    # reference: https://github.com/QwenLM/Qwen2.5-Coder/blob/main/qwencoder-eval/reasoning/livecode_bench_cot/lcb_runner_cq/prompts/code_generation.py#L31
+    FORMATTING_MESSAGE_WITH_STARTER_CODE = "You will use the following starter code to write the solution to the problem and enclose your code within delimiters."
+    FORMATTING_WITHOUT_STARTER_CODE = "Read the inputs from stdin solve the problem and write the answer to stdout (do not directly test on the sample inputs). Enclose your code within delimiters as follows. Ensure that when the python program runs, it reads the inputs, runs the algorithm and writes output to STDOUT."
+
+
+def parse_data(release_version='release_latest'):
+    data = load_dataset(
+        "livecodebench/code_generation_lite", split="test", version_tag=release_version, trust_remote_code=True
+    )
+    # data has the following fields
+    # question_title: str
+    # question_content: str
+    # platform: Platform
+    # question_id: str
+    # contest_id: str
+    # contest_date: datetime
+    # starter_code: str
+    # difficulty: Difficulty
+    # public_test_cases: list[Test]
+    # private_test_cases: list[Test]
+    # metadata: dict
+    return data
+
+
+def get_first_last_day(year_month_str):
+    try:
+        date_obj = datetime.strptime(year_month_str, "%Y-%m")
+        first_day = date_obj.date().replace(day=1)
+        last_day = (date_obj + relativedelta(months=1, days=-1)).date()
+        return first_day, last_day
+    except ValueError:
+        raise ValueError("Invalid date format. Please use '%Y-%m'.")
+
+
+def parse_month_range(start_date, end_date):
+    try:
+        start_date, _ = get_first_last_day(start_date)
+        _, end_date = get_first_last_day(end_date)
+        return start_date, end_date
+    except ValueError as e:
+        raise ValueError(str(e))
+
+
+def clean_data(dataset):
+    def map_fn(data):
+        question = data["question_content"] + "\n\n"
+        if data["starter_code"]:
+            question += f"{PromptConstants.FORMATTING_MESSAGE_WITH_STARTER_CODE}\n"
+            question += f"```python\n{data['starter_code']}\n```\n\n"
+        else:
+            question += f"{PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n\n"
+            question += f"```python\n# YOUR CODE HERE\n```\n\n"
+
+        data["task_id"] = data["question_id"]
+        data['question'] = question.replace('    ', '\t')
+        return data
+
+    remove_columns = [
+        'question_title',
+        'contest_id',
+        'public_test_cases',
+        'private_test_cases',
+        'metadata',
+        'question_content',
+        'platform',
+        'question_id',
+        'starter_code',
+    ]
+    dataset = dataset.map(map_fn, remove_columns=remove_columns)
+    return dataset
+
+
+def prepare(start_date, end_date, release_version, output_dir):
+    start_date, end_date = parse_month_range(start_date, end_date)
+    start_yymm = start_date.strftime("%y%m")
+    end_yymm = end_date.strftime("%y%m")
+    output_file_path = os.path.join(output_dir, f"test_{release_version}_{start_yymm}_{end_yymm}.jsonl")
+
+    assert release_version in ["v1", "v2", "v3", "v4", "v5", "v6"]
+
+    data = parse_data(release_version=f"release_{release_version}")
+    data = clean_data(data)
+    print("Len of data: ", len(data))
+
+    print("Writing to file...")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with open(output_file_path, 'w') as f:
+        for problem in data:
+            input_date = datetime.strptime(problem['contest_date'], '%Y-%m-%dT%H:%M:%S').date()
+            if start_date <= input_date <= end_date:
+                json.dump(
+                    {
+                        "task_id": problem["task_id"],
+                        "question": problem["question"],
+                        "difficulty": problem["difficulty"],
+                        "subset_for_metrics": problem["difficulty"],
+                        "release_version": release_version,
+                    },
+                    f,
+                )
+                f.write('\n')
+
+
+DEFAULT_SPLITS = [
+    ('v5', '2024-08', '2025-02'),  # previous default
+    # ('v5', '2024-07', '2024-12'),  # aai split
+    # ('v6', '2024-08', '2025-05'),  # current default in lb
+]
+
+
+if __name__ == '__main__':
+    # Write an argparse to a json file, read it in and parse it
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_dir', type=str, default=str(Path(__file__).parent))
+    parser.add_argument('--release_version', type=str, default='all')
+    parser.add_argument('--start_date', type=str, default='all', help="End date in YYYY-MM format")
+    parser.add_argument('--end_date', type=str, default='all', help="End date in YYYY-MM format")
+
+    args = parser.parse_args()
+
+    if args.release_version == 'all' and args.start_date == 'all' and args.end_date == 'all':
+        # Prepare all splits
+        for release_version, start_date, end_date in DEFAULT_SPLITS:
+            print(f"Processing data for {release_version} from {start_date} to {end_date}")
+            prepare(start_date, end_date, release_version, args.output_dir)
+    else:
+        if args.release_version == 'all' or args.start_date == 'all' or args.end_date == 'all':
+            raise ValueError(
+                "If preparing a custom split, you must specify all "
+                "--release_version, --start_date, and --end_date arguments."
+            )
+        prepare(args.start_date, args.end_date, args.release_version, args.output_dir)
+
+    # test_v5_2408_2502.jsonl: 279 samples
+    # test_v5_2410_2502.jsonl: 166 samples
+    # test_v5_2410_2504.jsonl: 166 samples
+    # test_v6_2408_2502.jsonl: 374 samples
+    # test_v6_2410_2502.jsonl: 261 samples
+    # test_v6_2410_2504.jsonl: 341 samples

--- a/nemo_skills/dataset/livecodebench-ja-prompt-ja/__init__.py
+++ b/nemo_skills/dataset/livecodebench-ja-prompt-ja/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+PROMPT_CONFIG = 'eval/livecodebench/python_codegen_ja'
+DATASET_GROUP = 'code'
+METRICS_TYPE = 'livecodebench'
+# EVAL_SPLIT = 'test_v5_2408_2502'
+# EVAL_SPLIT = 'test_v5_2407_2412'
+EVAL_SPLIT = 'test_v5_2407_2503'
+# EVAL_ARGS = "++eval_type=livecodebench ++eval_config.dataset=livecodebench
+EVAL_ARGS = "++eval_type=livecodebench"
+GENERATION_ARGS = ""

--- a/nemo_skills/dataset/livecodebench-ja-prompt-ja/prepare.py
+++ b/nemo_skills/dataset/livecodebench-ja-prompt-ja/prepare.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from datasets import load_dataset
+from dateutil.relativedelta import relativedelta
+
+
+class PromptConstants:
+    # reference: https://github.com/QwenLM/Qwen2.5-Coder/blob/main/qwencoder-eval/reasoning/livecode_bench_cot/lcb_runner_cq/prompts/code_generation.py#L31
+    FORMATTING_MESSAGE_WITH_STARTER_CODE = "You will use the following starter code to write the solution to the problem and enclose your code within delimiters."
+    FORMATTING_WITHOUT_STARTER_CODE = "Read the inputs from stdin solve the problem and write the answer to stdout (do not directly test on the sample inputs). Enclose your code within delimiters as follows. Ensure that when the python program runs, it reads the inputs, runs the algorithm and writes output to STDOUT."
+
+
+def parse_data(release_version='release_latest'):
+    data = load_dataset(
+        "livecodebench/code_generation_lite", split="test", version_tag=release_version, trust_remote_code=True
+    )
+    # data has the following fields
+    # question_title: str
+    # question_content: str
+    # platform: Platform
+    # question_id: str
+    # contest_id: str
+    # contest_date: datetime
+    # starter_code: str
+    # difficulty: Difficulty
+    # public_test_cases: list[Test]
+    # private_test_cases: list[Test]
+    # metadata: dict
+    return data
+
+
+def get_first_last_day(year_month_str):
+    try:
+        date_obj = datetime.strptime(year_month_str, "%Y-%m")
+        first_day = date_obj.date().replace(day=1)
+        last_day = (date_obj + relativedelta(months=1, days=-1)).date()
+        return first_day, last_day
+    except ValueError:
+        raise ValueError("Invalid date format. Please use '%Y-%m'.")
+
+
+def parse_month_range(start_date, end_date):
+    try:
+        start_date, _ = get_first_last_day(start_date)
+        _, end_date = get_first_last_day(end_date)
+        return start_date, end_date
+    except ValueError as e:
+        raise ValueError(str(e))
+
+
+def clean_data(dataset):
+    def map_fn(data):
+        question = data["question_content"] + "\n\n"
+        if data["starter_code"]:
+            question += f"{PromptConstants.FORMATTING_MESSAGE_WITH_STARTER_CODE}\n"
+            question += f"```python\n{data['starter_code']}\n```\n\n"
+        else:
+            question += f"{PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n\n"
+            question += f"```python\n# YOUR CODE HERE\n```\n\n"
+
+        data["task_id"] = data["question_id"]
+        data['question'] = question.replace('    ', '\t')
+        return data
+
+    remove_columns = [
+        'question_title',
+        'contest_id',
+        'public_test_cases',
+        'private_test_cases',
+        'metadata',
+        'question_content',
+        'platform',
+        'question_id',
+        'starter_code',
+    ]
+    dataset = dataset.map(map_fn, remove_columns=remove_columns)
+    return dataset
+
+
+def prepare(start_date, end_date, release_version, output_dir):
+    start_date, end_date = parse_month_range(start_date, end_date)
+    start_yymm = start_date.strftime("%y%m")
+    end_yymm = end_date.strftime("%y%m")
+    output_file_path = os.path.join(output_dir, f"test_{release_version}_{start_yymm}_{end_yymm}.jsonl")
+
+    assert release_version in ["v1", "v2", "v3", "v4", "v5", "v6"]
+
+    data = parse_data(release_version=f"release_{release_version}")
+    data = clean_data(data)
+    print("Len of data: ", len(data))
+
+    print("Writing to file...")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with open(output_file_path, 'w') as f:
+        for problem in data:
+            input_date = datetime.strptime(problem['contest_date'], '%Y-%m-%dT%H:%M:%S').date()
+            if start_date <= input_date <= end_date:
+                json.dump(
+                    {
+                        "task_id": problem["task_id"],
+                        "question": problem["question"],
+                        "difficulty": problem["difficulty"],
+                        "subset_for_metrics": problem["difficulty"],
+                        "release_version": release_version,
+                    },
+                    f,
+                )
+                f.write('\n')
+
+
+DEFAULT_SPLITS = [
+    ('v5', '2024-08', '2025-02'),  # previous default
+    # ('v5', '2024-07', '2024-12'),  # aai split
+    # ('v6', '2024-08', '2025-05'),  # current default in lb
+]
+
+
+if __name__ == '__main__':
+    # Write an argparse to a json file, read it in and parse it
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_dir', type=str, default=str(Path(__file__).parent))
+    parser.add_argument('--release_version', type=str, default='all')
+    parser.add_argument('--start_date', type=str, default='all', help="End date in YYYY-MM format")
+    parser.add_argument('--end_date', type=str, default='all', help="End date in YYYY-MM format")
+
+    args = parser.parse_args()
+
+    if args.release_version == 'all' and args.start_date == 'all' and args.end_date == 'all':
+        # Prepare all splits
+        for release_version, start_date, end_date in DEFAULT_SPLITS:
+            print(f"Processing data for {release_version} from {start_date} to {end_date}")
+            prepare(start_date, end_date, release_version, args.output_dir)
+    else:
+        if args.release_version == 'all' or args.start_date == 'all' or args.end_date == 'all':
+            raise ValueError(
+                "If preparing a custom split, you must specify all "
+                "--release_version, --start_date, and --end_date arguments."
+            )
+        prepare(args.start_date, args.end_date, args.release_version, args.output_dir)
+
+    # test_v5_2408_2502.jsonl: 279 samples
+    # test_v5_2410_2502.jsonl: 166 samples
+    # test_v5_2410_2504.jsonl: 166 samples
+    # test_v6_2408_2502.jsonl: 374 samples
+    # test_v6_2410_2502.jsonl: 261 samples
+    # test_v6_2410_2504.jsonl: 341 samples

--- a/nemo_skills/evaluation/metrics/map_metrics.py
+++ b/nemo_skills/evaluation/metrics/map_metrics.py
@@ -37,6 +37,7 @@ from nemo_skills.evaluation.metrics.if_metrics import IFMetrics
 from nemo_skills.evaluation.metrics.ioi_metrics import IOIMetrics
 from nemo_skills.evaluation.metrics.lean4_metrics import Lean4Metrics
 from nemo_skills.evaluation.metrics.math_metrics import MathMetrics
+from nemo_skills.evaluation.metrics.math_multilingual_metrics import MathMultilingualMetrics
 from nemo_skills.evaluation.metrics.mmau_pro_metrics import MMAUProMetrics
 from nemo_skills.evaluation.metrics.mrcr_metrics import MRCRMetrics
 from nemo_skills.evaluation.metrics.omni_metrics import OmniMetrics
@@ -64,6 +65,7 @@ METRICS_MAP = {
     "ioi": IOIMetrics,
     "icpc": ICPCMetrics,
     "multichoice": MathMetrics,
+    "multichoice_multilingual": MathMultilingualMetrics,
     "ruler": RulerMetrics,
     "ruler2": RulerMetrics,
     "livecodebench": LiveCodeBenchMetrics,

--- a/nemo_skills/evaluation/metrics/math_multilingual_metrics.py
+++ b/nemo_skills/evaluation/metrics/math_multilingual_metrics.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from collections import defaultdict
+
+from nemo_skills.evaluation.metrics.base import BaseMetrics, as_int, as_percentage
+from nemo_skills.evaluation.metrics.utils import is_correct_judgement
+from nemo_skills.utils import get_logger_name
+from langdetect import detect, DetectorFactory, LangDetectException
+import sys
+
+# Set seed for consistent results
+DetectorFactory.seed = 42
+
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+
+class MathMultilingualMetrics(BaseMetrics):
+    # TODO: how can we ensure that user-defined aggregations have all the same metrics as in base?
+
+    def __init__(self, compute_no_answer: bool = True, answer_key: str = "predicted_answer"):
+        super().__init__(compute_no_answer=compute_no_answer)
+        self.answer_key = answer_key
+
+    def _compute_reward_at_k(self, predictions: list[dict]):
+        score_dicts = [self._get_score_dict(pred) for pred in predictions]
+
+        for k in range(1, len(predictions) + 1):
+            for score_method in score_dicts[0].keys():
+                # Get valid answers and their results for this field
+                valid_answers_and_results = [
+                    (elem[self.answer_key], correctness_dict[score_method], elem["reward_model_score"])
+                    for elem, correctness_dict in zip(predictions[:k], score_dicts[:k])
+                    if elem[self.answer_key] is not None
+                ]
+
+                # If no valid answers, it's incorrect
+                if not valid_answers_and_results:
+                    is_correct = False
+                else:
+                    is_correct_best = sorted(valid_answers_and_results, key=lambda x: x[2], reverse=True)[0][1]
+                    self.eval_dict[f"rm_best@{k}"][score_method] += is_correct_best
+
+                    answer_to_score_dict = defaultdict(float)
+                    answer_to_correctness_dict = {}
+                    for predicted_answer, is_correct, reward_score in valid_answers_and_results:
+                        answer_to_score_dict[predicted_answer] += reward_score
+                        answer_to_correctness_dict[predicted_answer] = is_correct
+
+                    top_cum_reward_answer = sorted(
+                        list(answer_to_score_dict.items()), key=lambda x: x[1], reverse=True
+                    )[0][0]
+                    is_correct_majority = answer_to_correctness_dict[top_cum_reward_answer]
+                    self.eval_dict[f"rm_majority@{k}"][score_method] += is_correct_majority
+
+            no_answer = all(elem[self.answer_key] is None for elem in predictions[:k])
+            self.eval_dict[f"rm_best@{k}"]["no_answer"] += no_answer
+            self.eval_dict[f"rm_majority@{k}"]["no_answer"] += no_answer
+
+    def _get_score_dict(self, prediction: dict) -> dict[str, bool | int | float]:
+        correctness_dict = {}
+        if "target_language" in prediction:
+            language_correct = self._detect_language(prediction["generation"]) == prediction["target_language"]
+        else:
+            language_correct = False
+        if "symbolic_correct" in prediction:
+            correctness_dict["symbolic_correct"] = prediction["symbolic_correct"]
+            correctness_dict["symbolic_and_language_correct"] = language_correct and prediction["symbolic_correct"]
+        if "judgement" in prediction:
+            correctness_dict["judge_correct"] = is_correct_judgement(prediction["judgement"])
+            correctness_dict["judge_and_language_correct"] = language_correct and prediction["judge_correct"]
+        if "judge_correct" in correctness_dict and "symbolic_correct" in correctness_dict:
+            correctness_dict["both_correct"] = (
+                correctness_dict["symbolic_correct"] and correctness_dict["judge_correct"]
+            )
+            correctness_dict["both_language_correct"] = (
+                correctness_dict["symbolic_and_language_correct"] and correctness_dict["judge_and_language_correct"]
+            )
+            correctness_dict["any_correct"] = correctness_dict["symbolic_correct"] or correctness_dict["judge_correct"]
+            correctness_dict["any_language_correct"] = correctness_dict["symbolic_and_language_correct"] or correctness_dict["judge_and_language_correct"]
+        return correctness_dict
+
+    def get_incorrect_sample(self, prediction: dict) -> dict:
+        prediction = prediction.copy()
+        if "symbolic_correct" in prediction:
+            prediction["symbolic_correct"] = False
+        if "judgement" in prediction:
+            prediction["judgement"] = "Judgement: No"
+        prediction[self.answer_key] = None
+        return prediction
+
+    def update(self, predictions):
+        """Updating the evaluation results with the current element.
+
+        Args:
+            predictions (list[dict]): aggregated predictions across all generations.
+                The content of the file is benchmark specific.
+        """
+        super().update(predictions)
+        predicted_answers = [pred[self.answer_key] for pred in predictions]
+        self._compute_pass_at_k(predictions=predictions, predicted_answers=predicted_answers)
+        self._compute_majority_at_k(predictions=predictions, predicted_answers=predicted_answers)
+
+        if "reward_model_score" in predictions[0]:
+            self._compute_reward_at_k(predictions=predictions)
+
+        # Log discrepancies between the two judgements
+        for prediction in predictions:
+            correctness_dict = self._get_score_dict(prediction)
+            if "symbolic_correct" not in correctness_dict or "judge_correct" not in correctness_dict:
+                continue
+            if correctness_dict["symbolic_correct"] != correctness_dict["judge_correct"]:
+                LOG.debug(
+                    "Discrepancy between symbolic (%s) and LLM checkers (%s).\n"
+                    "Question: %s\nPredicted answer: %s\nExpected answer: %s\nLLM reasoning: %s\n",
+                    correctness_dict["symbolic_correct"],
+                    correctness_dict["judge_correct"],
+                    prediction["problem"],
+                    prediction[self.answer_key],
+                    prediction["expected_answer"],
+                    prediction["judgement"],
+                )
+
+    def evaluations_to_print(self):
+        """We will log all majority/rm/pass/pass@1[avg-of-k] up to k, but only report the kth one."""
+        return [
+            f"pass@1[avg-of-{self.max_k}]",
+            f"majority@{self.max_k}",
+            f"rm_best@{self.max_k}",
+            f"rm_majority@{self.max_k}",
+            f"pass@{self.max_k}",
+        ]
+
+    def metrics_to_print(self):
+        metrics_to_print = {
+            "num_entries": as_int,
+            "avg_tokens": as_int,
+            "gen_seconds": as_int,
+            "judge_correct": as_percentage,
+            "symbolic_correct": as_percentage,
+            "symbolic_and_language_correct": as_percentage,
+        }
+        if self.compute_no_answer:
+            metrics_to_print["no_answer"] = as_percentage
+        return metrics_to_print
+    
+    def _detect_language(self, text):
+        """
+        Detect the language of a given text.
+        
+        Args:
+            text (str): The text to analyze
+            
+        Returns:
+            str: The detected language code (e.g., 'en', 'es', 'fr') or 'unknown'
+        """
+        if not text or not text.strip():
+            return 'unknown'
+        
+        try:
+            # Clean the text by removing excessive whitespace
+            cleaned_text = ' '.join(text.split())
+            if len(cleaned_text) < 3:  # Too short to detect reliably
+                return 'unknown'
+            
+            detected_lang = detect(cleaned_text)
+            return detected_lang
+        except LangDetectException:
+            return 'unknown'

--- a/nemo_skills/prompt/config/eval/livecodebench/python_codegen_de.yaml
+++ b/nemo_skills/prompt/config/eval/livecodebench/python_codegen_de.yaml
@@ -1,0 +1,14 @@
+# Standard-Prompt für livecodebench Python
+# Original: default prompt for livecodebench Python
+
+system: ""
+
+# user: |-
+#   Here is a problem for which you need to generate an executable code in python programming language.
+
+#   {question}
+
+user: |-
+  Hier ist ein Problem, für das Sie ausführbaren Code in der Programmiersprache Python generieren müssen.
+
+  {question}

--- a/nemo_skills/prompt/config/eval/livecodebench/python_codegen_es.yaml
+++ b/nemo_skills/prompt/config/eval/livecodebench/python_codegen_es.yaml
@@ -1,0 +1,13 @@
+# default prompt for livecodebench Python
+
+system: ""
+
+# user: |-
+#   Here is a problem for which you need to generate an executable code in python programming language.
+
+#   {question}
+
+user: |-
+  Aquí tienes un problema para el cual necesitas generar un código ejecutable en el lenguaje de programación Python.
+
+  {question}

--- a/nemo_skills/prompt/config/eval/livecodebench/python_codegen_fr.yaml
+++ b/nemo_skills/prompt/config/eval/livecodebench/python_codegen_fr.yaml
@@ -1,0 +1,13 @@
+# default prompt for livecodebench Python
+
+system: ""
+
+# user: |-
+#   Here is a problem for which you need to generate an executable code in python programming language.
+
+#   {question}
+
+user: |-
+  Voici un problème pour lequel vous devez générer du code exécutable en langage de programmation Python.
+
+  {question}

--- a/nemo_skills/prompt/config/eval/livecodebench/python_codegen_ja.yaml
+++ b/nemo_skills/prompt/config/eval/livecodebench/python_codegen_ja.yaml
@@ -1,0 +1,13 @@
+# default prompt for livecodebench Python
+
+system: ""
+
+# user: |-
+#   Here is a problem for which you need to generate an executable code in python programming language.
+
+#   {question}
+
+user: |-
+  以下は、Pythonプログラミング言語で実行可能なコードを生成する必要がある問題です。
+
+  {question}

--- a/nemo_skills/prompt/config/multilingual/general-boxed_de.yaml
+++ b/nemo_skills/prompt/config/multilingual/general-boxed_de.yaml
@@ -1,0 +1,25 @@
+# prompt for any benchmarks evaluated with boxed (e.g. math, mmlu-pro, gpqa)
+
+few_shot_examples:
+  # prefix: "Here are some examples of problems and solutions you can refer to.\n\n"
+  # template: "Problem:\n{problem}\n\nSolution:\n{solution}\n\n\n\n\n\n"
+  # suffix: "Here is the problem you need to solve:\n"
+  prefix: "Hier sind einige Beispiele für Probleme und Lösungen, auf die Sie sich beziehen können.\n\n"
+  template: "Problem:\n{problem}\n\nLösung:\n{solution}\n\n\n\n\n\n"
+  suffix: "Hier ist das Problem, das Sie lösen müssen:\n"
+  # this is built as <prefix>{template.format(example1)}{template.format(example2)}...{template.format(exampleN)}<suffix>
+  # and available as {examples} key in the final prompt
+  # if examples_type is not specified, then {examples} will be empty
+  # by default there are no examples, but can be changed from code/cmd
+
+system: ""
+
+# user: |-
+#   Solve the following problem. Make sure to put the answer (and only answer) inside \boxed{{}}.
+
+#   {examples}{problem}
+
+user: |-
+  Lösen Sie das folgende Problem. Stellen Sie sicher, dass Sie die Antwort (und nur die Antwort) in \boxed{{}} setzen.
+
+  {examples}{problem}

--- a/nemo_skills/prompt/config/multilingual/general-boxed_es.yaml
+++ b/nemo_skills/prompt/config/multilingual/general-boxed_es.yaml
@@ -1,0 +1,25 @@
+# prompt for any benchmarks evaluated with boxed (e.g. math, mmlu-pro, gpqa)
+
+few_shot_examples:
+  # prefix: "Here are some examples of problems and solutions you can refer to.\n\n"
+  # template: "Problem:\n{problem}\n\nSolution:\n{solution}\n\n\n\n\n\n"
+  # suffix: "Here is the problem you need to solve:\n"
+  prefix: "Aquí tienes algunos ejemplos de problemas y soluciones que puedes consultar.\n\n"
+  template: "Problema:\n{problem}\n\nSolución:\n{solution}\n\n\n\n\n\n"
+  suffix: "Aquí tienes el problema que necesitas resolver:\n"
+  # this is built as <prefix>{template.format(example1)}{template.format(example2)}...{template.format(exampleN)}<suffix>
+  # and available as {examples} key in the final prompt
+  # if examples_type is not specified, then {examples} will be empty
+  # by default there are no examples, but can be changed from code/cmd
+
+system: ""
+
+# user: |-
+#   Solve the following problem. Make sure to put the answer (and only answer) inside \boxed{{}}.
+
+#   {examples}{problem}
+
+user: |-
+  Resuelve el siguiente problema. Asegúrate de poner la respuesta (y solo la respuesta) dentro de \boxed{{}}.
+
+  {examples}{problem}

--- a/nemo_skills/prompt/config/multilingual/general-boxed_fr.yaml
+++ b/nemo_skills/prompt/config/multilingual/general-boxed_fr.yaml
@@ -1,0 +1,25 @@
+# prompt for any benchmarks evaluated with boxed (e.g. math, mmlu-pro, gpqa)
+
+few_shot_examples:
+  # prefix: "Here are some examples of problems and solutions you can refer to.\n\n"
+  # template: "Problem:\n{problem}\n\nSolution:\n{solution}\n\n\n\n\n\n"
+  # suffix: "Here is the problem you need to solve:\n"
+  prefix: "Voici quelques exemples de problèmes et de solutions auxquels vous pouvez vous référer.\n\n"
+  template: "Problème:\n{problem}\n\nSolution:\n{solution}\n\n\n\n\n\n"
+  suffix: "Voici le problème que vous devez résoudre:\n"
+  # this is built as <prefix>{template.format(example1)}{template.format(example2)}...{template.format(exampleN)}<suffix>
+  # and available as {examples} key in the final prompt
+  # if examples_type is not specified, then {examples} will be empty
+  # by default there are no examples, but can be changed from code/cmd
+
+system: ""
+
+# user: |-
+#   Solve the following problem. Make sure to put the answer (and only answer) inside \boxed{{}}.
+
+#   {examples}{problem}
+
+user: |-
+  Résolvez le problème suivant. Assurez-vous de mettre la réponse (et seulement la réponse) dans \boxed{{}}.
+
+  {examples}{problem}

--- a/nemo_skills/prompt/config/multilingual/general-boxed_ja.yaml
+++ b/nemo_skills/prompt/config/multilingual/general-boxed_ja.yaml
@@ -1,0 +1,25 @@
+# prompt for any benchmarks evaluated with boxed (e.g. math, mmlu-pro, gpqa)
+
+few_shot_examples:
+  # prefix: "Here are some examples of problems and solutions you can refer to.\n\n"
+  # template: "Problem:\n{problem}\n\nSolution:\n{solution}\n\n\n\n\n\n"
+  # suffix: "Here is the problem you need to solve:\n"
+  prefix: "参考にできる問題と解答の例を以下に示します。\n\n"
+  template: "問題：\n{problem}\n\n解答：\n{solution}\n\n\n\n\n\n"
+  suffix: "解決すべき問題は以下の通りです：\n"
+  # this is built as <prefix>{template.format(example1)}{template.format(example2)}...{template.format(exampleN)}<suffix>
+  # and available as {examples} key in the final prompt
+  # if examples_type is not specified, then {examples} will be empty
+  # by default there are no examples, but can be changed from code/cmd
+
+system: ""
+
+# user: |-
+#   Solve the following problem. Make sure to put the answer (and only answer) inside \boxed{{}}.
+
+#   {examples}{problem}
+
+user: |-
+  以下の問題を解いてください。答え（答えのみ）を\boxed{{}}の中に入れてください。
+
+  {examples}{problem}

--- a/nemo_skills/prompt/config/multilingual/math_de.yaml
+++ b/nemo_skills/prompt/config/multilingual/math_de.yaml
@@ -1,0 +1,25 @@
+# default prompt for all math benchmarks (e.g. gsm8k, math)
+
+few_shot_examples:
+  # prefix: "Here are some examples of problems and solutions you can refer to.\n\n"
+  # template: "Problem:\n{problem}\n\nSolution:\n{solution}\n\n\n\n\n\n"
+  # suffix: "Here is the problem you need to solve:\n"
+  prefix: "Hier sind einige Beispiele für Probleme und Lösungen, auf die Sie sich beziehen können.\n\n"
+  template: "Problem:\n{problem}\n\nLösung:\n{solution}\n\n\n\n\n\n"
+  suffix: "Hier ist das Problem, das Sie lösen müssen:\n"
+  # this is built as <prefix>{template.format(example1)}{template.format(example2)}...{template.format(exampleN)}<suffix>
+  # and available as {examples} key in the final prompt
+  # if examples_type is not specified, then {examples} will be empty
+  # by default there are no examples, but can be changed from code/cmd
+
+system: ""
+
+# user: |-
+#   Solve the following math problem. Make sure to put the answer (and only answer) inside \boxed{{}}.
+
+#   {examples}{problem}
+
+user: |-
+  Lösen Sie das folgende Mathematikproblem. Stellen Sie sicher, dass Sie die Antwort (und nur die Antwort) in \boxed{{}} setzen.
+
+  {examples}{problem}

--- a/nemo_skills/prompt/config/multilingual/math_es.yaml
+++ b/nemo_skills/prompt/config/multilingual/math_es.yaml
@@ -1,0 +1,25 @@
+# default prompt for all math benchmarks (e.g. gsm8k, math)
+
+few_shot_examples:
+  # prefix: "Here are some examples of problems and solutions you can refer to.\n\n"
+  # template: "Problem:\n{problem}\n\nSolution:\n{solution}\n\n\n\n\n\n"
+  # suffix: "Here is the problem you need to solve:\n"
+  prefix: "Aquí tienes algunos ejemplos de problemas y soluciones que puedes consultar.\n\n"
+  template: "Problema:\n{problem}\n\nSolución:\n{solution}\n\n\n\n\n\n"
+  suffix: "Aquí tienes el problema que necesitas resolver:\n"
+  # this is built as <prefix>{template.format(example1)}{template.format(example2)}...{template.format(exampleN)}<suffix>
+  # and available as {examples} key in the final prompt
+  # if examples_type is not specified, then {examples} will be empty
+  # by default there are no examples, but can be changed from code/cmd
+
+system: ""
+
+# user: |-
+#   Solve the following math problem. Make sure to put the answer (and only answer) inside \boxed{{}}.
+
+#   {examples}{problem}
+
+user: |-
+  Resuelve el siguiente problema matemático. Asegúrate de poner la respuesta (y solo la respuesta) dentro de \boxed{{}}.
+
+  {examples}{problem}

--- a/nemo_skills/prompt/config/multilingual/math_fr.yaml
+++ b/nemo_skills/prompt/config/multilingual/math_fr.yaml
@@ -1,0 +1,25 @@
+# default prompt for all math benchmarks (e.g. gsm8k, math)
+
+few_shot_examples:
+  # prefix: "Here are some examples of problems and solutions you can refer to.\n\n"
+  # template: "Problem:\n{problem}\n\nSolution:\n{solution}\n\n\n\n\n\n"
+  # suffix: "Here is the problem you need to solve:\n"
+  prefix: "Voici quelques exemples de problèmes et de solutions auxquels vous pouvez vous référer.\n\n"
+  template: "Problème:\n{problem}\n\nSolution:\n{solution}\n\n\n\n\n\n"
+  suffix: "Voici le problème que vous devez résoudre:\n"
+  # this is built as <prefix>{template.format(example1)}{template.format(example2)}...{template.format(exampleN)}<suffix>
+  # and available as {examples} key in the final prompt
+  # if examples_type is not specified, then {examples} will be empty
+  # by default there are no examples, but can be changed from code/cmd
+
+system: ""
+
+# user: |-
+#   Solve the following math problem. Make sure to put the answer (and only answer) inside \boxed{{}}.
+
+#   {examples}{problem}
+
+user: |-
+  Résolvez le problème mathématique suivant. Assurez-vous de mettre la réponse (et seulement la réponse) dans \boxed{{}}.
+
+  {examples}{problem}

--- a/nemo_skills/prompt/config/multilingual/math_ja.yaml
+++ b/nemo_skills/prompt/config/multilingual/math_ja.yaml
@@ -1,0 +1,25 @@
+# default prompt for all math benchmarks (e.g. gsm8k, math)
+
+few_shot_examples:
+  # prefix: "Here are some examples of problems and solutions you can refer to.\n\n"
+  # template: "Problem:\n{problem}\n\nSolution:\n{solution}\n\n\n\n\n\n"
+  # suffix: "Here is the problem you need to solve:\n"
+  prefix: "参考にできる問題と解答の例を以下に示します。\n\n"
+  template: "問題：\n{problem}\n\n解答：\n{solution}\n\n\n\n\n\n"
+  suffix: "解決すべき問題は以下の通りです：\n"
+  # this is built as <prefix>{template.format(example1)}{template.format(example2)}...{template.format(exampleN)}<suffix>
+  # and available as {examples} key in the final prompt
+  # if examples_type is not specified, then {examples} will be empty
+  # by default there are no examples, but can be changed from code/cmd
+
+system: ""
+
+# user: |-
+#   Solve the following math problem. Make sure to put the answer (and only answer) inside \boxed{{}}.
+
+#   {examples}{problem}
+
+user: |-
+  以下の数学問題を解いてください。答え（答えのみ）を\boxed{{}}の中に入れてください。
+
+  {examples}{problem}


### PR DESCRIPTION
add multilingual aime25, gqpa and lcb and corresponding metrics calculation code.
The source data is not included yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multilingual dataset support for AIME25 (German, Spanish, French, Japanese) and GPQA (German, Spanish, French, Japanese) benchmarks across English and native language prompts.
  * Added LiveCodeBench dataset support in German, Spanish, French, and Japanese.
  * Introduced multilingual math evaluation metrics supporting language and symbolic correctness assessment.
  * Added multilingual prompt configurations for math and code benchmarks in German, Spanish, French, and Japanese.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->