### PR TITLE
Rename custom -> external benchmarks

### DIFF
--- a/docs/evaluation/external-benchmarks.md
+++ b/docs/evaluation/external-benchmarks.md
@@ -1,4 +1,4 @@
-# Custom benchmarks
+# External benchmarks
 
 NeMo-Skills supports defining benchmarks in external repositories. This lets you
 keep proprietary data private, iterate on benchmarks independently of NeMo-Skills

--- a/docs/evaluation/index.md
+++ b/docs/evaluation/index.md
@@ -259,4 +259,4 @@ To create a new benchmark follow this process:
 5. Create a new [metrics class](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/evaluation/metrics/map_metrics.py) ( if cannot re-use existing one).
 
 You can also define benchmarks in a **separate git repository** without modifying NeMo-Skills.
-See [Custom benchmarks](./custom-benchmarks.md) for a full walkthrough.
+See [External benchmarks](./external-benchmarks.md) for a full walkthrough.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ nav:
     - evaluation/vlm.md
     - evaluation/other-benchmarks.md
     - evaluation/robustness.md
-    - Custom benchmarks: evaluation/custom-benchmarks.md
+    - External benchmarks: evaluation/external-benchmarks.md
   - Agentic Inference:
     - agentic_inference/parallel_thinking.md
     - agentic_inference/tool_calling.md


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation headings, navigation entries, and cross-references to reflect the new "External benchmarks" naming convention throughout the evaluation documentation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->