### PR TITLE
Fix: Add missing latex2sympy2_extended to requirements

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -33,6 +33,7 @@ ipython
 iso639-lang
 langcodes
 language-data
+latex2sympy2_extended  # Needed for math evaluation
 litellm[caching]
 math-verify[antlr4_9_3]
 mcp


### PR DESCRIPTION
## Description

Adds missing dependency `latex2sympy2_extended` to [requirements/main.txt](https://github.com/NVIDIA-NeMo/Skills/blob/main/requirements/main.txt).

## Problem

The package `latex2sympy2_extended` is imported by [nemo_skills/evaluation/math_grader.py](https://github.com/NVIDIA-NeMo/Skills/blob/main/evaluation/math_grader.py#L18) but was not listed in the project requirements. This causes a `ModuleNotFoundError` when users install the package and attempt to run math evaluation pipelines (e.g., GSM8K, AIME, or any benchmark using the [math](https://github.com/NVIDIA-NeMo/Skills/blob/main/evaluation/math_grader.py#37-100) metric type).

**Import chain:**
```python
nemo_skills/pipeline/eval.py 
  → nemo_skills/pipeline/summarize_results.py
    → nemo_skills/evaluation/metrics/compute_metrics.py
      → nemo_skills/evaluation/metrics/math_metrics.py
        → nemo_skills/evaluation/math_grader.py
          → from latex2sympy2_extended import NormalizationConfig, normalize_latex
```

## Solution

Add `latex2sympy2_extended` to `requirements/main.txt` after `language-data` to maintain alphabetical ordering.

## Testing

After this change, users can successfully:
1. Install the package: `pip install -e .`
2. Run math evaluations without `ModuleNotFoundError`

## Impact

- **Breaking**: No
- **User-facing**: Yes (fixes broken installation for math evaluation)
- **Dependencies**: Adds one package to installation requirements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to enhance system capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->