### PR TITLE
Add SysBench benchmark

### DIFF
--- a/docs/evaluation/instruction-following.md
+++ b/docs/evaluation/instruction-following.md
@@ -13,3 +13,8 @@ More details are coming soon!
 
 - Benchmark is defined in [`nemo_skills/dataset/ifeval/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/ifeval/__init__.py)
 - Original benchmark source is [here](https://github.com/google-research/google-research/tree/master/instruction_following_eval).
+
+### sysbench
+
+- Benchmark is defined in [`nemo_skills/dataset/sysbench/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/sysbench/__init__.py)
+- Original benchmark source is [here](https://github.com/PKU-Baichuan-MLSystemLab/SysBench).

--- a/nemo_skills/dataset/sysbench/__init__.py
+++ b/nemo_skills/dataset/sysbench/__init__.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SysBench dataset configuration for NeMo Skills.
+
+# This dataset evaluates how well models follow the system instructions in the
+# SysBench benchmark (https://github.com/PKU-Baichuan-MLSystemLab/SysBench).
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+DATASET_GROUP = "chat"
+METRICS_TYPE = "sysbench"
+DEFAULT_SPLIT = "test"
+EVAL_SPLIT = "test"
+
+# Use custom generation module for multi-turn evaluation
+GENERATION_MODULE = "nemo_skills.inference.eval.sysbench"
+GENERATION_ARGS = "++prompt_format=openai ++generation_key=generation"
+
+JUDGE_PIPELINE_ARGS = {
+    "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "server_type": "vllm",
+    "server_gpus": 8,  # Number of GPUs for judge server
+}
+
+JUDGE_ARGS = "++prompt_config=judge/sys-bench ++generation_key=judgement ++add_generation_stats=False ++inference.tokens_to_generate=65536"
+

--- a/nemo_skills/dataset/sysbench/prepare.py
+++ b/nemo_skills/dataset/sysbench/prepare.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import urllib.request
+from pathlib import Path
+
+from nemo_skills.utils import get_logger_name, setup_logging
+
+URL = "https://raw.githubusercontent.com/PKU-Baichuan-MLSystemLab/SysBench/main/datas/system_benchmark_eval_datas.json"
+
+
+def run_preparation():
+    """Prepare SysBench dataset for multi-turn evaluation.
+    
+    Each entry in the output represents one complete dialogue (system_id).
+    The custom evaluator (sysbench.py) will handle:
+    1. Generating assistant responses turn-by-turn
+    2. Building history blocks for judging
+    3. Formatting criteria for each turn
+    """
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+    source_file = data_dir / "system_benchmark_eval_datas.json"
+    if not source_file.exists():
+        print(f"Downloading SysBench dataset manifest from {URL}")
+        urllib.request.urlretrieve(URL, source_file)
+    output_file = data_dir / "test.jsonl"
+
+    with open(source_file, "rt", encoding="utf-8") as fin:
+        raw_entries = json.load(fin)
+
+    print(f"Preparing {len(raw_entries)} SysBench dialogues")
+
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in raw_entries:
+            # Keep the full dialogue structure
+            # The evaluator will generate each assistant turn and judge it
+            prepared_entry = {
+                "system_id": entry.get("system_id"),
+                "domain": entry.get("领域"),
+                "scene": entry.get("场景"),
+                "system_prompt": entry.get("system_prompt"),
+                "messages": entry.get("messages", []),  # Full conversation template
+                "prompt_infos": entry.get("prompt_infos", {}),  # Criteria for each user prompt
+                "rounds_related": entry.get("rounds_related"),
+                "split": "test",
+            }
+            fout.write(json.dumps(prepared_entry, ensure_ascii=False) + "\n")
+    print(f"Saved prepared SysBench data to {output_file}")
+
+
+if __name__ == "__main__":
+    setup_logging()
+    run_preparation()

--- a/nemo_skills/evaluation/metrics/map_metrics.py
+++ b/nemo_skills/evaluation/metrics/map_metrics.py
@@ -43,6 +43,7 @@ from nemo_skills.evaluation.metrics.mrcr_metrics import MRCRMetrics
 from nemo_skills.evaluation.metrics.omni_metrics import OmniMetrics
 from nemo_skills.evaluation.metrics.ruler_metrics import RulerMetrics
 from nemo_skills.evaluation.metrics.simpleqa_metrics import SimpleQAMetrics
+from nemo_skills.evaluation.metrics.sysbench_metrics import SysBenchMetrics
 from nemo_skills.evaluation.metrics.translation_metrics import TranslationMetrics
 
 METRICS_MAP = {
@@ -75,6 +76,7 @@ METRICS_MAP = {
     "bigcodebench": BigCodeBenchMetrics,
     "mrcr": MRCRMetrics,
     "aalcr": AALCRMetrics,
+    "sysbench": SysBenchMetrics,
     "livebench_coding": LiveCodeBenchMetrics,
     "translation": TranslationMetrics,
     "human_eval_infilling": HumanEvalInfillingMetrics,

--- a/nemo_skills/evaluation/metrics/sysbench_metrics.py
+++ b/nemo_skills/evaluation/metrics/sysbench_metrics.py
@@ -1,0 +1,545 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import re
+from collections import defaultdict
+
+from nemo_skills.evaluation.metrics.base import BaseMetrics
+from nemo_skills.utils import get_logger_name
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+
+class SysBenchMetrics(BaseMetrics):
+    """Metrics for SysBench dataset.
+
+    This dataset uses an LLM-based equality checker (Officially, GPT-4o)
+    to evaluate whether candidate answers are consistent with official answers.
+    
+    Implements official SysBench metrics:
+    - CSR (Constraint Satisfaction Rate): Per constraint type accuracy
+    - ISR (Instruction Satisfaction Rate): Per alignment type accuracy  
+    - SSR (Session Satisfaction Rate): Per turn with accumulated session success
+    """
+
+    # Constraint type mapping (Chinese to English)
+    CONSTRAINT_TYPES = {
+        "动作约束": "Action",
+        "内容约束": "Content",
+        "背景约束": "Background",
+        "角色约束": "Role",
+        "格式约束": "Format",
+        "风格约束": "Style",
+    }
+    
+    NUM_TURNS = 5  # SysBench has 5 turns per dialogue
+
+    def __init__(self):
+        super().__init__()
+        # Track metrics by domain/scene category for detailed analysis
+        self.category_metrics = defaultdict(lambda: defaultdict(float))
+        self.category_totals = defaultdict(int)
+        self.token_stats = defaultdict(list)  # Track input token statistics
+        
+        # Store all predictions for computing official SysBench metrics
+        self.all_predictions = []
+
+    def reset(self):
+        super().reset()
+        self.category_metrics = defaultdict(lambda: defaultdict(float))
+        self.category_totals = defaultdict(int)
+        self.token_stats = defaultdict(list)
+        self.all_predictions = []
+
+    @staticmethod
+    def parse_sysbench_judgement(judgement: str) -> dict | None:
+        """Parse SysBench JSON judgement.
+        
+        Expected format:
+        {
+          "评判理由": "reason",
+          "评判结果": {
+            "1": "是",
+            "2": "否",
+            ...
+          }
+        }
+        
+        Note: The official SysBench judge prompt uses unquoted integer keys (1: instead of "1":)
+        which is invalid JSON. We handle this by converting them to quoted strings.
+        
+        Returns:
+            Dict with judgement results, or None if parsing fails
+        """
+        if judgement is None:
+            return None
+        
+        try:
+            # Try to extract JSON from code blocks if present
+            judgement = judgement.strip()
+            if "```json" in judgement:
+                json_match = re.search(r'```json\s*(\{.*?\})\s*```', judgement, re.DOTALL)
+                if json_match:
+                    judgement = json_match.group(1)
+            elif "```" in judgement:
+                json_match = re.search(r'```\s*(\{.*?\})\s*```', judgement, re.DOTALL)
+                if json_match:
+                    judgement = json_match.group(1)
+            
+            # Fix unquoted integer keys (e.g., {1: "是" -> {"1": "是")
+            # This is needed because the official SysBench judge prompt format uses integer keys
+            judgement = re.sub(r'([\s{,])(\d+)(\s*:\s*")', r'\1"\2"\3', judgement)
+            
+            # Parse JSON
+            result = json.loads(judgement)
+            
+            # Validate required fields
+            if "评判结果" in result and isinstance(result["评判结果"], dict):
+                return result
+            
+            return None
+        except (json.JSONDecodeError, AttributeError, ValueError):
+            # ValueError can occur if JSON contains extremely large integers
+            # that exceed Python's integer string conversion limit
+            return None
+    
+    @staticmethod
+    def is_sysbench_correct(judgement: str, prompt_infos: dict = None, current_user_content: str = None) -> bool:
+        """Check if SysBench judgement indicates all criteria are met.
+        
+        A response is correct only if ALL criteria have "是" (yes) as the result.
+        
+        Args:
+            judgement: The LLM judge's response
+            prompt_infos: Full prompt_infos dict containing criteria
+            current_user_content: Current user prompt (to lookup criteria in prompt_infos)
+        
+        Returns:
+            True if all criteria are met, False otherwise
+        """
+        parsed = SysBenchMetrics.parse_sysbench_judgement(judgement)
+        if parsed is None:
+            return False
+        
+        results = parsed.get("评判结果", {})
+        if not results:
+            return False
+        
+        # Validate that judge output keys match expected criteria IDs
+        if prompt_infos and current_user_content:
+            criteria = prompt_infos[current_user_content]["criteria"]
+            expected_keys = set(str(k) for k in criteria.keys())
+            actual_keys = set(str(k) for k in results.keys())
+            if expected_keys != actual_keys:
+                LOG.warning(
+                    f"Judge output keys {actual_keys} don't match expected criteria IDs {expected_keys}. "
+                    f"Missing: {expected_keys - actual_keys}, Extra: {actual_keys - expected_keys}"
+                )
+                # Return False if keys don't match - judge output is unreliable
+                return False
+        
+        # All criteria must be "是" for the turn to be correct
+        return all(value == "是" for value in results.values())
+
+    def _get_score_dict(self, prediction: dict) -> dict[str, bool | int | float]:
+        """Get correctness scores for a prediction using LLM-based equality checker."""
+        correctness_dict = {}
+
+        # Primary evaluation method: LLM-based equality checker
+        if "judgement" in prediction:
+            # Invalid generation: reasoning is not finished or non-reasoning generation is empty
+            generation = prediction.get("current_assistant_content", prediction.get("generation", ""))
+            correctness_dict["generation_valid"] = len(generation.strip()) > 0
+            
+            # Check if all criteria passed according to the judge
+            correctness_dict["judge_correct"] = (
+                self.is_sysbench_correct(
+                    prediction["judgement"],
+                    prompt_infos=prediction.get("prompt_infos"),
+                    current_user_content=prediction.get("current_user_content")
+                ) if correctness_dict["generation_valid"] else False
+            )
+
+        return correctness_dict
+
+    @classmethod
+    def get_incorrect_sample(cls, prediction: dict) -> dict:
+        """Return a prediction that evaluates as incorrect."""
+        prediction = prediction.copy()
+        prediction["judgement"] = "INCORRECT"
+        prediction["predicted_answer"] = None
+        return prediction
+
+    def _update_category_metrics(self, prediction: dict, score_dict: dict):
+        """Update per-category metrics if domain/scene is available."""
+        # Use domain as the primary category for SysBench
+        domain = prediction.get("domain", "unknown")
+        scene = prediction.get("scene", "unknown")
+        category = f"{domain}/{scene}" if domain != "unknown" and scene != "unknown" else domain
+        
+        self.category_totals[category] += 1
+
+        for score_method, is_correct in score_dict.items():
+            if is_correct:
+                self.category_metrics[category][score_method] += 1
+
+    def _update_token_stats(self, prediction: dict):
+        """Track input token statistics by category."""
+        domain = prediction.get("domain", "unknown")
+        scene = prediction.get("scene", "unknown")
+        category = f"{domain}/{scene}" if domain != "unknown" and scene != "unknown" else domain
+        
+        input_tokens = prediction.get("num_input_tokens") or prediction.get("input_tokens")
+        if input_tokens is not None:
+            self.token_stats[category].append(int(input_tokens))
+
+    def update(self, predictions):
+        """Update the evaluation results with the current element.
+
+        Args:
+            predictions (list[dict]): aggregated predictions across all generations.
+                Each prediction should contain 'judgement' from LLM equality checker.
+        """
+        super().update(predictions)
+
+        # Update category metrics and token stats using the first prediction
+        # (they should all have the same expected answer and metadata)
+        if predictions:
+            pred = predictions[0]
+            score_dict = self._get_score_dict(pred)
+            self._update_category_metrics(pred, score_dict)
+            self._update_token_stats(pred)
+            
+            # Store prediction with computed correctness for official metrics
+            pred_copy = pred.copy()
+            pred_copy["_is_correct"] = score_dict.get("judge_correct", False)
+            self.all_predictions.append(pred_copy)
+
+        # Compute standard pass@k and majority@k metrics
+        # Here we use 'judgement' and 'current_assistant_content' (or 'generation') to calculate score and no_answer metric
+        predicted_answers = [
+            pred.get("current_assistant_content", pred.get("generation", ""))
+            for pred in predictions
+        ]
+
+        self._compute_pass_at_k(predictions=predictions, predicted_answers=predicted_answers)
+        self._compute_majority_at_k(predictions=predictions, predicted_answers=predicted_answers)
+
+    def _compute_csr(self):
+        """Compute Constraint Satisfaction Rate (CSR) per constraint type.
+        
+        CSR measures what percentage of constraints of each type are satisfied.
+        """
+        # Count correct/total for each constraint type
+        constraint_correct = defaultdict(int)
+        constraint_total = defaultdict(int)
+        
+        for pred in self.all_predictions:
+            is_correct = pred.get("_is_correct", False)
+            prompt_infos = pred["prompt_infos"]
+            current_user_content = pred["current_user_content"]
+            
+            # Get the criteria for this turn
+            criteria = prompt_infos[current_user_content]["criteria"]
+            
+            # Parse judgement to get per-criterion results
+            judgement = pred.get("judgement", "")
+            parsed = self.parse_sysbench_judgement(judgement)
+            results = parsed.get("评判结果", {}) if parsed else {}
+            
+            for crit_id, crit_info in criteria.items():
+                crit_type = crit_info["criteria_type"]
+                crit_type_en = self.CONSTRAINT_TYPES.get(crit_type, crit_type)
+                
+                # Check if this criterion passed
+                crit_passed = results.get(str(crit_id), "否") == "是"
+                
+                constraint_total[crit_type_en] += 1
+                if crit_passed:
+                    constraint_correct[crit_type_en] += 1
+        
+        # Compute rates
+        csr = {}
+        total_correct = 0
+        total_count = 0
+        for crit_type in self.CONSTRAINT_TYPES.values():
+            if constraint_total[crit_type] > 0:
+                csr[crit_type] = 100.0 * constraint_correct[crit_type] / constraint_total[crit_type]
+                total_correct += constraint_correct[crit_type]
+                total_count += constraint_total[crit_type]
+            else:
+                csr[crit_type] = 0.0
+        
+        csr["Total"] = 100.0 * total_correct / total_count if total_count > 0 else 0.0
+        return csr
+    
+    def _compute_isr(self):
+        """Compute Instruction Satisfaction Rate (ISR) per alignment type.
+        
+        ISR measures accuracy separately for aligned vs misaligned instructions.
+        """
+        alignment_correct = defaultdict(int)
+        alignment_total = defaultdict(int)
+        
+        for pred in self.all_predictions:
+            is_correct = pred.get("_is_correct", False)
+            alignment = pred.get("alignment", "unknown")
+            
+            alignment_total[alignment] += 1
+            alignment_total["Total"] += 1
+            if is_correct:
+                alignment_correct[alignment] += 1
+                alignment_correct["Total"] += 1
+        
+        isr = {}
+        for align_type in ["align", "misalign", "Total"]:
+            if alignment_total[align_type] > 0:
+                isr[align_type] = 100.0 * alignment_correct[align_type] / alignment_total[align_type]
+            else:
+                isr[align_type] = 0.0
+        
+        return isr
+    
+    def _compute_ssr(self):
+        """Compute Session Satisfaction Rate (SSR) with accumulated session success.
+        
+        SSR tracks per-turn success with the constraint that if turn N fails,
+        all subsequent turns are counted as failed (accumulated session success).
+        Separates by rounds_related (dependent vs parallel/independent).
+        """
+        # Group predictions by system_id
+        dialogues = defaultdict(list)
+        for pred in self.all_predictions:
+            system_id = pred.get("system_id")
+            if system_id is not None:
+                dialogues[system_id].append(pred)
+        
+        # Sort turns within each dialogue
+        for system_id in dialogues:
+            dialogues[system_id].sort(key=lambda x: x.get("turn_idx", 0))
+        
+        # Track per-turn success with accumulated logic
+        # dependent[turn] = (correct, total), parallel[turn] = (correct, total)
+        dependent_correct = [0] * self.NUM_TURNS
+        dependent_total = [0] * self.NUM_TURNS
+        parallel_correct = [0] * self.NUM_TURNS
+        parallel_total = [0] * self.NUM_TURNS
+        
+        # Also track accumulated session scores (all turns passed up to turn N)
+        dependent_session_scores = []
+        parallel_session_scores = []
+        
+        for system_id, turns in dialogues.items():
+            if not turns:
+                continue
+                
+            rounds_related = turns[0].get("rounds_related", False)
+            accumulated_success = 0
+            
+            for turn_idx, turn in enumerate(turns):
+                if turn_idx >= self.NUM_TURNS:
+                    break
+                    
+                is_correct = turn.get("_is_correct", False)
+                
+                # Update accumulated success
+                if is_correct and accumulated_success == turn_idx:
+                    accumulated_success += 1
+                
+                # Count this turn as successful only if all previous turns succeeded
+                turn_success = (accumulated_success == turn_idx + 1)
+                
+                if rounds_related:
+                    dependent_total[turn_idx] += 1
+                    if turn_success:
+                        dependent_correct[turn_idx] += 1
+                else:
+                    parallel_total[turn_idx] += 1
+                    if turn_success:
+                        parallel_correct[turn_idx] += 1
+            
+            # Record session score (how many turns succeeded in a row)
+            if rounds_related:
+                dependent_session_scores.append(accumulated_success)
+            else:
+                parallel_session_scores.append(accumulated_success)
+        
+        # Compute SSR metrics
+        ssr = {
+            "dependent": {},
+            "parallel": {},
+        }
+        
+        # Per-turn rates for dependent (multi-turn related)
+        for i in range(self.NUM_TURNS):
+            if dependent_total[i] > 0:
+                ssr["dependent"][f"R{i+1}"] = 100.0 * dependent_correct[i] / dependent_total[i]
+            else:
+                ssr["dependent"][f"R{i+1}"] = 0.0
+        
+        # Average session score for dependent
+        if dependent_session_scores:
+            ssr["dependent"]["SSR"] = 100.0 * sum(dependent_session_scores) / (len(dependent_session_scores) * self.NUM_TURNS)
+        else:
+            ssr["dependent"]["SSR"] = 0.0
+        
+        # Per-turn rates for parallel (independent)
+        for i in range(self.NUM_TURNS):
+            if parallel_total[i] > 0:
+                ssr["parallel"][f"R{i+1}"] = 100.0 * parallel_correct[i] / parallel_total[i]
+            else:
+                ssr["parallel"][f"R{i+1}"] = 0.0
+        
+        # Average session score for parallel
+        if parallel_session_scores:
+            ssr["parallel"]["SSR"] = 100.0 * sum(parallel_session_scores) / (len(parallel_session_scores) * self.NUM_TURNS)
+        else:
+            ssr["parallel"]["SSR"] = 0.0
+        
+        # Total SSR
+        all_session_scores = dependent_session_scores + parallel_session_scores
+        if all_session_scores:
+            ssr["Total"] = 100.0 * sum(all_session_scores) / (len(all_session_scores) * self.NUM_TURNS)
+        else:
+            ssr["Total"] = 0.0
+        
+        return ssr
+
+    def get_metrics(self):
+        """Get all computed metrics including official SysBench metrics (CSR, ISR, SSR)."""
+        metrics_dict = super().get_metrics()
+
+        # Compute official SysBench metrics
+        if self.all_predictions:
+            csr = self._compute_csr()
+            isr = self._compute_isr()
+            ssr = self._compute_ssr()
+            
+            # Add to metrics dict for the main evaluation mode
+            for eval_mode in metrics_dict:
+                # Add headline metrics
+                metrics_dict[eval_mode]["CSR"] = csr.get("Total", 0.0)
+                metrics_dict[eval_mode]["ISR"] = isr.get("Total", 0.0)
+                metrics_dict[eval_mode]["SSR"] = ssr.get("Total", 0.0)
+                
+                # Add detailed breakdowns
+                metrics_dict[eval_mode]["csr_breakdown"] = csr
+                metrics_dict[eval_mode]["isr_breakdown"] = isr
+                metrics_dict[eval_mode]["ssr_breakdown"] = ssr
+            
+            # Print official SysBench metrics table
+            self._print_sysbench_metrics(csr, isr, ssr)
+
+        # Add per-category metrics (domain/scene breakdown)
+        if self.category_totals:
+            category_results = {}
+            for category, total in self.category_totals.items():
+                category_results[category] = {}
+                for score_method, correct_count in self.category_metrics[category].items():
+                    accuracy = 100.0 * correct_count / total
+                    category_results[category][score_method] = accuracy
+
+                category_results[category]["total_samples"] = total
+
+                # Add token statistics
+                if category in self.token_stats and self.token_stats[category]:
+                    tokens = self.token_stats[category]
+                    category_results[category]["avg_input_tokens"] = int(sum(tokens) / len(tokens))
+                    category_results[category]["max_input_tokens"] = max(tokens)
+                    category_results[category]["min_input_tokens"] = min(tokens)
+
+            # Add category breakdown to the main evaluation mode
+            for eval_mode in metrics_dict:
+                if eval_mode == f"pass@1[avg-of-{self.max_k}]":  # Only add to the main evaluation mode
+                    metrics_dict[eval_mode]["category_breakdown"] = category_results
+
+        return metrics_dict
+    
+    def _print_sysbench_metrics(self, csr, isr, ssr):
+        """Print official SysBench metrics in a formatted table."""
+        width = 70
+        
+        print("\n" + "=" * width)
+        print(" Official SysBench Metrics ".center(width))
+        print("=" * width)
+        
+        # Main metrics
+        print(f"\n{'Metric':<20} {'Score':>10}")
+        print("-" * 32)
+        print(f"{'CSR (Total):':<20} {csr.get('Total', 0):.2f}%")
+        print(f"{'ISR (Total):':<20} {isr.get('Total', 0):.2f}%")
+        print(f"{'SSR (Total):':<20} {ssr.get('Total', 0):.2f}%")
+        
+        # CSR breakdown
+        print(f"\n{'-' * width}")
+        print(" CSR (Constraint Satisfaction Rate) by Type ".center(width))
+        print("-" * width)
+        print(f"{'Constraint Type':<20} {'Score':>10}")
+        print("-" * 32)
+        for ctype in ["Action", "Content", "Background", "Role", "Format", "Style"]:
+            if ctype in csr:
+                print(f"{ctype:<20} {csr[ctype]:.2f}%")
+        
+        # ISR breakdown
+        print(f"\n{'-' * width}")
+        print(" ISR (Instruction Satisfaction Rate) by Alignment ".center(width))
+        print("-" * width)
+        print(f"{'Alignment':<20} {'Score':>10}")
+        print("-" * 32)
+        print(f"{'Aligned:':<20} {isr.get('align', 0):.2f}%")
+        print(f"{'Misaligned:':<20} {isr.get('misalign', 0):.2f}%")
+        
+        # SSR breakdown
+        print(f"\n{'-' * width}")
+        print(" SSR (Session Satisfaction Rate) by Turn ".center(width))
+        print("-" * width)
+        
+        # Dependent (multi-turn related)
+        print("\nMulti-turn Dependent:")
+        dep = ssr.get("dependent", {})
+        for i in range(1, self.NUM_TURNS + 1):
+            print(f"  R{i}: {dep.get(f'R{i}', 0):.2f}%")
+        print(f"  SSR: {dep.get('SSR', 0):.2f}%")
+        
+        # Parallel (independent)
+        print("\nMulti-turn Parallel:")
+        par = ssr.get("parallel", {})
+        for i in range(1, self.NUM_TURNS + 1):
+            print(f"  R{i}: {par.get(f'R{i}', 0):.2f}%")
+        print(f"  SSR: {par.get('SSR', 0):.2f}%")
+        
+        print("\n" + "=" * width + "\n")
+
+    def evaluations_to_print(self):
+        """Return which evaluations should be printed in the summary."""
+        if self.max_k > 1:
+            return [f"pass@1[avg-of-{self.max_k}]", f"majority@{self.max_k}", f"pass@{self.max_k}"]
+        else:
+            return ["pass@1"]
+
+    def metrics_to_print(self):
+        """Control which metrics are displayed in the summary table."""
+        from nemo_skills.evaluation.metrics.base import default_formatting
+
+        # Show official SysBench metrics (CSR, ISR, SSR) as main metrics
+        return {
+            "CSR": default_formatting,
+            "ISR": default_formatting,
+            "SSR": default_formatting,
+            "judge_correct": default_formatting,
+            "num_entries": default_formatting,
+            "no_answer": default_formatting,
+        }

--- a/nemo_skills/inference/eval/sysbench.py
+++ b/nemo_skills/inference/eval/sysbench.py
@@ -1,0 +1,417 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+import logging
+import sys
+from dataclasses import asdict, field
+
+import hydra
+
+from nemo_skills.inference.generate import (
+    GenerationTask,
+    GenerationTaskConfig,
+    InferenceConfig,
+)
+from nemo_skills.utils import (
+    get_help_message,
+    get_logger_name,
+    nested_dataclass,
+    parse_reasoning,
+    setup_logging,
+)
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+
+@nested_dataclass(kw_only=True)
+class SysBenchGenerationConfig(GenerationTaskConfig):
+    """SysBench multi-turn benchmark generation."""
+
+    # Inheritance was converting these dataclasses to dicts, so to be on the safe side we override them
+    inference: InferenceConfig = field(default_factory=InferenceConfig)
+    # Inference server configuration
+    server: dict = field(default_factory=dict)
+
+    def _post_init_validate_params(self):
+        """Validate that certain parameters are restricted to certain values"""
+        if self.prompt_format not in ["openai"]:
+            raise ValueError(f"prompt_format must be 'openai' for SysBench, got '{self.prompt_format}'")
+
+        if self.prompt_format == "openai":
+            assert self.prompt_config is None, "prompt_config is not supported for prompt_format == 'openai'"
+
+    def _get_disallowed_params(self):
+        """Returns a list of parameters with their default values to check that they are not changed from the defaults"""
+        return [
+            ("prompt_config", None),
+        ]
+
+
+cs = hydra.core.config_store.ConfigStore.instance()
+cs.store(name="base_sysbench_generation_config", node=SysBenchGenerationConfig)
+
+
+class SysBenchGenerationTask(GenerationTask):
+    """SysBench multi-turn generation task.
+    
+    This task handles the multi-turn nature of SysBench:
+    1. For each dialogue, iterate through user messages
+    2. Generate assistant responses turn by turn
+    3. Build history blocks for judging
+    4. Format criteria for each turn
+    """
+
+    def __init__(self, cfg: SysBenchGenerationConfig):
+        super().__init__(cfg)
+        self.cfg = cfg
+
+    def log_example_prompt(self, data):
+        """SysBench is a multi-turn benchmark, so we can't print a single prompt."""
+        return
+
+    def setup_prompt(self):
+        """SysBench uses OpenAI chat format, no prompt template needed."""
+        return None
+
+    def _build_history_block(self, messages, current_turn_idx):
+        """Build the history block for judge prompt (all turns before current).
+        
+        Args:
+            messages: List of messages (system, user, assistant alternating)
+            current_turn_idx: Index of the current assistant message being judged
+        
+        Returns:
+            Formatted history string for judge prompt
+        """
+        history_parts = []
+        round_num = 1
+        
+        # Iterate through pairs of user/assistant messages before the current turn
+        # messages[0] is system, messages[1] is first user, messages[2] is first assistant, etc.
+        for i in range(1, current_turn_idx, 2):
+            if i + 1 <= current_turn_idx:
+                user_msg = messages[i]
+                assistant_msg = messages[i + 1] if i + 1 < current_turn_idx else None
+                
+                if assistant_msg:
+                    history_parts.append(f"""<round-{round_num}>
+<role:>
+{user_msg["role"]}
+</role>
+<content>
+{user_msg["content"]}
+</content>
+<role:>{assistant_msg["role"]}</role>
+<content>
+{assistant_msg["content"]}
+</content>
+</round-{round_num}>""")
+                    round_num += 1
+        
+        return "\n\n".join(history_parts) if history_parts else ""
+
+    def _format_criteria(self, criteria_dict):
+        """Format criteria dict into the required string format for judge prompt.
+        
+        Args:
+            criteria_dict: Dict mapping criterion ID to criterion info
+        
+        Returns:
+            Formatted criteria string
+        """
+        criteria_lines = []
+        for crit_id, crit_info in criteria_dict.items():
+            criteria_lines.append(
+                f"{crit_id}. {crit_info['criteria_content']} | {crit_info['criteria_type']}"
+            )
+        return "\n".join(criteria_lines)
+
+    async def _generate_single_assistant_turn(self, messages):
+        """Generate a single assistant response given the conversation history.
+        
+        Args:
+            messages: List of message dicts in OpenAI format
+            
+        Returns:
+            Dict with generated message and metadata
+        """
+        # Construct input dict for generation
+        # SysBench messages already include the system message, so only prepend if not present
+        if self.cfg.system_message and (not messages or messages[0].get("role") != "system"):
+            messages = [{"role": "system", "content": self.cfg.system_message}] + messages
+        
+        input_dict = {
+            "prompt": messages,
+            "include_response": True,
+            **asdict(self.cfg.inference),
+        }
+        
+        return_dict = {}
+        if self.cfg.count_prompt_tokens:
+            from nemo_skills.prompt.utils import get_token_count
+            num_input_tokens = get_token_count(self.hf_tokenizer, messages=messages)
+            return_dict["num_input_tokens"] = num_input_tokens
+        
+        # Query the LLM server
+        try:
+            output = await self.generate_with_semaphore(**input_dict)
+        except Exception as error:
+            from nemo_skills.inference.model.utils import is_context_window_exceeded_error
+            if is_context_window_exceeded_error(error):
+                LOG.warning(f"SysBench generation failed due to running out of context: {error}")
+                return None
+            else:
+                raise error
+        
+        # Extract the response
+        return_dict["num_generated_tokens"] = output.get("num_generated_tokens", 0)
+        
+        # Parse the generation output
+        if "response" in output:
+            # Server-side response
+            response_message = output["response"].choices[0].message
+            content = response_message.content
+        elif "generation" in output:
+            # Client-side response
+            content = output["generation"]
+        else:
+            LOG.error("Unexpected output format from generation")
+            return None
+        
+        return_dict["content"] = content
+        return return_dict
+
+    async def _generate_single_data_point_multi_turn(self, data_point):
+        """Generate each turn of a SysBench dialogue.
+        
+        Args:
+            data_point: Dict containing system_id, messages, prompt_infos, etc.
+        
+        Returns:
+            List of dicts, one per turn, ready for judging
+        """
+        system_id = data_point["system_id"]
+        messages_template = data_point["messages"]  # Original message template
+        prompt_infos = data_point["prompt_infos"]  # Criteria for each user prompt
+        domain = data_point.get("domain")
+        scene = data_point.get("scene")
+        
+        # Build the actual conversation with generated assistant responses
+        generated_messages = []
+        turn_results = []
+        
+        # Add system message
+        if messages_template and messages_template[0]["role"] == "system":
+            generated_messages.append(messages_template[0])
+        
+        # Process each user/assistant turn
+        for i in range(1, len(messages_template), 2):
+            if i >= len(messages_template):
+                break
+            
+            user_msg = messages_template[i]
+            generated_messages.append(user_msg)
+            
+            # Generate assistant response
+            assistant_response = await self._generate_single_assistant_turn(generated_messages)
+            
+            if assistant_response is None:
+                LOG.warning(f"Failed to generate response for system_id {system_id}, turn {i // 2 + 1}")
+                break
+            
+            # Parse reasoning tokens if configured (for reasoning models)
+            raw_content = assistant_response["content"]
+            if self.cfg.parse_reasoning:
+                # Use parse_reasoning utility to extract non-thinking content
+                temp_sample = {"generation": raw_content}
+                parse_reasoning(temp_sample, "generation", self.cfg.end_reasoning_string)
+                parsed_content = temp_sample["generation"]
+                full_content = temp_sample.get("_full_generation", raw_content)
+            else:
+                parsed_content = raw_content
+                full_content = raw_content
+            
+            # Add assistant message to conversation (use parsed content for history)
+            assistant_msg = {
+                "role": "assistant",
+                "content": parsed_content
+            }
+            generated_messages.append(assistant_msg)
+            
+            # Build history block (all turns before current)
+            history = self._build_history_block(generated_messages, len(generated_messages) - 1)
+            
+            # Get criteria for this user prompt
+            user_prompt_content = user_msg["content"]
+            prompt_info = prompt_infos[user_prompt_content]
+            criteria = prompt_info["criteria"]
+            formatted_criteria = self._format_criteria(criteria)
+            alignment = prompt_info.get("alignment", "unknown")
+            
+            # Create a standalone result for this turn (for judge input)
+            turn_result = {
+                "system_id": system_id,
+                "domain": domain,
+                "scene": scene,
+                "turn_idx": i // 2,
+                "rounds_related": data_point.get("rounds_related", False),  # For SSR metric
+                "alignment": alignment,  # For ISR metric (align/misalign)
+                "system_prompt": generated_messages[0]["content"] if generated_messages[0]["role"] == "system" else "",
+                "history": history,
+                "current_user_role": user_msg["role"],
+                "current_assistant_role": assistant_msg["role"],
+                "current_user_content": user_prompt_content,  # Changed from final_user_prompt
+                "current_assistant_content": parsed_content,  # Use parsed content (thinking removed if parse_reasoning=True)
+                "criteria": formatted_criteria,
+                "criteria_types": {k: v.get("criteria_type", "unknown") for k, v in criteria.items()},  # For CSR metric
+                "prompt_infos": prompt_infos,  # Keep full prompt_infos for metrics
+                "num_generated_tokens": assistant_response.get("num_generated_tokens", 0),
+            }
+            
+            # Store full content with thinking for debugging (if different from parsed)
+            if full_content != parsed_content:
+                turn_result["_full_current_assistant_content"] = full_content
+            
+            if self.cfg.count_prompt_tokens:
+                turn_result["num_input_tokens"] = assistant_response.get("num_input_tokens", 0)
+            
+            turn_results.append(turn_result)
+        
+        # Return list of turn results (each will be written as a separate line)
+        return turn_results
+
+    async def process_single_datapoint(self, data_point, all_data):
+        """Process a single SysBench dialogue."""
+        turn_results = await self._generate_single_data_point_multi_turn(data_point)
+        # Wrap in a dict to satisfy parent class expectations
+        return {"turn_results": turn_results, "system_id": data_point["system_id"]}
+    
+    async def postprocess_single_output(self, output, original_data_point):
+        """Override to keep turn_results structure intact."""
+        # Don't do the standard postprocessing - we'll handle it in dump_outputs
+        # Just ensure generation_key is set for each turn if needed
+        pass
+    
+    def dump_outputs(self, outputs, data_points, fout):
+        """Override to write multiple lines per dialogue (one per turn)."""
+        for output in outputs:
+            # Check if this is a SysBench multi-turn output
+            if "turn_results" in output:
+                turn_results = output["turn_results"]
+                generation_metadata = {
+                    "generation_start_time": output.get("generation_start_time"),
+                    "generation_end_time": output.get("generation_end_time"),
+                    "generation_time": output.get("generation_time"),
+                }
+                
+                # Write each turn as a separate line (without async_position since we handle ordering ourselves)
+                for turn_result in turn_results:
+                    turn_output = dict(turn_result)
+                    
+                    # Add generation metadata if configured
+                    if self.cfg.add_generation_stats:
+                        turn_output.update(generation_metadata)
+                    
+                    # Ensure generation_key is set
+                    if "current_assistant_content" in turn_output:
+                        turn_output[self.cfg.generation_key] = turn_output["current_assistant_content"]
+                    
+                    fout.write(json.dumps(turn_output) + "\n")
+            else:
+                # Standard single output
+                fout.write(json.dumps(output) + "\n")
+    
+    def skip_completed_samples(self, data):
+        """Override to handle multi-turn output when skipping completed samples.
+        
+        For SysBench, we can't use async_position since we write multiple lines per input.
+        Instead, we check which system_ids have been completed.
+        """
+        from pathlib import Path
+        import json
+        
+        if not self.cfg.skip_filled:
+            return data
+        
+        output_file = Path(self.cfg.output_file)
+        if not output_file.exists():
+            return data
+        
+        # Collect completed system_ids
+        completed_system_ids = set()
+        with open(output_file, "rt", encoding="utf-8") as fin:
+            for line in fin:
+                try:
+                    result = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                system_id = result.get("system_id")
+                if system_id is not None:
+                    completed_system_ids.add(system_id)
+        
+        if not completed_system_ids:
+            return data
+        
+        # Filter out completed dialogues
+        remaining_data = [d for d in data if d.get("system_id") not in completed_system_ids]
+        
+        LOG.info(f"Skipping {len(completed_system_ids)} completed dialogues, {len(remaining_data)} remaining")
+        return remaining_data
+    
+    def restore_async_order(self):
+        """Override to skip order restoration for SysBench.
+        
+        SysBench writes multiple lines per input dialogue, so we can't use the standard
+        async position restoration (which assumes 1 output per input). The turns are already
+        written in the correct order during generation.
+        """
+        # Simply rename the async file to the final output file
+        import shutil
+        from pathlib import Path
+        
+        async_file = Path(self.cfg.output_file + "-async")
+        final_file = Path(self.cfg.output_file)
+        
+        if async_file.exists():
+            shutil.move(str(async_file), str(final_file))
+        
+        self.cleanup_litellm_cache()
+
+
+GENERATION_TASK_CLASS = SysBenchGenerationTask
+
+
+@hydra.main(version_base=None, config_name="base_sysbench_generation_config")
+def sysbench_generation(cfg: SysBenchGenerationConfig):
+    cfg = SysBenchGenerationConfig(_init_nested=True, **cfg)
+    LOG.info("Config used: %s", cfg)
+
+    task = SysBenchGenerationTask(cfg)
+    task.generate()
+
+
+HELP_MESSAGE = get_help_message(
+    SysBenchGenerationConfig,
+    name="sysbench",
+)
+
+
+if __name__ == "__main__":
+    if '--help' in sys.argv or '-h' in sys.argv:
+        print(HELP_MESSAGE)
+    else:
+        setup_logging()
+        sysbench_generation()

--- a/nemo_skills/prompt/config/judge/sys-bench.yaml
+++ b/nemo_skills/prompt/config/judge/sys-bench.yaml
@@ -1,0 +1,47 @@
+user: |-
+  # 背景与目标
+  你现在是一个大模型结果评估专家。以下，你将会面对一个大模型 system prompt 遵循能力评估任务。
+  我将会给出你对应的 system prompt、历史对话、当前轮次的问题、和当前轮次的回答，
+  需要你准确判断当前轮次的回答是否合格。
+  为了让你的评判足够准确，我还将会给出评判细则，需要你准确判断并告知评判细则当中的每一条约束的遵循情况。
+
+  # 对话信息
+  ## system prompt
+  <system prompt>
+  {system_prompt}
+  </system prompt>
+
+  ## 历史对话轮次
+  {history}
+
+  ## 当前待评估的对话轮次
+  <role:>
+  {current_user_role}
+  </role>
+  <content>
+  {current_user_content}
+  </content>
+  <role:>
+  {current_assistant_role}
+  </role>
+  <content>
+  {current_assistant_content}
+  </content>
+
+  # 评判细则
+  <评判细则>
+  {criteria}
+  </评判细则>
+
+  请你认真阅读上述 system prompt 设定与历史对话轮次，并严格以评判细则为评判标准，针对评判细则当中的逐条要求，判断当前对话轮次的回答是否遵循。
+  请以 json 格式回答，包含两个字段：评判理由、评判结果（评判结果为一个 dict，dict 的 key 为评判细则的序号，value 为对应的评判结果（是/否））。
+  输出格式如下：
+  '''json
+  {{
+    "评判理由": "……",
+    "评判结果": {{
+      1: "……",
+      ……
+    }}
+  }}
+  '''

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -61,6 +61,7 @@ DATASETS = [
     ("librispeech-pc", ["test"]),
     ("musan", ["test"]),
     ("compute-eval", ["eval"]),
+    ("sysbench", ["test"]),
 ]
 
 

--- a/tests/test_sysbench_metrics.py
+++ b/tests/test_sysbench_metrics.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo_skills.evaluation.metrics.sysbench_metrics import SysBenchMetrics
+
+
+def test_parse_judgement():
+    """Test parsing JSON judgement with unquoted integer keys."""
+    judgement = '{"评判结果": {1: "是", 2: "否"}}'
+    result = SysBenchMetrics.parse_sysbench_judgement(judgement)
+    assert result is not None
+    assert result["评判结果"]["1"] == "是"
+
+
+def test_is_correct():
+    """Test correctness check."""
+    assert SysBenchMetrics.is_sysbench_correct('{"评判结果": {"1": "是", "2": "是"}}') is True
+    assert SysBenchMetrics.is_sysbench_correct('{"评判结果": {"1": "是", "2": "否"}}') is False
+    assert SysBenchMetrics.is_sysbench_correct("INVALID") is False


### PR DESCRIPTION
Add SysBench benchmark (https://github.com/PKU-Baichuan-MLSystemLab/SysBench/tree/main) to NeMo-Skills. SysBench is a multi-turn benchmark with a judge, and the implementation is based off of the BFCL implementation.

Key Components:

- Dataset (dataset/sysbench/): Downloads from SysBench data from SysBench repo.
- Inference (inference/eval/sysbench.py): Multi-turn sysbench generation.
- Metrics (evaluation/metrics/sysbench.py): Reports various forms of accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SysBench benchmark support with full evaluation workflow
  * Introduced SysBench metrics evaluation including constraint satisfaction, instruction satisfaction, and session satisfaction rates
  * Added dataset preparation and multi-turn dialogue generation capabilities for SysBench evaluations

* **Documentation**
  * Added SysBench benchmark documentation

* **Tests**
  * Added unit tests for SysBench metrics validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->