### PR TITLE
SALM Backend Support and HF ASR Leaderboard Evaluation Recipe

### DIFF
--- a/nemo_skills/dataset/asr-leaderboard/prepare.py
+++ b/nemo_skills/dataset/asr-leaderboard/prepare.py
@@ -16,121 +16,122 @@
 
 Downloads and formats datasets from the official HF Open ASR Leaderboard ESB
 test-only sorted dataset (hf-audio/esb-datasets-test-only-sorted). This is the
-same data source used by the official leaderboard and the offline NeMo eval
-pipeline, ensuring apples-to-apples WER comparison.
+same data source used by the official leaderboard, ensuring apples-to-apples
+WER comparison.
 
 Audio paths in JSONL: /dataset/asr-leaderboard/data/{dataset}/{sample_id}.flac
 
 Usage:
     ns prepare_data asr-leaderboard
     ns prepare_data asr-leaderboard --datasets librispeech_clean ami
-    ns prepare_data asr-leaderboard --datasets earnings22
-    ns prepare_data asr-leaderboard --no-audio  # skip saving audio files
+    ns prepare_data asr-leaderboard --no-audio
 """
 
 import argparse
 import json
 from pathlib import Path
 
+import numpy as np
 import soundfile as sf
-from datasets import load_dataset
+from datasets import Audio, load_dataset
 from tqdm import tqdm
 
+HF_REPO = "hf-audio/esb-datasets-test-only-sorted"
 SYSTEM_MESSAGE = "You are a helpful assistant. /no_think"
-MIN_AUDIO_DURATION = 0.1  # Skip audio shorter than this (causes mel spectrogram errors)
+AUDIO_SAMPLE_RATE = 16000
 
-# (hf_repo, config, split, text_field, id_field)
+# (config, split, text_field, id_field)
 DATASET_CONFIGS = {
-    "librispeech_clean": ("hf-audio/esb-datasets-test-only-sorted", "librispeech", "test.clean", "text", "id"),
-    "librispeech_other": ("hf-audio/esb-datasets-test-only-sorted", "librispeech", "test.other", "text", "id"),
-    "voxpopuli": ("hf-audio/esb-datasets-test-only-sorted", "voxpopuli", "test", "text", "id"),
-    "tedlium": ("hf-audio/esb-datasets-test-only-sorted", "tedlium", "test", "text", "id"),
-    "gigaspeech": ("hf-audio/esb-datasets-test-only-sorted", "gigaspeech", "test", "text", "id"),
-    "spgispeech": ("hf-audio/esb-datasets-test-only-sorted", "spgispeech", "test", "text", "id"),
-    "earnings22": ("hf-audio/esb-datasets-test-only-sorted", "earnings22", "test", "text", "id"),
-    "ami": ("hf-audio/esb-datasets-test-only-sorted", "ami", "test", "text", "id"),
+    "librispeech_clean": ("librispeech", "test.clean", "text", "id"),
+    "librispeech_other": ("librispeech", "test.other", "text", "id"),
+    "voxpopuli": ("voxpopuli", "test", "text", "id"),
+    "tedlium": ("tedlium", "test", "text", "id"),
+    "gigaspeech": ("gigaspeech", "test", "text", "id"),
+    "spgispeech": ("spgispeech", "test", "text", "id"),
+    "earnings22": ("earnings22", "test", "text", "id"),
+    "ami": ("ami", "test", "text", "id"),
 }
 
 
-def save_audio_and_format_entry(
-    entry, dataset_name, audio_dir, sample_idx, text_field="text", id_field="id", with_audio=True
-):
-    """Format a dataset entry and optionally save audio file."""
-    text = entry[text_field].strip()
+def extract_audio(audio_info):
+    """Extract audio array and sampling rate from a HF dataset audio entry.
 
