### PR TITLE
Fix incorrect string format

### DIFF
--- a/nemo_skills/prompt/config/compute-eval/baseline.yaml
+++ b/nemo_skills/prompt/config/compute-eval/baseline.yaml
@@ -48,13 +48,13 @@ user: |-
 
   Problem
   Description:
-  $problem_prompt
+  {problem_prompt}
 
   Build command:
-  $build_command
+  {build_command}
 
   Context files:
-  $context_files_block
+  {context_files_block}
 
   Output requirements
 


### PR DESCRIPTION
I mistakenly used the `Template` format in the user prompt and we should be using the `str.format` directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated template placeholder syntax in configuration to use modern interpolation format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->