### PR TITLE
Fix CI disk space for Docker image builds

### DIFF
--- a/dockerfiles/Dockerfile.sandbox
+++ b/dockerfiles/Dockerfile.sandbox
@@ -30,7 +30,6 @@
 
 # Use the base image with Python 3.10 and Flask
 FROM tiangolo/uwsgi-nginx-flask:python3.10
-ARG CACHEBUST=2026-02-12
 
 # Install dependencies required for Lean 4, pypy3, and other tools
 ARG TARGETARCH


### PR DESCRIPTION
## Summary
- Remove irrelevant files to free disk space on Ubuntu runners
- Add `docker builder prune -f` between image builds to prevent "no space left on device" during sandbox image load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD build pipeline for improved efficiency and reliability, including refined disk space management and additional builder pruning to reclaim space during image builds.
  * Introduced cache-busting for sandbox image builds to ensure updated build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->