-    system_message = {"role": "system", "content": SYSTEM_MESSAGE}
-    user_message = {"role": "user", "content": "Transcribe the following audio."}
+    Handles both the legacy dict format ({"array": ..., "sampling_rate": ...})
+    and the newer AudioDecoder object from torchcodec-based datasets library.
+    """
+    if audio_info is None:
+        return None, None
+    try:
+        audio_array = np.array(audio_info["array"])
+        sampling_rate = int(audio_info["sampling_rate"])
+        return audio_array, sampling_rate
+    except (KeyError, TypeError, IndexError):
+        return None, None
+
+
+def format_entry(entry, dataset_name, audio_dir, text_field, id_field, with_audio):
+    """Format a dataset entry into JSONL and optionally save the audio file."""
+    text = entry[text_field].strip()
+    if not text:
+        return None
 
     sample_id = str(entry[id_field]).replace("/", "_")
     audio_filename = f"{Path(sample_id).stem}.flac"
 
-    audio_info = entry.get("audio", {})
+    audio_array, sampling_rate = extract_audio(entry.get("audio"))
     duration = None
-    if isinstance(audio_info, dict) and "array" in audio_info and "sampling_rate" in audio_info:
-        audio_array = audio_info["array"]
-        sampling_rate = audio_info["sampling_rate"]
+
+    if audio_array is not None and sampling_rate is not None:
         duration = len(audio_array) / sampling_rate
-
-        if duration < MIN_AUDIO_DURATION:
-            return None
-
         if with_audio:
             sf.write(str(audio_dir / audio_filename), audio_array, sampling_rate)
 
+    user_message = {"role": "user", "content": "Transcribe the following audio."}
     audio_meta = {"path": f"/dataset/asr-leaderboard/data/{dataset_name}/{audio_filename}"}
     if duration is not None:
         audio_meta["duration"] = float(duration)
     user_message["audio"] = audio_meta
 
-    formatted_entry = {
+    formatted = {
         "task_type": "ASR",
         "expected_answer": text,
-        "messages": [system_message, user_message],
+        "messages": [{"role": "system", "content": SYSTEM_MESSAGE}, user_message],
         "subset_for_metrics": dataset_name,
+        "id": entry[id_field],
     }
-
-    formatted_entry["id"] = entry[id_field]
     if "speaker_id" in entry:
-        formatted_entry["speaker_id"] = entry["speaker_id"]
+        formatted["speaker_id"] = entry["speaker_id"]
 
-    return formatted_entry
+    return formatted
 
 
 def prepare_dataset(dataset_name, output_dir, with_audio=True):
-    """Prepare a single ASR dataset."""
+    """Download, decode, and write a single ASR dataset to JSONL + audio files."""
     if dataset_name not in DATASET_CONFIGS:
         raise ValueError(f"Unknown dataset: {dataset_name}. Available: {list(DATASET_CONFIGS.keys())}")
 
-    hf_repo, hf_config, hf_split, text_field, id_field = DATASET_CONFIGS[dataset_name]
+    hf_config, hf_split, text_field, id_field = DATASET_CONFIGS[dataset_name]
 
-    print(f"Loading {dataset_name} from {hf_repo} (config={hf_config}, split={hf_split})...")
-    dataset = load_dataset(hf_repo, hf_config, split=hf_split, trust_remote_code=True)
+    print(f"Loading {dataset_name} from {HF_REPO} (config={hf_config}, split={hf_split})...")
+    dataset = load_dataset(HF_REPO, hf_config, split=hf_split)
+    if with_audio and "audio" in dataset.column_names:
+        dataset = dataset.cast_column("audio", Audio(sampling_rate=AUDIO_SAMPLE_RATE))
 
     output_file = output_dir / f"{dataset_name}.jsonl"
     audio_dir = output_dir / "data" / dataset_name
 
     if with_audio:
         audio_dir.mkdir(parents=True, exist_ok=True)
-        print(f"Saving audio files to {audio_dir}")
 
     print(f"Processing {len(dataset)} samples from {dataset_name}...")
-
     count = 0
-    skipped = 0
     with open(output_file, "w", encoding="utf-8") as fout:
-        for idx, entry in enumerate(tqdm(dataset, desc=dataset_name)):
-            formatted = save_audio_and_format_entry(
-                entry, dataset_name, audio_dir, idx, text_field=text_field, id_field=id_field, with_audio=with_audio
-            )
+        for entry in tqdm(dataset, desc=dataset_name):
+            formatted = format_entry(entry, dataset_name, audio_dir, text_field, id_field, with_audio)
             if formatted is None:
-                skipped += 1
                 continue
-            if formatted["expected_answer"]:
-                fout.write(json.dumps(formatted) + "\n")
-                count += 1
-
-    if skipped > 0:
-        print(f"Skipped {skipped} samples with audio < {MIN_AUDIO_DURATION}s")
+            fout.write(json.dumps(formatted) + "\n")
+            count += 1
 
     print(f"Saved {count} samples to {output_file}")
     return count
@@ -157,11 +158,8 @@ def main():
     output_dir.mkdir(parents=True, exist_ok=True)
 
     with_audio = not args.no_audio
-
-    if args.no_audio:
+    if not with_audio:
         print("Running without saving audio files.")
-    else:
-        print("Running with audio. Saving to data/{dataset}/")
 
     datasets_to_prepare = list(DATASET_CONFIGS.keys()) if "all" in args.datasets else args.datasets
 
@@ -169,13 +167,10 @@ def main():
     for dataset_name in datasets_to_prepare:
         total_samples += prepare_dataset(dataset_name, output_dir, with_audio=with_audio)
 
-    # Combine all dataset JSONLs into test.jsonl
     combined_file = output_dir / "test.jsonl"
     print(f"\nCreating combined file: {combined_file}")
 
-    all_jsonl_files = sorted(output_dir.glob("*.jsonl"))
-    dataset_files = [f for f in all_jsonl_files if f.name != "test.jsonl"]
-
+    dataset_files = sorted(f for f in output_dir.glob("*.jsonl") if f.name != "test.jsonl")
     combined_count = 0
     with open(combined_file, "w", encoding="utf-8") as fout:
         for dataset_file in dataset_files:

--- a/recipes/asr/run_hf_leaderboard.py
+++ b/recipes/asr/run_hf_leaderboard.py
@@ -38,7 +38,8 @@ Example usage::
 
 import argparse
 
-from nemo_skills.pipeline.cli import eval, wrap_arguments
+from nemo_skills.pipeline.cli import eval as run_eval
+from nemo_skills.pipeline.cli import wrap_arguments
 
 DEFAULT_SERVER_CONTAINER = "nvcr.io/nvidia/nemo:25.11"
 DEFAULT_INSTALLATION_COMMAND = "pip install -r requirements/audio.txt"
@@ -69,7 +70,7 @@ def main():
 
     args = parser.parse_args()
 
-    eval(
+    run_eval(
         ctx=wrap_arguments(
             "++prompt_format=openai "
             "++prompt_config=null "

--- a/recipes/asr/run_hf_leaderboard.py
+++ b/recipes/asr/run_hf_leaderboard.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HuggingFace Open ASR Leaderboard evaluation for NeMo ASR models.
+
+Runs the HF Open ASR Leaderboard benchmark (8 datasets, WER metric) on
+NeMo ASR models using the unified server with the nemo_asr or salm backend.
+
+Uses 1 GPU for the server (NeMo ASR model). The evaluation client runs
+on CPU alongside it.
+
+Example usage::
+
+    # Evaluate parakeet-v3 (traditional ASR model -> nemo_asr backend)
+    python recipes/asr/run_hf_leaderboard.py \\
+        --model nvidia/parakeet-tdt-0.6b-v3 \\
+        --cluster oci_iad \\
+        --output_dir /lustre/.../parakeet-v3-asr-leaderboard
+
+    # Evaluate canary-qwen-2.5b (SALM model -> salm backend)
+    python recipes/asr/run_hf_leaderboard.py \\
+        --model nvidia/canary-qwen-2.5b \\
+        --backend salm \\
+        --cluster oci_iad \\
+        --output_dir /lustre/.../canary-qwen-asr-leaderboard
+"""
+
+import argparse
+
+from nemo_skills.pipeline.cli import eval, wrap_arguments
+
+DEFAULT_SERVER_CONTAINER = "nvcr.io/nvidia/nemo:25.11"
+DEFAULT_INSTALLATION_COMMAND = "pip install -r requirements/audio.txt"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run HF Open ASR Leaderboard evaluation on a NeMo ASR model")
+    parser.add_argument("--model", required=True, help="NeMo ASR model name or path (e.g. nvidia/canary-qwen-2.5b)")
+    parser.add_argument("--cluster", required=True, help="Cluster name (e.g. oci_iad)")
+    parser.add_argument("--output_dir", required=True, help="Directory for evaluation outputs")
+    parser.add_argument("--data_dir", default="/dataset", help="Root data directory (must contain asr-leaderboard/)")
+    parser.add_argument("--server_container", default=DEFAULT_SERVER_CONTAINER, help="NeMo container image")
+    parser.add_argument("--server_gpus", type=int, default=1, help="Number of GPUs for the ASR server")
+    parser.add_argument(
+        "--backend",
+        default="nemo_asr",
+        choices=["nemo_asr", "salm"],
+        help="Server backend: nemo_asr for traditional ASR models (parakeet), salm for SALM models (canary-qwen)",
+    )
+    parser.add_argument("--batch_size", type=int, default=16, help="NeMo ASR transcription batch size")
+    parser.add_argument(
+        "--num_chunks", type=int, default=None, help="Split dataset into N chunks for data parallelism"
+    )
+    parser.add_argument("--expname", default="asr-leaderboard", help="Experiment name")
+    parser.add_argument("--partition", default=None, help="Slurm partition (e.g. interactive)")
+    parser.add_argument("--config_dir", default=None, help="Directory containing cluster config YAMLs")
+    parser.add_argument("--split", default=None, help="Dataset split to evaluate (default: test = all datasets)")
+
+    args = parser.parse_args()
+
+    eval(
+        ctx=wrap_arguments(
+            "++prompt_format=openai "
+            "++prompt_config=null "
+            "++enable_audio=true "
+            "++server.server_type=vllm_multimodal "
+            "++max_concurrent_requests=16 "
+            "++inference.tokens_to_generate=256"
+        ),
+        cluster=args.cluster,
+        output_dir=args.output_dir,
+        benchmarks="asr-leaderboard",
+        model=args.model,
+        server_type="generic",
+        server_gpus=args.server_gpus,
+        server_entrypoint=(
+            "MKL_SERVICE_FORCE_INTEL=1 MKL_THREADING_LAYER=GNU "
+            "MKL_NUM_THREADS=1 VML_NUM_THREADS=1 "
+            "python -m nemo_skills.inference.server.serve_unified"
+        ),
+        server_args=f"--backend {args.backend} --batch_size {args.batch_size}",
+        server_container=args.server_container,
+        num_chunks=args.num_chunks,
+        data_dir=args.data_dir,
+        config_dir=args.config_dir,
+        partition=args.partition,
+        split=args.split,
+        installation_command=DEFAULT_INSTALLATION_COMMAND,
+        expname=args.expname,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/multimodal/server/backends/__init__.py
+++ b/recipes/multimodal/server/backends/__init__.py
@@ -18,6 +18,7 @@ Backend implementations for the Unified NeMo Inference Server.
 Available backends:
 - magpie_tts: MagpieTTS text-to-speech (audio output from text input)
 - nemo_asr: NeMo ASR speech-to-text (text output from audio input)
+- salm: SALM speech-to-text using chat-style generate API (e.g. canary-qwen-2.5b)
 
 Backends are lazily loaded to avoid importing heavy dependencies upfront.
 """
@@ -40,6 +41,7 @@ __all__ = [
 BACKEND_REGISTRY = {
     "magpie_tts": ("magpie_tts_backend", "MagpieTTSBackend"),
     "nemo_asr": ("nemo_asr_backend", "NeMoASRBackend"),
+    "salm": ("salm_backend", "SALMBackend"),
 }
 
 

--- a/recipes/multimodal/server/backends/nemo_asr_backend.py
+++ b/recipes/multimodal/server/backends/nemo_asr_backend.py
@@ -217,7 +217,11 @@ class NeMoASRBackend(InferenceBackend):
             return hyp, []
 
         if isinstance(hyp, dict):
-            text = hyp.get("text") or hyp.get("pred_text") or hyp.get("transcript") or ""
+            text = hyp.get("text")
+            if text is None:
+                text = hyp.get("pred_text")
+            if text is None:
+                text = hyp.get("transcript", "")
             words = hyp.get("words")
             if words is None:
                 ts = hyp.get("timestamp")
@@ -229,7 +233,11 @@ class NeMoASRBackend(InferenceBackend):
                     words = ts["word"]
             return text, self._normalize_words(words)
 
-        text = getattr(hyp, "text", None) or getattr(hyp, "pred_text", None) or str(hyp)
+        text = getattr(hyp, "text", None)
+        if text is None:
+            text = getattr(hyp, "pred_text", None)
+        if text is None:
+            text = ""
         words = getattr(hyp, "words", None)
         if words is None:
             ts = getattr(hyp, "timestamp", None)

--- a/recipes/multimodal/server/backends/nemo_asr_backend.py
+++ b/recipes/multimodal/server/backends/nemo_asr_backend.py
@@ -221,7 +221,9 @@ class NeMoASRBackend(InferenceBackend):
             if text is None:
                 text = hyp.get("pred_text")
             if text is None:
-                text = hyp.get("transcript", "")
+                text = hyp.get("transcript")
+            if text is None:
+                text = ""
             words = hyp.get("words")
             if words is None:
                 ts = hyp.get("timestamp")

--- a/recipes/multimodal/server/backends/salm_backend.py
+++ b/recipes/multimodal/server/backends/salm_backend.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+"""SALM (Speech-Augmented Language Model) backend for unified_server.
+
+This backend performs speech-to-text using NeMo SALM models (e.g. canary-qwen-2.5b).
+Unlike the nemo_asr backend which uses ASRModel.transcribe(), SALM models use a
+chat-style generate() API with audio file references embedded in prompts.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+import time
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from .base import BackendConfig, GenerationRequest, GenerationResult, InferenceBackend, Modality
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ASR_PROMPT = "Transcribe the following:"
+
+
+@dataclass
+class SALMConfig(BackendConfig):
+    """Configuration for SALM backend."""
+
+    model_name: Optional[str] = None
+    batch_size: int = 16
+    warmup: bool = True
+    user_prompt: str = DEFAULT_ASR_PROMPT
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "SALMConfig":
+        if d.get("model_name") and not d.get("model_path"):
+            d = {**d, "model_path": d["model_name"]}
+        known = {
+            "model_path",
+            "model_name",
+            "device",
+            "dtype",
+            "max_new_tokens",
+            "temperature",
+            "top_p",
+            "top_k",
+            "batch_size",
+            "warmup",
+            "user_prompt",
+        }
+        return cls(
+            **{k: v for k, v in d.items() if k in known},
+            extra_config={k: v for k, v in d.items() if k not in known},
+        )
+
+
+class SALMBackend(InferenceBackend):
+    """Unified-server backend for SALM models (e.g. canary-qwen-2.5b)."""
+
+    @classmethod
+    def get_config_class(cls) -> type:
+        return SALMConfig
+
+    @property
+    def name(self) -> str:
+        return "salm"
+
+    @property
+    def supported_modalities(self) -> Set[Modality]:
+        return {Modality.AUDIO_IN, Modality.TEXT}
+
+    def __init__(self, config: BackendConfig):
+        self.salm_config = config if isinstance(config, SALMConfig) else SALMConfig.from_dict(config.extra_config)
+        super().__init__(self.salm_config)
+        self._model_name = self.salm_config.model_path or self.salm_config.model_name
+        self._model = None
+
+    def load_model(self) -> None:
+        if not self._model_name:
+            raise ValueError("SALM backend requires model_path (or model_name).")
+
+        from nemo.collections.speechlm2.models import SALM
+
+        model_ref = self._model_name
+
+        if Path(model_ref).exists():
+            self._model = SALM.restore_from(model_ref)
+        else:
+            self._model = SALM.from_pretrained(model_ref)
+
+        self._model.to(self.config.device)
+        self._model.eval()
+
+        if self.salm_config.warmup:
+            self._run_warmup()
+
+        self._is_loaded = True
+        logger.info("Loaded SALM model=%s on device=%s", self._model_name, self.config.device)
+
+    def _run_warmup(self) -> None:
+        """Run one short warmup call so runtime init happens before traffic."""
+        fd, path = tempfile.mkstemp(suffix=".wav", prefix="salm_warmup_")
+        os.close(fd)
+        try:
+            with wave.open(path, "wb") as wavf:
+                wavf.setnchannels(1)
+                wavf.setsampwidth(2)
+                wavf.setframerate(16000)
+                wavf.writeframes(b"\x00\x00" * 16000)  # 1 sec silence
+            prompts = [
+                [
+                    {
+                        "role": "user",
+                        "content": f"{self.salm_config.user_prompt} {self._model.audio_locator_tag}",
+                        "audio": [path],
+                    }
+                ]
+            ]
+            output_ids = self._model.generate(prompts=prompts, max_new_tokens=8)
+            logger.info("SALM warmup completed, output length=%d tokens", len(output_ids[0]))
+        except Exception as e:
+            logger.warning("SALM warmup skipped due to error: %s", e)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def _get_request_audio_bytes(self, request: GenerationRequest) -> bytes:
+        if request.audio_bytes:
+            return request.audio_bytes
+        if request.audio_bytes_list:
+            if len(request.audio_bytes_list) > 1:
+                raise ValueError("SALM backend currently supports one audio input per request.")
+            return request.audio_bytes_list[0]
+        raise ValueError("Request must contain audio_bytes/audio_bytes_list")
+
+    def validate_request(self, request: GenerationRequest) -> Optional[str]:
+        has_audio = request.audio_bytes is not None or (
+            request.audio_bytes_list is not None and len(request.audio_bytes_list) > 0
+        )
+        if not has_audio:
+            return "SALM backend requires audio input"
+        return None
+
+    def generate(self, requests: List[GenerationRequest]) -> List[GenerationResult]:
+        if not self._is_loaded:
+            return [GenerationResult(error="Model not loaded", request_id=r.request_id) for r in requests]
+        if not requests:
+            return []
+
+        tmp_dir = Path(tempfile.mkdtemp(prefix="salm_batch_"))
+        start = time.time()
+        temp_paths: List[str] = []
+        valid_indices: List[int] = []
+        results: List[Optional[GenerationResult]] = [None] * len(requests)
+
+        try:
+            for idx, req in enumerate(requests):
+                try:
+                    audio_bytes = self._get_request_audio_bytes(req)
+                    p = tmp_dir / f"req_{idx:04d}.wav"
+                    p.write_bytes(audio_bytes)
+                    temp_paths.append(str(p))
+                    valid_indices.append(idx)
+                except Exception as e:
+                    results[idx] = GenerationResult(error=str(e), request_id=req.request_id)
+
+            if temp_paths:
+                first_extra = requests[valid_indices[0]].extra_params or {}
+                user_prompt = first_extra.get("user_prompt", self.salm_config.user_prompt)
+                max_new_tokens = int(first_extra.get("max_new_tokens", self.config.max_new_tokens))
+                audio_tag = self._model.audio_locator_tag
+
+                prompts = []
+                for path in temp_paths:
+                    prompts.append(
+                        [
+                            {
+                                "role": "user",
+                                "content": f"{user_prompt} {audio_tag}",
+                                "audio": [path],
+                            }
+                        ]
+                    )
+
+                output_ids = self._model.generate(prompts=prompts, max_new_tokens=max_new_tokens)
+
+                if len(output_ids) != len(temp_paths):
+                    raise RuntimeError(
+                        f"SALM output size mismatch: got {len(output_ids)} for {len(temp_paths)} inputs."
+                    )
+
+                per_req_ms = (time.time() - start) * 1000.0 / max(len(temp_paths), 1)
+                for out_idx, ids in enumerate(output_ids):
+                    req_idx = valid_indices[out_idx]
+                    req = requests[req_idx]
+                    text = self._model.tokenizer.ids_to_text(ids.cpu())
+                    results[req_idx] = GenerationResult(
+                        text=text,
+                        request_id=req.request_id,
+                        num_tokens_generated=len(ids),
+                        generation_time_ms=per_req_ms,
+                        debug_info={
+                            "backend": "salm",
+                            "model": self._model_name,
+                            "user_prompt": user_prompt,
+                        },
+                    )
+
+            return [r if r is not None else GenerationResult(error="Unknown SALM backend error") for r in results]
+        except Exception as e:
+            return [GenerationResult(error=str(e), request_id=r.request_id) for r in requests]
+        finally:
+            for p in temp_paths:
+                Path(p).unlink(missing_ok=True)
+            try:
+                tmp_dir.rmdir()
+            except OSError:
+                pass

--- a/recipes/multimodal/server/backends/salm_backend.py
+++ b/recipes/multimodal/server/backends/salm_backend.py
@@ -33,7 +33,6 @@ class SALMConfig(BackendConfig):
     """Configuration for SALM backend."""
 
     model_name: Optional[str] = None
-    batch_size: int = 16
     warmup: bool = True
     user_prompt: str = DEFAULT_ASR_PROMPT
 
@@ -50,7 +49,6 @@ class SALMConfig(BackendConfig):
             "temperature",
             "top_p",
             "top_k",
-            "batch_size",
             "warmup",
             "user_prompt",
         }
