### PR TITLE
Add --installation_command support to prepare_data

### DIFF
--- a/nemo_skills/pipeline/prepare_data.py
+++ b/nemo_skills/pipeline/prepare_data.py
@@ -76,6 +76,12 @@ def prepare_data(
     log_dir: str = typer.Option(None, help="Custom location for slurm logs"),
     exclusive: bool | None = typer.Option(None, help="If set will add exclusive flag to the slurm job."),
     check_mounted_paths: bool = typer.Option(False, help="Check mounted paths availability"),
+    installation_command: str | None = typer.Option(
+        None,
+        help="An installation command to run before main job. Only affects main task (not server or sandbox). "
+        "You can use an arbitrary command here and we will run it on a single rank for each node. "
+        "E.g. 'pip install my_package'",
+    ),
     skip_hf_home_check: bool | None = typer.Option(
         None,
         help="If True, skip checking that HF_HOME env var is defined in the cluster config.",
@@ -173,6 +179,7 @@ def prepare_data(
         log_dir=log_dir,
         exclusive=exclusive,
         check_mounted_paths=check_mounted_paths,
+        installation_command=installation_command,
         skip_hf_home_check=skip_hf_home_check,
         sbatch_kwargs=sbatch_kwargs,
     )


### PR DESCRIPTION
Adds the missing `--installation_command` parameter to `ns prepare_data` for consistency with other pipeline commands (generate, eval, convert, run_cmd).

This allows running custom installation commands (e.g., `pip install package`) before data preparation tasks, which is useful when datasets require specialized packages for parsing or processing.

Changes:
- Added `installation_command` parameter to prepare_data function signature
- Passed parameter through to underlying `_run_cmd()` call

Tested in Docker container with basic installations, complex multi-commands, failure handling, and backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `installation_command` parameter to the data preparation pipeline. Users can now specify a command to execute before the main task, providing greater flexibility in setup and installation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->