### PR TITLE
Add nv_tts dataset and evaluation scripts

### DIFF
--- a/nemo_skills/dataset/nv_tts/TTS_eval.md
+++ b/nemo_skills/dataset/nv_tts/TTS_eval.md
@@ -1,0 +1,123 @@
+# TTS Evaluation Based on NeMo-Skills
+
+This is an adaptation of `examples/tts/magpietts_inference.py` into NeMo-Skills. The generation and scoring are separated into 2 stages and can be effectively parallelized. The same code as in `magpietts_inference.py` is used for both stages.
+
+The test sets are also borrowed from the current evaluation setup.
+
+## Getting Started
+
+### 1. Clone and Setup
+
+```bash
+# Clone this branch
+git clone <repository_url>
+cd ns_eval
+
+# Create a virtual environment and install nemo-skills
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+### 2. Cluster Configuration
+
+Decide which cluster you want to work on and setup the corresponding cluster configuration.
+
+- An example configuration for EOS is provided in `cluster_configs/eos_example.yaml`
+- You can get more configurations from the [NeMo-Skills cluster configs](https://github.com/NVIDIA/NeMo-Skills/tree/main/cluster_configs)
+- Update the username in the configuration file
+
+Note that NeMo-Skills standard quant of resources is 1 gpu. Eos cluster is special because it allows assigning only full nodes (not e.g. 2 gpus from 8). So I had to write a fix, which is not nice, so probably won't be merged as is. You can remove the "EOS FIX 8 chunks per node" if running on other clusters. This may entail small changes in the config.
+
+### 3. Prepare Test Data
+
+You can either prepare a new test set or reuse an existing data directory.
+
+**To prepare a new test set:**
+
+```bash
+cd /home/vmendelev/workspace/expressiveness/src/ns_eval && source .venv/bin/activate && \
+python nemo_skills/dataset/nv_tts/prepare.py \
+  --config <cluster_login>:<path_to_>/eval_config_full_fixed.json
+```
+
+This will prepare `test.jsonl` for each benchmark with pointers to the files on the cluster.
+
+**To reuse an existing data directory (EOS):**
+
+```
+/lustre/fsw/llmservice_nemo_speechlm/users/vmendelev/tmp/data_dir
+```
+
+### 4. Configuration Files
+
+Review the config file and ensure all required artifacts are in the specified locations:
+
+| Config | Description |
+|--------|-------------|
+| `nemo_skills/dataset/nv_tts/scripts/config/default.yaml` | For `.nemo` model input |
+| `nemo_skills/dataset/nv_tts/scripts/config/grpo_small_step1100.yaml` | For checkpoint + hparams input |
+
+### 5. Environment Setup
+
+Make sure `HF_TOKEN` is present in the environment:
+
+```bash
+export HF_TOKEN=<your_huggingface_token>
+# or source from your .env file
+. ~/.env && export HF_TOKEN=$HF_READ_ONLY
+```
+
+## Running Evaluation
+
+### Full Evaluation (Generation + Scoring)
+
+```bash
+cd /home/vmendelev/workspace/expressiveness/src/ns_eval && source .venv/bin/activate && \
+NEMO_SKILLS_DISABLE_UNCOMMITTED_CHANGES_CHECK=1 \
+python -m nemo_skills.dataset.nv_tts.scripts.run_tts_eval \
+  --config nemo_skills/dataset/nv_tts/scripts/config/default.yaml \
+  --stage all \
+  --expname default_eval
+```
+
+### Stage Options
+
+| Stage | Description |
+|-------|-------------|
+| `all` | Run both generation and scoring |
+| `generation` | Run only TTS generation |
+| `scoring` | Run only scoring (requires completed generation) |
+| `aggregation` | Print summary of all metrics |
+
+## Comparing Results
+
+To produce a comparison report between different evaluation runs:
+
+```bash
+cd /home/vmendelev/workspace/expressiveness/src/ns_eval && source .venv/bin/activate && \
+python nemo_skills/dataset/nv_tts/scripts/compare_eval_results.py \
+  --baseline_dir <path_to_baseline_results> \
+  --compare_dir <path_to_comparison_results> \
+  --output_file tts_comparison_report.md
+```
+
+See [example report](scripts/tts_comparison_report.md) for sample output.
+
+## Output Structure
+
+Results are saved to `output_dir/eval-results/` with the following structure:
+
+```
+output_dir/
+├── eval-results/
+│   ├── nv_tts.libritts_seen/
+│   │   ├── output.jsonl          # Generated audio paths + metadata
+│   │   ├── output_with_metrics.jsonl  # With per-file metrics
+│   │   ├── metrics.json          # Aggregate metrics (CER, WER, UTMOSv2)
+│   │   └── audio/                # Generated audio files
+│   ├── nv_tts.vctk/
+│   │   └── ...
+│   └── ...
+└── eval-logs/                    # Job logs
+```

--- a/nemo_skills/dataset/nv_tts/__init__.py
+++ b/nemo_skills/dataset/nv_tts/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NV TTS evaluation dataset - for testing TTS models
+
+DATASET_GROUP = "tts"
+IS_BENCHMARK_GROUP = True
+
+# BENCHMARKS will be populated dynamically based on the config file
+# Example: {"nv_tts.libritts_seen": {}, "nv_tts.riva_hard_digits": {}}
+BENCHMARKS = {}
+
+GENERATION_ARGS = "++prompt_format=openai"

--- a/nemo_skills/dataset/nv_tts/prepare.py
+++ b/nemo_skills/dataset/nv_tts/prepare.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prepare NV TTS evaluation datasets.
+
+Reads a config JSON file (local or remote) containing subtest definitions,
+fetches manifest JSONL files, and generates nemo-skills test.jsonl files
+with manifest content embedded as JSON in user message content.
+
+Usage:
+    python prepare.py --config login-eos.nvidia.com:/path/to/evalset_config.json
+    python prepare.py --config /local/path/to/evalset_config.json
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+SYSTEM_MESSAGE = "You are a helpful assistant."
+
+# Template for subtest __init__.py files
+INIT_TEMPLATE = """# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NV TTS subtest: {subtest_name}
+
+GENERATION_ARGS = "++prompt_format=openai"
+"""
+
+
+def is_remote_path(path: str) -> bool:
+    """Check if path is a remote path (host:/path format)."""
+    return ":" in path and not path.startswith("/") and not path.startswith(".")
+
+
+def fetch_remote_file(remote_path: str, local_path: str) -> None:
+    """Fetch a file from a remote host using scp."""
+    result = subprocess.run(
+        ["scp", remote_path, local_path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to fetch {remote_path}: {result.stderr}")
+
+
+def read_file_content(path: str) -> str:
+    """Read file content, handling both local and remote paths."""
+    if is_remote_path(path):
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".tmp") as tmp:
+            tmp_path = tmp.name
+        try:
+            fetch_remote_file(path, tmp_path)
+            with open(tmp_path, "r", encoding="utf-8") as f:
+                return f.read()
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+    else:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+
+def get_remote_host(path: str) -> str:
+    """Extract host from a remote path."""
+    if is_remote_path(path):
+        return path.split(":")[0]
+    return ""
+
+
+def make_remote_path(host: str, path: str) -> str:
+    """Create a remote path from host and path."""
+    if host:
+        return f"{host}:{path}"
+    return path
+
+
+def format_manifest_entry(entry: dict, audio_dir: str) -> dict:
+    """Format a manifest entry into nemo-skills format.
+
+    Args:
+        entry: Manifest entry with fields like text, context_audio_filepath, etc.
+        audio_dir: Base directory for audio files to make paths absolute.
+
+    Returns:
+        Formatted entry with messages containing the manifest as JSON string.
+    """
+    # Make audio paths absolute by combining with audio_dir
+    entry_with_absolute_paths = entry.copy()
+
+    if "context_audio_filepath" in entry_with_absolute_paths and audio_dir:
+        entry_with_absolute_paths["context_audio_filepath"] = os.path.join(
+            audio_dir, entry_with_absolute_paths["context_audio_filepath"]
+        )
+
+    if "audio_filepath" in entry_with_absolute_paths and audio_dir:
+        entry_with_absolute_paths["audio_filepath"] = os.path.join(
+            audio_dir, entry_with_absolute_paths["audio_filepath"]
+        )
+
+    # Create the nemo-skills format entry
+    content = json.dumps(entry_with_absolute_paths)
+
+    return {
+        "problem": "",
+        "messages": [
+            {"role": "system", "content": SYSTEM_MESSAGE},
+            {"role": "user", "content": content},
+        ],
+    }
+
+
+def create_subtest_init(subtest_dir: Path, subtest_name: str) -> None:
+    """Create __init__.py for a subtest directory."""
+    content = INIT_TEMPLATE.format(subtest_name=subtest_name)
+    with open(subtest_dir / "__init__.py", "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def process_subtest(
+    subtest_name: str,
+    config: dict,
+    output_dir: Path,
+    remote_host: str,
+) -> int:
+    """Process a single subtest and generate test.jsonl.
+
+    Args:
+        subtest_name: Name of the subtest (e.g., "libritts_seen").
+        config: Subtest config with manifest_path, audio_dir, feature_dir.
+        output_dir: Base output directory for the dataset.
+        remote_host: Remote host for fetching files (empty for local).
+
+    Returns:
+        Number of entries processed.
+    """
+    subtest_dir = output_dir / subtest_name
+    subtest_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = config["manifest_path"]
+    audio_dir = config.get("audio_dir", "")
+
+    # Fetch manifest file
+    if remote_host:
+        manifest_remote = make_remote_path(remote_host, manifest_path)
+        print(f"Fetching manifest from {manifest_remote}...")
+        manifest_content = read_file_content(manifest_remote)
+    else:
+        print(f"Reading manifest from {manifest_path}...")
+        manifest_content = read_file_content(manifest_path)
+
+    # Process manifest entries
+    output_file = subtest_dir / "test.jsonl"
+    count = 0
+
+    with open(output_file, "w", encoding="utf-8") as fout:
+        for line in manifest_content.strip().split("\n"):
+            if not line.strip():
+                continue
+
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as e:
+                print(f"  Warning: Skipping invalid JSON line: {e}")
+                continue
+
+            formatted = format_manifest_entry(entry, audio_dir)
+            fout.write(json.dumps(formatted) + "\n")
+            count += 1
+
+    # Create __init__.py
+    create_subtest_init(subtest_dir, subtest_name)
+
+    print(f"  Wrote {count} entries to {output_file}")
+    return count
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Prepare NV TTS evaluation datasets")
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to config JSON file (local or remote: host:/path/to/config.json)",
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(__file__).parent
+
+    # Determine if config is remote and extract host
+    config_path = args.config
+    remote_host = get_remote_host(config_path)
+
+    # Read config file
+    print(f"Reading config from {config_path}...")
+    config_content = read_file_content(config_path)
+    config = json.loads(config_content)
+
+    print(f"Found {len(config)} subtests: {list(config.keys())}")
+
+    total_entries = 0
+    for subtest_name, subtest_config in config.items():
+        print(f"\nProcessing {subtest_name}...")
+        count = process_subtest(subtest_name, subtest_config, output_dir, remote_host)
+        total_entries += count
+
+    print(f"\nDone! Processed {total_entries} total entries across {len(config)} subtests.")
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_skills/dataset/nv_tts/scripts/__init__.py
+++ b/nemo_skills/dataset/nv_tts/scripts/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NV TTS evaluation scripts."""

--- a/nemo_skills/dataset/nv_tts/scripts/compare_tts_eval_results.py
+++ b/nemo_skills/dataset/nv_tts/scripts/compare_tts_eval_results.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""
+Compare multiple TTS evaluation results and generate a Markdown report.
+
+Usage:
+    python compare_tts_eval_results.py \
+        --eval_folders "/path/to/eval1:Model A" "/path/to/eval2:Model B" \
+        --output report.md
+
+Supports remote folders via SSH:
+    python compare_tts_eval_results.py \
+        --eval_folders "host1:/path/to/eval1:Model A" "host2:/path/to/eval2:Model B" \
+        --output report.md
+
+Each eval folder should contain subdirectories for different test sets,
+each with a metrics.json file.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+from typing import Optional
+
+
+def run_remote_cmd(host: str, cmd: str, timeout: int = 30) -> Optional[str]:
+    """Run a command on a remote host via SSH."""
+    try:
+        result = subprocess.run(["ssh", host, cmd], capture_output=True, text=True, timeout=timeout)
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, Exception):
+        return None
+
+
+def list_test_sets_local(eval_folder: str) -> list[str]:
+    """List test set subdirectories in a local eval folder."""
+    if not os.path.isdir(eval_folder):
+        return []
+    return [d for d in os.listdir(eval_folder) if os.path.isdir(os.path.join(eval_folder, d))]
+
+
+def list_test_sets_remote(host: str, eval_folder: str) -> list[str]:
+    """List test set subdirectories in a remote eval folder via SSH."""
+    output = run_remote_cmd(host, f"ls -1 {eval_folder}")
+    if output is None:
+        return []
+    return [d.strip() for d in output.split("\n") if d.strip()]
+
+
+def load_metrics_local(metrics_path: str) -> Optional[dict]:
+    """Load metrics from a local JSON file."""
+    if not os.path.exists(metrics_path):
+        return None
+    with open(metrics_path, "r") as f:
+        return json.load(f)
+
+
+def load_metrics_remote(host: str, metrics_path: str) -> Optional[dict]:
+    """Load metrics from a remote JSON file via SSH."""
+    output = run_remote_cmd(host, f"cat {metrics_path}")
+    if output is None:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError:
+        return None
+
+
+def load_metrics(path: str, host: Optional[str] = None) -> Optional[dict]:
+    """Load metrics from a local or remote JSON file."""
+    if host:
+        return load_metrics_remote(host, path)
+    return load_metrics_local(path)
+
+
+def list_test_sets(eval_folder: str, host: Optional[str] = None) -> list[str]:
+    """List test set subdirectories."""
+    if host:
+        return list_test_sets_remote(host, eval_folder)
+    return list_test_sets_local(eval_folder)
+
+
+def format_value(value, format_spec: str = ".4f", na_str: str = "N/A") -> str:
+    """Format a value for display."""
+    if value is None:
+        return na_str
+    try:
+        return f"{value:{format_spec}}"
+    except (ValueError, TypeError):
+        return str(value)
+
+
+def format_percent(value, na_str: str = "N/A") -> str:
+    """Format a value as percentage."""
+    if value is None:
+        return na_str
+    try:
+        return f"{value * 100:.2f}%"
+    except (ValueError, TypeError):
+        return str(value)
+
+
+def parse_folder_spec(spec: str) -> tuple[Optional[str], str, str]:
+    """
+    Parse folder specification in format:
+      - 'path:name' (local)
+      - 'path' (local, auto-name)
+      - 'host:path:name' (remote)
+      - 'host:path' (remote, auto-name)
+    """
+    parts = spec.split(":")
+    if len(parts) == 1:
+        path = parts[0]
+        name = os.path.basename(path.rstrip("/"))
+        return None, path, name
+    if len(parts) == 2:
+        if parts[0].startswith("/") or parts[0].startswith("."):
+            return None, parts[0], parts[1]
+        else:
+            host, path = parts[0], parts[1]
+            name = os.path.basename(path.rstrip("/"))
+            return host, path, name
+    if len(parts) == 3:
+        return parts[0], parts[1], parts[2]
+    if len(parts) > 3:
+        host = parts[0]
+        name = parts[-1]
+        path = ":".join(parts[1:-1])
+        return host, path, name
+    return None, spec, os.path.basename(spec.rstrip("/"))
+
+
+# TTS metrics: (key, display_name, format_func, higher_is_better)
+TTS_METRICS = [
+    ("wer_cumulative", "WER (cumulative)", format_percent, False),
+    ("cer_cumulative", "CER (cumulative)", format_percent, False),
+    ("wer_filewise_avg", "WER (filewise avg)", format_percent, False),
+    ("cer_filewise_avg", "CER (filewise avg)", format_percent, False),
+    ("utmosv2_avg", "UTMOS v2", lambda v: format_value(v, ".3f"), True),
+    ("ssim_pred_gt_avg", "SSIM (pred vs GT)", lambda v: format_value(v, ".4f"), True),
+    ("ssim_pred_context_avg", "SSIM (pred vs context)", lambda v: format_value(v, ".4f"), True),
+    ("total_gen_audio_seconds", "Total audio (sec)", lambda v: format_value(v, ".1f"), None),
+]
+
+
+def generate_test_set_table(
+    test_set: str,
+    models: list[tuple[str, dict]],
+) -> list[str]:
+    """Generate a comparison table for a single test set."""
+    lines = []
+    lines.append(f"### {test_set}\n")
+
+    # Table header
+    header = "| Metric | " + " | ".join(name for name, _ in models) + " |"
+    separator = "|" + "|".join(["---"] * (len(models) + 1)) + "|"
+    lines.append(header)
+    lines.append(separator)
+
+    for metric_key, display_name, fmt_func, higher_better in TTS_METRICS:
+        values = []
+        raw_values = []
+        for _, m in models:
+            val = m.get(metric_key)
+            raw_values.append(val)
+            values.append(fmt_func(val))
+
+        # Highlight best value
+        if higher_better is not None:
+            valid_vals = [(i, v) for i, v in enumerate(raw_values) if v is not None]
+            if len(valid_vals) >= 2:
+                if higher_better:
+                    best_idx = max(valid_vals, key=lambda x: x[1])[0]
+                else:
+                    best_idx = min(valid_vals, key=lambda x: x[1])[0]
+                values[best_idx] = f"**{values[best_idx]}**"
+
+        row = f"| {display_name} | " + " | ".join(values) + " |"
+        lines.append(row)
+
+    lines.append("")
+    return lines
+
+
+def compute_summary_metrics(
+    all_test_sets: list[str],
+    model_metrics: dict[str, dict[str, dict]],
+) -> dict[str, dict[str, float]]:
+    """Compute average metrics across all test sets for each model."""
+    summary = {}
+    for model_name, test_data in model_metrics.items():
+        totals = {}
+        counts = {}
+        for test_set in all_test_sets:
+            if test_set not in test_data:
+                continue
+            m = test_data[test_set]
+            for key, _, _, _ in TTS_METRICS:
+                if key in m and m[key] is not None:
+                    totals[key] = totals.get(key, 0) + m[key]
+                    counts[key] = counts.get(key, 0) + 1
+        summary[model_name] = {k: totals[k] / counts[k] for k in totals if counts.get(k, 0) > 0}
+    return summary
+
+
+def determine_best_model(models: list[tuple[str, dict]]) -> tuple[str, str]:
+    """Determine the best model based on summary metrics."""
+    if len(models) < 2:
+        return "", "Need at least 2 models to compare."
+
+    scores = {name: 0.0 for name, _ in models}
+    comparisons = []
+
+    # Weight metrics
+    weights = {
+        "wer_cumulative": 2.0,
+        "cer_cumulative": 1.5,
+        "utmosv2_avg": 2.0,
+        "ssim_pred_gt_avg": 1.0,
+    }
+
+    for metric_key, metric_name, _, higher_better in TTS_METRICS:
+        if higher_better is None:
+            continue
+        weight = weights.get(metric_key, 1.0)
+        valid = [(name, m.get(metric_key)) for name, m in models if m.get(metric_key) is not None]
+        if len(valid) < 2:
+            continue
+
+        if higher_better:
+            best_val = max(v for _, v in valid)
+            worst_val = min(v for _, v in valid)
+        else:
+            best_val = min(v for _, v in valid)
+            worst_val = max(v for _, v in valid)
+
+        if best_val == worst_val:
+            continue
+
+        best_name = [n for n, v in valid if v == best_val][0]
+        for name, val in valid:
+            if higher_better:
+                normalized = (val - worst_val) / (best_val - worst_val)
+            else:
+                normalized = (worst_val - val) / (worst_val - best_val)
+            scores[name] += normalized * weight
+        comparisons.append(f"{best_name} leads in {metric_name}")
+
+    if not any(scores.values()):
+        return "", "Unable to determine best model: insufficient metrics."
+
+    sorted_scores = sorted(scores.items(), key=lambda x: x[1], reverse=True)
+    best_name = sorted_scores[0][0]
+    return best_name, (
+        f"**{best_name}** performs best overall. "
+        f"Key advantages: {'; '.join(comparisons[:4]) if comparisons else 'balanced performance'}."
+    )
+
+
+def generate_report(
+    model_names: list[str],
+    all_test_sets: list[str],
+    model_metrics: dict[str, dict[str, dict]],
+    output_path: str,
+):
+    """Generate the full Markdown comparison report."""
+    lines = []
+    lines.append("# TTS Evaluation Comparison Report\n")
+    lines.append(f"Comparing {len(model_names)} model(s): " + ", ".join(model_names) + "\n")
+
+    # Summary section
+    lines.append("## Summary (Averaged Across Test Sets)\n")
+    summary = compute_summary_metrics(all_test_sets, model_metrics)
+    summary_models = [(name, summary.get(name, {})) for name in model_names]
+
+    header = "| Metric | " + " | ".join(model_names) + " |"
+    separator = "|" + "|".join(["---"] * (len(model_names) + 1)) + "|"
+    lines.append(header)
+    lines.append(separator)
+
+    for metric_key, display_name, fmt_func, higher_better in TTS_METRICS:
+        if metric_key == "total_gen_audio_seconds":
+            continue  # Skip total audio in summary
+        values = []
+        raw_values = []
+        for name in model_names:
+            val = summary.get(name, {}).get(metric_key)
+            raw_values.append(val)
+            values.append(fmt_func(val))
+
+        if higher_better is not None:
+            valid_vals = [(i, v) for i, v in enumerate(raw_values) if v is not None]
+            if len(valid_vals) >= 2:
+                if higher_better:
+                    best_idx = max(valid_vals, key=lambda x: x[1])[0]
+                else:
+                    best_idx = min(valid_vals, key=lambda x: x[1])[0]
+                values[best_idx] = f"**{values[best_idx]}**"
+
+        row = f"| {display_name} | " + " | ".join(values) + " |"
+        lines.append(row)
+
+    lines.append("")
+
+    # Best model analysis
+    best_name, explanation = determine_best_model(summary_models)
+    lines.append("### Analysis\n")
+    lines.append(explanation)
+    lines.append("")
+
+    # Per-test-set sections
+    lines.append("## Per-Test-Set Results\n")
+
+    for test_set in sorted(all_test_sets):
+        test_models = []
+        for name in model_names:
+            m = model_metrics.get(name, {}).get(test_set)
+            if m is not None:
+                test_models.append((name, m))
+
+        if not test_models:
+            continue
+
+        lines.extend(generate_test_set_table(test_set, test_models))
+
+    # Legend
+    lines.append("---")
+    lines.append("*Lower WER/CER is better, higher UTMOS/SSIM is better. **bold** = best value.*")
+
+    report = "\n".join(lines)
+
+    with open(output_path, "w") as f:
+        f.write(report)
+
+    print(f"Report saved to: {output_path}")
+    print("\n" + "=" * 60)
+    print(report)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare TTS evaluation results from multiple folders",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    # Remote folders (via SSH):
+    python compare_tts_eval_results.py \\
+        --eval_folders "login-eos:/path/to/eval1/eval-results:Model A" \\
+                       "login-eos:/path/to/eval2/eval-results:Model B" \\
+        --output comparison_report.md
+
+    # Local folders:
+    python compare_tts_eval_results.py \\
+        --eval_folders "/path/to/eval1:Model A" "/path/to/eval2:Model B" \\
+        --output comparison_report.md
+
+Each eval folder should contain subdirectories for different test sets
+(e.g., nv_tts.vctk, nv_tts.libritts_test_clean), each with a metrics.json.
+        """,
+    )
+    parser.add_argument(
+        "--eval_folders",
+        nargs="+",
+        required=True,
+        help="Evaluation folders: 'path:name', 'host:path:name', or 'host:path'",
+    )
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    default_output = os.path.join(script_dir, "tts_comparison_report.md")
+    parser.add_argument("--output", type=str, default=default_output, help="Output Markdown file path")
+
+    args = parser.parse_args()
+
+    # Parse folder specs
+    folder_specs = []
+    for spec in args.eval_folders:
+        host, path, name = parse_folder_spec(spec)
+        folder_specs.append((host, path, name))
+
+    # Discover all test sets across all models
+    all_test_sets = set()
+    model_test_sets = {}
+    for host, path, name in folder_specs:
+        test_sets = list_test_sets(path, host)
+        model_test_sets[name] = (host, path, test_sets)
+        all_test_sets.update(test_sets)
+        loc = f"{host}:{path}" if host else path
+        print(f"Found {len(test_sets)} test sets for {name} at {loc}")
+
+    if not all_test_sets:
+        print("Error: No test sets found.")
+        return 1
+
+    # Load metrics for each model and test set
+    model_metrics: dict[str, dict[str, dict]] = {}
+    model_names = []
+
+    for host, path, name in folder_specs:
+        model_names.append(name)
+        model_metrics[name] = {}
+        test_sets = model_test_sets[name][2]
+
+        for test_set in test_sets:
+            metrics_path = f"{path}/{test_set}/metrics.json"
+            metrics = load_metrics(metrics_path, host)
+            if metrics is not None:
+                model_metrics[name][test_set] = metrics
+                print(f"  Loaded {test_set} for {name}")
+            else:
+                print(f"  Skipping {test_set} for {name} (no metrics.json)")
+
+    # Filter to test sets that have metrics for at least one model
+    valid_test_sets = [ts for ts in all_test_sets if any(ts in model_metrics.get(n, {}) for n in model_names)]
+
+    if not valid_test_sets:
+        print("Error: No valid metrics found for any test set.")
+        return 1
+
+    generate_report(model_names, valid_test_sets, model_metrics, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/nemo_skills/dataset/nv_tts/scripts/config/default.yaml
+++ b/nemo_skills/dataset/nv_tts/scripts/config/default.yaml
@@ -1,0 +1,31 @@
+# TTS Pipeline Configuration
+
+# Cluster and execution settings (shared across all stages)
+cluster: eos
+container: /lustre/fsw/llmservice_nemo_speechlm/users/vmendelev/containters/nemo-25.11.sqsh
+partition: batch
+mount_paths: /lustre:/lustre
+output_dir: /lustre/fsw/llmservice_nemo_speechlm/users/vmendelev/tmp/nv_tts_eval_full_a3
+
+# NeMo code path
+nemo_code_path: /lustre/fsw/llmservice_nemo_speechlm/users/vmendelev/experimenta/tts_eval/NeMo
+
+# Generation settings (ns eval arguments)
+generation:
+  benchmarks: nv_tts.libritts_seen,nv_tts.libritts_test_clean,nv_tts.riva_hard_digits,nv_tts.riva_hard_letters,nv_tts.riva_hard_money,nv_tts.riva_hard_short,nv_tts.vctk
+  model: nvidia/magpie_tts_multilingual_357m
+  server_type: generic
+  server_gpus: 1
+  server_entrypoint: python -m nemo_skills.inference.server.serve_unified
+  server_args: --backend magpie_tts --codec_model nvidia/nemo-nano-codec-22khz-1.89kbps-21.5fps --batch_size 32 --batch_timeout 0.1 --use_cfg --cfg_scale 2.5
+  data_dir: /lustre/fsw/llmservice_nemo_speechlm/users/vmendelev/tmp/data_dir
+  num_chunks: 2
+  extra_args: ++server.server_type=vllm_multimodal
+
+# Scoring settings
+scoring:
+  sv_model: titanet
+  asr_model_name: nvidia/parakeet-tdt-1.1b
+  language: en
+  with_utmosv2: true
+  gpus: 1

--- a/nemo_skills/dataset/nv_tts/scripts/config/grpo_small_step1100.yaml
+++ b/nemo_skills/dataset/nv_tts/scripts/config/grpo_small_step1100.yaml
@@ -1,0 +1,39 @@
+# TTS Pipeline Configuration - GRPO Small Step 1100
+
+# Cluster and execution settings (shared across all stages)
+cluster: eos
+container: /lustre/fsw/llmservice_nemo_speechlm/users/vmendelev/containters/nemo-25.11.sqsh
+partition: batch
+mount_paths: /lustre:/lustre
+output_dir: /lustre/fsw/llmservice_nemo_speechlm/users/vmendelev/tmp/nv_tts_eval_grpo_small_step1100_full
+
+# NeMo code path
+nemo_code_path: /lustre/fsw/llmservice_nemo_speechlm/users/vmendelev/experimenta/tts_eval/NeMo
+
+# Generation settings (ns eval arguments)
+generation:
+  benchmarks: nv_tts.libritts_seen,nv_tts.libritts_test_clean,nv_tts.riva_hard_digits,nv_tts.riva_hard_letters,nv_tts.riva_hard_money,nv_tts.riva_hard_short,nv_tts.vctk
+  model: grpo_small_step1100  # name for logging, actual model loaded via hparams/checkpoint in server_args
+  server_type: generic
+  server_gpus: 1
+  server_entrypoint: "cd /lustre/fsw/llmservice_nemo_speechlm/users/vmendelev/experimenta/tts_eval/NeMo && python -m nemo_skills.inference.server.serve_unified"
+  server_args: >-
+    --backend magpie_tts
+    --codec_model nvidia/nemo-nano-codec-22khz-1.89kbps-21.5fps
+    --batch_size 32
+    --batch_timeout 0.1
+    --use_cfg
+    --cfg_scale 2.5
+    --hparams_file /lustre/fsw/llmservice_nemo_speechlm/users/vmendelev/experimenta/tts_eval/small_hparams.yaml
+    --checkpoint_file /lustre/fsw/llmservice_nemo_speechlm/users/agorodetskii/checkpoints/N2512_English_TTSArena/grpo_small_from_ft_step1100.ckpt
+  data_dir: /lustre/fsw/llmservice_nemo_speechlm/users/vmendelev/tmp/data_dir
+  num_chunks: 2
+  extra_args: ++server.server_type=vllm_multimodal
+
+# Scoring settings
+scoring:
+  sv_model: titanet
+  asr_model_name: nvidia/parakeet-tdt-1.1b
+  language: en
+  with_utmosv2: true
+  gpus: 1

--- a/nemo_skills/dataset/nv_tts/scripts/run_tts_eval.py
+++ b/nemo_skills/dataset/nv_tts/scripts/run_tts_eval.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+TTS Pipeline: Generation -> Scoring (-> Aggregation)
+
+Usage:
+    python run_tts_eval.py --config config.yaml
+    python run_tts_eval.py --config config.yaml --stage scoring
+    python run_tts_eval.py --config config.yaml --stage aggregation
+"""
+
+import argparse
+import os
+
+import yaml
+
+from nemo_skills.pipeline.eval import eval as ns_eval
+from nemo_skills.pipeline.run_cmd import run_cmd as ns_run_cmd
+
+
+class MockContext:
+    """Mock typer.Context for programmatic calls."""
+
+    def __init__(self, extra_args=None):
+        self.args = extra_args or []
+
+
+def load_config(config_path: str) -> dict:
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+def run_generation(cfg: dict, expname: str):
+    """Run generation stage using ns eval, returns experiment object."""
+    gen = cfg["generation"]
+
+    # Add nemo_code_path to server_args
+    server_args = gen["server_args"]
+    if cfg.get("nemo_code_path"):
+        server_args += f" --code_path {cfg['nemo_code_path']}"
+
+    # Parse extra_args for the context
+    extra_args = gen.get("extra_args", "").split() if gen.get("extra_args") else []
+    ctx = MockContext(extra_args)
+
+    # Call eval programmatically
+    return ns_eval(
+        ctx=ctx,
+        cluster=cfg["cluster"],
+        output_dir=cfg["output_dir"],
+        benchmarks=gen["benchmarks"],
+        model=gen["model"],
+        server_type=gen["server_type"],
+        server_gpus=gen["server_gpus"],
+        server_container=cfg["container"],
+        mount_paths=cfg["mount_paths"],
+        server_entrypoint=gen["server_entrypoint"],
+        server_args=server_args,
+        data_dir=gen["data_dir"],
+        num_chunks=gen["num_chunks"],
+        partition=cfg["partition"],
+        expname=expname,
+        auto_summarize_results=False,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="TTS Pipeline")
+    parser.add_argument("--config", required=True)
+    parser.add_argument(
+        "--stage",
+        choices=["all", "generation", "scoring", "aggregation"],
+        default="all",
+        help="Stage to run. 'all' runs generation+scoring (no aggregation)",
+    )
+    parser.add_argument("--expname", default="tts_eval", help="Base experiment name for job tracking")
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    scoring = cfg.get("scoring", {})
+    hf_token = os.environ.get("HF_TOKEN", "")
+    nemo_path = cfg["nemo_code_path"]
+    output_dir = cfg["output_dir"]
+
+    gen_exp_name = None
+
+    # Stage 1: Generation
+    if args.stage in ("all", "generation"):
+        print("\n" + "=" * 60)
+        print("Stage 1: GENERATION")
+        print("=" * 60)
+        gen_exp = run_generation(cfg, args.expname)
+        # Extract experiment name/id for dependency tracking
+        gen_exp_name = args.expname  # The expname we passed to ns_eval
+        print(f"Generation submitted: {gen_exp}")
+
+    # Stage 2: Scoring (one job per benchmark, depends on generation)
+    if args.stage in ("all", "scoring"):
+        print("\n" + "=" * 60)
+        print("Stage 2: SCORING")
+        print("=" * 60)
+
+        # Parse benchmarks list
+        benchmarks = cfg["generation"]["benchmarks"].split(",")
+
+        install_cmd = None
+        if scoring.get("with_utmosv2"):
+            install_cmd = "pip install git+https://github.com/sarulab-speech/UTMOSv2.git@v1.2.1"
+
+        # When running both stages, scoring depends on generation experiment (by name)
+        run_after = [gen_exp_name] if args.stage == "all" and gen_exp_name else None
+
+        for benchmark in benchmarks:
+            benchmark = benchmark.strip()
+            # Benchmark dir in eval-results keeps dot notation (nv_tts.libritts_seen)
+            benchmark_dir = benchmark
+
+            scoring_cmd = (
+                f"HF_TOKEN={hf_token} "
+                f"PYTHONPATH={nemo_path}:$PYTHONPATH "
+                f"python -m nemo_skills.dataset.nv_tts.scripts.score "
+                f"--results_dir {output_dir} "
+                f"--benchmark {benchmark_dir} "
+                f"--sv_model {scoring.get('sv_model', 'titanet')} "
+                f"--asr_model_name {scoring.get('asr_model_name', 'nvidia/parakeet-tdt-1.1b')} "
+                f"--language {scoring.get('language', 'en')}"
+            )
+            if scoring.get("with_utmosv2"):
+                scoring_cmd += " --with_utmosv2"
+
+            # Short name for job (e.g. libritts_seen from nv_tts.libritts_seen)
+            short_name = benchmark.split(".")[-1]
+            print(f"  Submitting scoring job for: {benchmark}")
+
+            ns_run_cmd(
+                ctx=MockContext(),
+                cluster=cfg["cluster"],
+                container=cfg["container"],
+                partition=cfg["partition"],
+                num_gpus=scoring.get("gpus", 1),
+                mount_paths=cfg["mount_paths"],
+                command=scoring_cmd,
+                installation_command=install_cmd,
+                run_after=run_after,
+                expname=f"{args.expname}_score_{short_name}",
+                log_dir=f"{output_dir}/eval-logs",
+            )
+
+    # Stage 3: Aggregation (only if explicitly requested)
+    if args.stage == "aggregation":
+        print("\n" + "=" * 60)
+        print("Stage 3: AGGREGATION")
+        print("=" * 60)
+        agg_cmd = f"python -m nemo_skills.dataset.nv_tts.scripts.score --results_dir {output_dir} --aggregation_only"
+        ns_run_cmd(
+            ctx=MockContext(),
+            cluster=cfg["cluster"],
+            container=cfg["container"],
+            partition=cfg["partition"],
+            num_gpus=0,
+            mount_paths=cfg["mount_paths"],
+            command=agg_cmd,
+            expname=f"{args.expname}_agg",
+            log_dir=f"{output_dir}/eval-logs",
+        )
+
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_skills/dataset/nv_tts/scripts/score.py
+++ b/nemo_skills/dataset/nv_tts/scripts/score.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scoring and aggregation functions for TTS evaluation."""
+
+import argparse
+import json
+import os
+import tempfile
+
+from nemo.collections.tts.modules.magpietts_inference.evaluate_generated_audio import evaluate
+
+
+def run_scoring(
+    results_dir: str,
+    sv_model: str = "titanet",
+    asr_model_name: str = "nvidia/parakeet-tdt-1.1b",
+    language: str = "en",
+    with_utmosv2: bool = False,
+) -> None:
+    """Run NeMo scoring on all benchmarks in results_dir."""
+    benchmarks_dir = os.path.join(results_dir, "eval-results")
+    if not os.path.exists(benchmarks_dir):
+        benchmarks_dir = results_dir
+
+    scoring_cfg = {
+        "sv_model": sv_model,
+        "asr_model_name": asr_model_name,
+        "language": language,
+        "with_utmosv2": with_utmosv2,
+    }
+
+    for benchmark in os.listdir(benchmarks_dir):
+        benchmark_dir = os.path.join(benchmarks_dir, benchmark)
+        if not os.path.isdir(benchmark_dir):
+            continue
+
+        output_jsonl = os.path.join(benchmark_dir, "output.jsonl")
+        if not os.path.exists(output_jsonl):
+            continue
+
+        print(f"\nScoring: {benchmark}")
+        metrics = score_benchmark(output_jsonl, scoring_cfg)
+
+        # Save metrics.json
+        metrics_path = os.path.join(benchmark_dir, "metrics.json")
+        with open(metrics_path, "w") as f:
+            json.dump(metrics, f, indent=2)
+        print(f"Saved: {metrics_path}")
+        print(f"  CER: {metrics.get('cer_cumulative', 'N/A'):.4f}")
+        print(f"  WER: {metrics.get('wer_cumulative', 'N/A'):.4f}")
+        if "utmosv2_avg" in metrics:
+            print(f"  UTMOSv2: {metrics.get('utmosv2_avg', 'N/A'):.4f}")
+
+
+def score_benchmark(output_jsonl: str, scoring_cfg: dict) -> dict:
+    """Score a single benchmark."""
+    # Parse output.jsonl
+    entries = []
+    records = []
+    with open(output_jsonl) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            records.append(record)
+
+            # Extract manifest from user message
+            manifest_entry = None
+            for msg in record.get("messages", []):
+                if msg.get("role") == "user":
+                    content = msg.get("content", "")
+                    manifest_entry = json.loads(content) if isinstance(content, str) else content
+                    break
+
+            audio_path = record.get("audio", {}).get("path")
+            if audio_path and manifest_entry:
+                entries.append((manifest_entry, audio_path))
+
+    if not entries:
+        return {}
+
+    # Create temp dir with manifest and symlinks
+    with tempfile.TemporaryDirectory(prefix="tts_scoring_") as tmp_dir:
+        manifest_path = os.path.join(tmp_dir, "manifest.json")
+        gen_audio_dir = os.path.join(tmp_dir, "generated")
+        os.makedirs(gen_audio_dir)
+
+        with open(manifest_path, "w") as f:
+            for i, (manifest_entry, audio_path) in enumerate(entries):
+                f.write(json.dumps(manifest_entry) + "\n")
+                dst = os.path.join(gen_audio_dir, f"predicted_audio_{i}.wav")
+                if os.path.exists(audio_path):
+                    os.symlink(audio_path, dst)
+
+        avg_metrics, filewise_metrics = evaluate(
+            manifest_path=manifest_path,
+            audio_dir=None,
+            generated_audio_dir=gen_audio_dir,
+            language=scoring_cfg.get("language", "en"),
+            sv_model_type=scoring_cfg.get("sv_model", "titanet"),
+            asr_model_name=scoring_cfg.get("asr_model_name", "nvidia/parakeet-tdt-1.1b"),
+            with_utmosv2=scoring_cfg.get("with_utmosv2", False),
+        )
+
+        # Save output_with_metrics.jsonl
+        output_with_metrics_path = output_jsonl.replace("output.jsonl", "output_with_metrics.jsonl")
+        with open(output_with_metrics_path, "w") as f:
+            for i, record in enumerate(records):
+                if i < len(filewise_metrics):
+                    record["metrics"] = filewise_metrics[i]
+                f.write(json.dumps(record) + "\n")
+        print(f"Saved: {output_with_metrics_path}")
+
+        return avg_metrics
+
+
+def run_aggregation(results_dir: str) -> None:
+    """Print summary of all metrics."""
+    benchmarks_dir = os.path.join(results_dir, "eval-results")
+    if not os.path.exists(benchmarks_dir):
+        benchmarks_dir = results_dir
+
+    print("\nAggregated Results:")
+    for benchmark in sorted(os.listdir(benchmarks_dir)):
+        metrics_path = os.path.join(benchmarks_dir, benchmark, "metrics.json")
+        if os.path.exists(metrics_path):
+            with open(metrics_path) as f:
+                metrics = json.load(f)
+            print(f"  {benchmark}:")
+            print(f"    CER: {metrics.get('cer_cumulative', 'N/A'):.4f}")
+            print(f"    WER: {metrics.get('wer_cumulative', 'N/A'):.4f}")
+            if "utmosv2_avg" in metrics:
+                print(f"    UTMOSv2: {metrics.get('utmosv2_avg', 'N/A'):.4f}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="TTS Scoring")
+    parser.add_argument("--results_dir", required=True)
+    parser.add_argument("--sv_model", default="titanet")
+    parser.add_argument("--asr_model_name", default="nvidia/parakeet-tdt-1.1b")
+    parser.add_argument("--language", default="en")
+    parser.add_argument("--with_utmosv2", action="store_true")
+    parser.add_argument("--aggregation_only", action="store_true")
+    args = parser.parse_args()
+
+    if args.aggregation_only:
+        run_aggregation(args.results_dir)
+    else:
+        run_scoring(
+            args.results_dir,
+            sv_model=args.sv_model,
+            asr_model_name=args.asr_model_name,
+            language=args.language,
+            with_utmosv2=args.with_utmosv2,
+        )

--- a/nemo_skills/dataset/nv_tts/scripts/score.py
+++ b/nemo_skills/dataset/nv_tts/scripts/score.py
@@ -51,11 +51,15 @@ def run_scoring(
         if not os.path.exists(output_jsonl):
             continue
 
+        metrics_path = os.path.join(benchmark_dir, "metrics.json")
+        if os.path.exists(metrics_path):
+            print(f"Skipping {benchmark}: metrics.json already exists")
+            continue
+
         print(f"\nScoring: {benchmark}")
         metrics = score_benchmark(output_jsonl, scoring_cfg)
 
         # Save metrics.json
-        metrics_path = os.path.join(benchmark_dir, "metrics.json")
         with open(metrics_path, "w") as f:
             json.dump(metrics, f, indent=2)
         print(f"Saved: {metrics_path}")

--- a/nemo_skills/dataset/nv_tts/scripts/score.py
+++ b/nemo_skills/dataset/nv_tts/scripts/score.py
@@ -29,8 +29,13 @@ def run_scoring(
     asr_model_name: str = "nvidia/parakeet-tdt-1.1b",
     language: str = "en",
     with_utmosv2: bool = False,
+    benchmark: str = None,
 ) -> None:
-    """Run NeMo scoring on all benchmarks in results_dir."""
+    """Run NeMo scoring on benchmarks in results_dir.
+
+    Args:
+        benchmark: If provided, score only this benchmark. Otherwise score all.
+    """
     benchmarks_dir = os.path.join(results_dir, "eval-results")
     if not os.path.exists(benchmarks_dir):
         benchmarks_dir = results_dir
@@ -42,21 +47,28 @@ def run_scoring(
         "with_utmosv2": with_utmosv2,
     }
 
-    for benchmark in os.listdir(benchmarks_dir):
-        benchmark_dir = os.path.join(benchmarks_dir, benchmark)
+    # Determine which benchmarks to score
+    if benchmark:
+        benchmarks_to_score = [benchmark]
+    else:
+        benchmarks_to_score = os.listdir(benchmarks_dir)
+
+    for bench in benchmarks_to_score:
+        benchmark_dir = os.path.join(benchmarks_dir, bench)
         if not os.path.isdir(benchmark_dir):
             continue
 
         output_jsonl = os.path.join(benchmark_dir, "output.jsonl")
         if not os.path.exists(output_jsonl):
+            print(f"Skipping {bench}: output.jsonl not found")
             continue
 
         metrics_path = os.path.join(benchmark_dir, "metrics.json")
         if os.path.exists(metrics_path):
-            print(f"Skipping {benchmark}: metrics.json already exists")
+            print(f"Skipping {bench}: metrics.json already exists")
             continue
 
-        print(f"\nScoring: {benchmark}")
+        print(f"\nScoring: {bench}")
         metrics = score_benchmark(output_jsonl, scoring_cfg)
 
         # Save metrics.json
@@ -158,6 +170,7 @@ if __name__ == "__main__":
     parser.add_argument("--language", default="en")
     parser.add_argument("--with_utmosv2", action="store_true")
     parser.add_argument("--aggregation_only", action="store_true")
+    parser.add_argument("--benchmark", default=None, help="Score only this benchmark (e.g. nv_tts.libritts_seen)")
     args = parser.parse_args()
 
     if args.aggregation_only:
@@ -169,4 +182,5 @@ if __name__ == "__main__":
             asr_model_name=args.asr_model_name,
             language=args.language,
             with_utmosv2=args.with_utmosv2,
+            benchmark=args.benchmark,
         )

--- a/nemo_skills/dataset/nv_tts/scripts/tts_comparison_report.md
+++ b/nemo_skills/dataset/nv_tts/scripts/tts_comparison_report.md
@@ -1,0 +1,115 @@
+# TTS Evaluation Comparison Report
+
+Comparing 2 model(s): GRPO Step 1100, A3 Baseline
+
+## Summary (Averaged Across Test Sets)
+
+| Metric | GRPO Step 1100 | A3 Baseline |
+|---|---|---|
+| WER (cumulative) | 4.56% | **3.65%** |
+| CER (cumulative) | 2.75% | **2.24%** |
+| WER (filewise avg) | 4.49% | **3.54%** |
+| CER (filewise avg) | 3.14% | **2.28%** |
+| UTMOS v2 | **3.124** | 3.005 |
+| SSIM (pred vs GT) | **0.6599** | 0.0255 |
+| SSIM (pred vs context) | **0.6709** | 0.0259 |
+
+### Analysis
+
+**A3 Baseline** performs best overall. Key advantages: A3 Baseline leads in WER (cumulative); A3 Baseline leads in CER (cumulative); A3 Baseline leads in WER (filewise avg); A3 Baseline leads in CER (filewise avg).
+
+## Per-Test-Set Results
+
+### nv_tts.libritts_seen
+
+| Metric | GRPO Step 1100 |
+|---|---|
+| WER (cumulative) | 2.76% |
+| CER (cumulative) | 1.92% |
+| WER (filewise avg) | 2.69% |
+| CER (filewise avg) | 1.83% |
+| UTMOS v2 | 3.322 |
+| SSIM (pred vs GT) | 0.8022 |
+| SSIM (pred vs context) | 0.8022 |
+| Total audio (sec) | 1314.7 |
+
+### nv_tts.libritts_test_clean
+
+| Metric | GRPO Step 1100 | A3 Baseline |
+|---|---|---|
+| WER (cumulative) | 1.37% | **1.27%** |
+| CER (cumulative) | 0.46% | **0.41%** |
+| WER (filewise avg) | 1.47% | **1.30%** |
+| CER (filewise avg) | 0.51% | **0.42%** |
+| UTMOS v2 | **3.279** | 3.153 |
+| SSIM (pred vs GT) | **0.8378** | -0.0138 |
+| SSIM (pred vs context) | **0.8378** | -0.0138 |
+| Total audio (sec) | 12454.1 | 15257.6 |
+
+### nv_tts.riva_hard_digits
+
+| Metric | GRPO Step 1100 | A3 Baseline |
+|---|---|---|
+| WER (cumulative) | 3.52% | **2.13%** |
+| CER (cumulative) | 2.58% | **1.41%** |
+| WER (filewise avg) | 3.27% | **1.96%** |
+| CER (filewise avg) | 2.43% | **1.32%** |
+| UTMOS v2 | **3.119** | 3.035 |
+| SSIM (pred vs GT) | **0.6976** | 0.0460 |
+| SSIM (pred vs context) | **0.6976** | 0.0460 |
+| Total audio (sec) | 2462.9 | 3022.4 |
+
+### nv_tts.riva_hard_letters
+
+| Metric | GRPO Step 1100 | A3 Baseline |
+|---|---|---|
+| WER (cumulative) | **5.34%** | 6.17% |
+| CER (cumulative) | **2.92%** | 4.51% |
+| WER (filewise avg) | **5.00%** | 5.82% |
+| CER (filewise avg) | **2.82%** | 4.26% |
+| UTMOS v2 | 2.988 | **2.991** |
+| SSIM (pred vs GT) | **0.6505** | 0.0432 |
+| SSIM (pred vs context) | **0.6505** | 0.0432 |
+| Total audio (sec) | 1984.2 | 2432.8 |
+
+### nv_tts.riva_hard_money
+
+| Metric | GRPO Step 1100 | A3 Baseline |
+|---|---|---|
+| WER (cumulative) | 2.92% | **0.92%** |
+| CER (cumulative) | 2.00% | **0.55%** |
+| WER (filewise avg) | 2.86% | **0.86%** |
+| CER (filewise avg) | 1.96% | **0.49%** |
+| UTMOS v2 | **3.191** | 3.076 |
+| SSIM (pred vs GT) | **0.7075** | 0.0428 |
+| SSIM (pred vs context) | **0.7075** | 0.0428 |
+| Total audio (sec) | 2635.0 | 3149.5 |
+
+### nv_tts.riva_hard_short
+
+| Metric | GRPO Step 1100 | A3 Baseline |
+|---|---|---|
+| WER (cumulative) | 15.66% | **9.84%** |
+| CER (cumulative) | 9.24% | **6.11%** |
+| WER (filewise avg) | 15.66% | **9.84%** |
+| CER (filewise avg) | 12.32% | **6.76%** |
+| UTMOS v2 | 2.525 | **2.544** |
+| SSIM (pred vs GT) | **0.3004** | 0.0373 |
+| SSIM (pred vs context) | **0.3004** | 0.0373 |
+| Total audio (sec) | 312.4 | 573.5 |
+
+### nv_tts.vctk
+
+| Metric | GRPO Step 1100 | A3 Baseline |
+|---|---|---|
+| WER (cumulative) | **0.36%** | 1.55% |
+| CER (cumulative) | **0.09%** | 0.46% |
+| WER (filewise avg) | **0.47%** | 1.43% |
+| CER (filewise avg) | **0.10%** | 0.45% |
+| UTMOS v2 | **3.441** | 3.229 |
+| SSIM (pred vs GT) | **0.6236** | -0.0028 |
+| SSIM (pred vs context) | **0.7002** | -0.0004 |
+| Total audio (sec) | 310.6 | 334.6 |
+
+---
+*Lower WER/CER is better, higher UTMOS/SSIM is better. **bold** = best value.*


### PR DESCRIPTION
## Summary
- Add nv_tts benchmark dataset with prepare script and `__init__.py`
- Add TTS evaluation scoring and aggregation (CER, WER, UTMOSv2)
- Add per-benchmark scoring support with `--benchmark` flag
- Add comparison script and TTS evaluation documentation
- Add Hydra config files for TTS eval runs

## Files added
- `nemo_skills/dataset/nv_tts/__init__.py` — dataset registration
- `nemo_skills/dataset/nv_tts/prepare.py` — data preparation
- `nemo_skills/dataset/nv_tts/TTS_eval.md` — evaluation documentation
- `nemo_skills/dataset/nv_tts/scripts/` — scoring, evaluation, and comparison scripts
- `nemo_skills/dataset/nv_tts/scripts/config/` — Hydra config files

## Test plan
- [ ] Run `python -m pytest tests/` to verify no regressions
- [ ] Verify nv_tts dataset preparation works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive TTS evaluation toolkit enabling dataset preparation, multi-stage evaluation (generation, scoring, aggregation), and multi-model comparison reports.
  * Supports local and remote SSH operations for flexible evaluation workflows.
  * Integrated metrics include WER, CER, UTMOSV2, and SSIM scores.

* **Documentation**
  * Added TTS evaluation workflow guide and example comparison reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->