@@ -144,6 +142,8 @@ class SALMBackend(InferenceBackend):
         )
         if not has_audio:
             return "SALM backend requires audio input"
+        if request.audio_bytes_list is not None and len(request.audio_bytes_list) > 1:
+            return "SALM backend currently supports one audio input per request"
         return None
 
     def generate(self, requests: List[GenerationRequest]) -> List[GenerationResult]:
@@ -170,9 +170,10 @@ class SALMBackend(InferenceBackend):
                     results[idx] = GenerationResult(error=str(e), request_id=req.request_id)
 
             if temp_paths:
-                first_extra = requests[valid_indices[0]].extra_params or {}
+                first_req = requests[valid_indices[0]]
+                first_extra = first_req.extra_params or {}
                 user_prompt = first_extra.get("user_prompt", self.salm_config.user_prompt)
-                max_new_tokens = int(first_extra.get("max_new_tokens", self.config.max_new_tokens))
+                max_new_tokens = first_req.max_new_tokens or self.config.max_new_tokens
                 audio_tag = self._model.audio_locator_tag
 
                 prompts = []

--- a/recipes/multimodal/server/backends/salm_backend.py
+++ b/recipes/multimodal/server/backends/salm_backend.py
@@ -178,17 +178,15 @@ class SALMBackend(InferenceBackend):
                     req = requests[valid_indices[out_idx]]
                     user_prompt = req.user_prompt or self.salm_config.user_prompt
 
-                    conversation = []
-                    if req.system_prompt:
-                        conversation.append({"role": "system", "content": req.system_prompt})
-                    conversation.append(
-                        {
-                            "role": "user",
-                            "content": f"{user_prompt} {audio_tag}",
-                            "audio": [path],
-                        }
+                    prompts.append(
+                        [
+                            {
+                                "role": "user",
+                                "content": f"{user_prompt} {audio_tag}",
+                                "audio": [path],
+                            }
+                        ]
                     )
-                    prompts.append(conversation)
 
                     req_tokens = req.max_new_tokens or self.config.max_new_tokens
                     if req_tokens and (batch_max_tokens is None or req_tokens > batch_max_tokens):
@@ -226,5 +224,5 @@ class SALMBackend(InferenceBackend):
                 Path(p).unlink(missing_ok=True)
             try:
                 tmp_dir.rmdir()
-            except OSError:
-                pass
+            except OSError as e:
+                logger.warning("Could not remove temp dir %s: %s", tmp_dir, e)

--- a/recipes/multimodal/server/backends/salm_backend.py
+++ b/recipes/multimodal/server/backends/salm_backend.py
@@ -170,25 +170,31 @@ class SALMBackend(InferenceBackend):
                     results[idx] = GenerationResult(error=str(e), request_id=req.request_id)
 
             if temp_paths:
-                first_req = requests[valid_indices[0]]
-                first_extra = first_req.extra_params or {}
-                user_prompt = first_extra.get("user_prompt", self.salm_config.user_prompt)
-                max_new_tokens = first_req.max_new_tokens or self.config.max_new_tokens
                 audio_tag = self._model.audio_locator_tag
-
                 prompts = []
-                for path in temp_paths:
-                    prompts.append(
-                        [
-                            {
-                                "role": "user",
-                                "content": f"{user_prompt} {audio_tag}",
-                                "audio": [path],
-                            }
-                        ]
-                    )
+                batch_max_tokens = self.config.max_new_tokens
 
-                output_ids = self._model.generate(prompts=prompts, max_new_tokens=max_new_tokens)
+                for out_idx, path in enumerate(temp_paths):
+                    req = requests[valid_indices[out_idx]]
+                    user_prompt = req.user_prompt or self.salm_config.user_prompt
+
+                    conversation = []
+                    if req.system_prompt:
+                        conversation.append({"role": "system", "content": req.system_prompt})
+                    conversation.append(
+                        {
+                            "role": "user",
+                            "content": f"{user_prompt} {audio_tag}",
+                            "audio": [path],
+                        }
+                    )
+                    prompts.append(conversation)
+
+                    req_tokens = req.max_new_tokens or self.config.max_new_tokens
+                    if req_tokens and (batch_max_tokens is None or req_tokens > batch_max_tokens):
+                        batch_max_tokens = req_tokens
+
+                output_ids = self._model.generate(prompts=prompts, max_new_tokens=batch_max_tokens)
 
                 if len(output_ids) != len(temp_paths):
                     raise RuntimeError(
@@ -208,7 +214,7 @@ class SALMBackend(InferenceBackend):
                         debug_info={
                             "backend": "salm",
                             "model": self._model_name,
-                            "user_prompt": user_prompt,
+                            "user_prompt": req.user_prompt or self.salm_config.user_prompt,
                         },
                     )
 

--- a/tests/slurm-tests/run_all.sh
+++ b/tests/slurm-tests/run_all.sh
@@ -24,4 +24,6 @@ python tests/slurm-tests/unified_asr/run_test.py --cluster $CLUSTER --workspace 
 python tests/slurm-tests/unified_tts/run_test.py --cluster $CLUSTER --workspace /workspace/nemo-skills-slurm-ci/$RUN_NAME/unified_tts --expname_prefix unified_tts_$RUN_NAME
 # sleep 10
 python tests/slurm-tests/wmt24pp_gym_topology/run_test.py --cluster $CLUSTER --workspace /workspace/nemo-skills-slurm-ci/$RUN_NAME/wmt24pp_gym_topology --expname_prefix wmt24pp_gym_topology_$RUN_NAME
+# sleep 10
+python tests/slurm-tests/unified_salm/run_test.py --cluster $CLUSTER --workspace /workspace/nemo-skills-slurm-ci/$RUN_NAME/unified_salm --expname_prefix unified_salm_$RUN_NAME
 # wait

--- a/tests/slurm-tests/unified_salm/check_results.py
+++ b/tests/slurm-tests/unified_salm/check_results.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))  # for utils.py
+from utils import assert_all, soft_assert  # noqa: E402
+
+_DIGIT_TO_WORD = {
+    "0": "zero",
+    "1": "one",
+    "2": "two",
+    "3": "three",
+    "4": "four",
+    "5": "five",
+    "6": "six",
+    "7": "seven",
+    "8": "eight",
+    "9": "nine",
+}
+
+
+def normalize_text(text: str) -> str:
+    text = text.lower().replace("-", " ")
+    text = re.sub(r"[^\w\s]", "", text)
+    tokens = []
+    for token in text.split():
+        if token in _DIGIT_TO_WORD:
+            tokens.append(_DIGIT_TO_WORD[token])
+        else:
+            tokens.append(token)
+    return " ".join(tokens)
+
+
+def load_references() -> dict[str, str]:
+    container_path = Path("/nemo_run/code/tests/slurm-tests/unified_salm/salm_openai.test")
+    local_path = Path(__file__).resolve().parent / "salm_openai.test"
+    reference_path = container_path if container_path.exists() else local_path
+    refs: dict[str, str] = {}
+    with reference_path.open("rt", encoding="utf-8") as fin:
+        for line in fin:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            refs[row["id"]] = row["_reference"]
+    return refs
+
+
+def load_outputs(output_dir: Path) -> list[dict]:
+    rows: list[dict] = []
+    files = sorted(output_dir.glob("output*.jsonl"))
+    soft_assert(len(files) > 0, f"No output JSONL files found in {output_dir}")
+    for fpath in files:
+        with fpath.open("rt", encoding="utf-8") as fin:
+            for line in fin:
+                if line.strip():
+                    rows.append(json.loads(line))
+    return rows
+
+
+def check_salm_results(workspace: str):
+    output_dir = Path(workspace) / "salm_outputs"
+    soft_assert(output_dir.exists(), f"Missing output directory: {output_dir}")
+    if not output_dir.exists():
+        return
+
+    references = load_references()
+    rows = load_outputs(output_dir)
+
+    soft_assert(len(rows) == len(references), f"Expected {len(references)} outputs, found {len(rows)}")
+
+    for row in rows:
+        sample_id = row.get("id")
+        soft_assert(sample_id in references, f"Unexpected sample id in output: {sample_id}")
+        if sample_id not in references:
+            continue
+
+        transcript = (row.get("generation") or "").strip()
+        soft_assert(bool(transcript), f"Empty transcript for sample {sample_id}")
+        if not transcript:
+            continue
+
+        ref_words = set(normalize_text(references[sample_id]).split())
+        hyp_words = set(normalize_text(transcript).split())
+        missing = sorted(ref_words - hyp_words)
+        soft_assert(not missing, f"Sample {sample_id}: missing reference words: {', '.join(missing)}")
+
+        debug_info = row.get("debug_info")
+        if isinstance(debug_info, dict):
+            soft_assert(
+                debug_info.get("backend") == "salm",
+                f"Sample {sample_id}: expected backend='salm' in debug_info, got {debug_info.get('backend')!r}",
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", required=True, help="Workspace directory containing results")
+    args = parser.parse_args()
+
+    check_salm_results(args.workspace)
+    assert_all()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/slurm-tests/unified_salm/run_test.py
+++ b/tests/slurm-tests/unified_salm/run_test.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from pathlib import Path
+
+from nemo_skills.pipeline.cli import generate, run_cmd, wrap_arguments
+from nemo_skills.pipeline.utils import create_remote_directory, get_cluster_config
+
+DEFAULT_SERVER_CONTAINER = "nvcr.io/nvidia/nemo:25.11"
+DEFAULT_MODEL = "nvidia/canary-qwen-2.5b"
+DEFAULT_INSTALLATION_COMMAND = (
+    "pip install func_timeout 'compute-eval @ git+https://github.com/NVIDIA/compute-eval.git@2d14770'"
+)
+
+
+def ensure_workspace_exists(workspace: str, cluster: str, config_dir: str | None = None) -> None:
+    cluster_config = get_cluster_config(cluster, config_dir=config_dir)
+    create_remote_directory(workspace, cluster_config)
+
+
+def run_unified_salm_test(
+    workspace: str,
+    cluster: str,
+    expname_prefix: str,
+    server_container: str,
+    model: str,
+    config_dir: str | None = None,
+    installation_command: str | None = DEFAULT_INSTALLATION_COMMAND,
+) -> str:
+    input_file = "/nemo_run/code/tests/slurm-tests/unified_salm/salm_openai.test"
+    output_dir = f"{workspace}/salm_outputs"
+    mount_paths = f"{Path(workspace).parent}:{Path(workspace).parent}"
+
+    generate(
+        ctx=wrap_arguments(
+            "++prompt_format=openai "
+            "++prompt_config=null "
+            "++enable_audio=true "
+            "++server.server_type=vllm_multimodal "
+            "++max_concurrent_requests=2 "
+            "++inference.temperature=0.0 "
+            "++inference.top_p=1.0 "
+            "++inference.top_k=-1 "
+            "++inference.tokens_to_generate=256"
+        ),
+        cluster=cluster,
+        generation_module="nemo_skills.inference.generate",
+        input_file=input_file,
+        output_dir=output_dir,
+        model=model,
+        server_type="generic",
+        num_chunks=1,
+        server_gpus=1,
+        server_nodes=1,
+        server_entrypoint="HF_HUB_OFFLINE=0 python -m nemo_skills.inference.server.serve_unified",
+        server_container=server_container,
+        server_args="--backend salm --batch_size 2",
+        mount_paths=mount_paths,
+        config_dir=config_dir,
+        installation_command=installation_command,
+        expname=expname_prefix,
+    )
+    return expname_prefix
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", required=True, help="Workspace directory containing all experiment data")
+    parser.add_argument("--cluster", required=True, help="Cluster name")
+    parser.add_argument("--expname_prefix", required=True, help="Experiment name prefix")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="SALM model path/name")
+    parser.add_argument("--server_container", default=DEFAULT_SERVER_CONTAINER, help="Container image for server job")
+    parser.add_argument("--config_dir", default=None, help="Optional directory containing cluster config YAMLs")
+    parser.add_argument(
+        "--installation_command",
+        default=DEFAULT_INSTALLATION_COMMAND,
+        help="Optional install command for generation container bootstrap",
+    )
+    parser.add_argument("--skip_check", action="store_true", help="Skip scheduling results checker")
+    args = parser.parse_args()
+
+    ensure_workspace_exists(args.workspace, args.cluster, config_dir=args.config_dir)
+
+    salm_expname = run_unified_salm_test(
+        workspace=args.workspace,
+        cluster=args.cluster,
+        expname_prefix=args.expname_prefix,
+        server_container=args.server_container,
+        model=args.model,
+        config_dir=args.config_dir,
+        installation_command=args.installation_command,
+    )
+
+    if args.skip_check:
+        return
+
+    checker_cmd = f"python tests/slurm-tests/unified_salm/check_results.py --workspace {args.workspace}"
+    run_cmd(
+        ctx=wrap_arguments(checker_cmd),
+        cluster=args.cluster,
+        expname=f"{args.expname_prefix}-check-results",
+        log_dir=f"{args.workspace}/check-results-logs",
+        mount_paths=f"{Path(args.workspace).parent}:{Path(args.workspace).parent}",
+        config_dir=args.config_dir,
+        run_after=salm_expname,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/slurm-tests/unified_salm/salm_openai.test
+++ b/tests/slurm-tests/unified_salm/salm_openai.test
@@ -1,0 +1,2 @@
+{"id": "sample_2", "_reference": "sample 2 this is a test of text to speech synthesis", "messages": [{"role": "user", "content": "Transcribe the following audio.", "audio": {"path": "/nemo_run/code/tests/slurm-tests/asr_nim/wavs/t2_16.wav"}}]}
+{"id": "sample_3", "_reference": "sample 3 hello how are you today", "messages": [{"role": "user", "content": "Transcribe the following audio.", "audio": {"path": "/nemo_run/code/tests/slurm-tests/asr_nim/wavs/t3_16.wav"}}]}


### PR DESCRIPTION
Summary
- Add a new salm backend for NeMo SALM models (e.g. `canary-qwen-2.5b`) that use `nemo.collections.speechlm2.models.SALM` and its chat-style generate() API. This complements the existing `nemo_asr` backend (for traditional ASR models) and the upcoming `vllm_nemo_speechlm` backend (for vLLM-served models).
- Fix a bug in `nemo_asr_backend` where empty transcriptions caused the raw Hypothesis object repr (~698 words of tensor data) to be returned instead of an empty string, inflating WER scores.
- Add `run_hf_leaderboard.py` recipe for running HF Open ASR Leaderboard evaluation on NeMo models with a single command.
- Improve the ASR leaderboard dataset preparation script for better robustness and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ASR leaderboard CLI to run evaluations with configurable model/backend.
  * New SALM inference backend and selectable backend registry entry.
  * End-to-end SALM slurm test harness and result-checking utilities.

* **Improvements**
  * Dataset handling accepts entries without audio; standardized 16 kHz decoding and tolerant failures.
  * Deterministic transcript selection and consolidated CLI messages.

* **Bug Fixes**
  * More reliable JSONL message formatting and per-request validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->