### PR TITLE
[Feat] Add sandbox_mounts cluster config field with r/w permission support

### DIFF
--- a/cluster_configs/example-local.yaml
+++ b/cluster_configs/example-local.yaml
@@ -37,6 +37,15 @@ containers:
 #   you can also override container libraries by directly mounting over them. E.g. to override NeMo-RL do
 #   - <...>/NeMo-RL:/opt/NeMo-RL
 
+# optional: sandbox-specific mounts (independent of mounts above).
+# when defined, the sandbox container receives exactly these mounts instead of either all cluster
+# mounts (keep_mounts_for_sandbox=True) or no mounts (keep_mounts_for_sandbox=False, the default).
+# supports src:dst or src:dst:mode format, where mode must be ro or rw (e.g. src:dst:ro for read-only).
+# if absent, the existing keep_mounts_for_sandbox behaviour is used as fallback.
+# sandbox_mounts:
+#   - /mnt/datadrive/sandbox-data:/sandbox-data
+#   - /mnt/datadrive/readonly-data:/readonly-data:ro
+
 # define any environment variables. Note that HF_HOME is required by default and needs to be a mounted path!
 # env_vars:
 #   - HF_HOME=/models/hf-cache

--- a/cluster_configs/example-slurm.yaml
+++ b/cluster_configs/example-slurm.yaml
@@ -46,6 +46,15 @@ job_name_prefix: "nemo_skills:"
 #   you can also override container libraries by directly mounting over them. E.g. to override NeMo-Aligner do
 #   - <path on slurm>/NeMo-Aligner:/opt/NeMo-Aligner
 
+# optional: sandbox-specific mounts (independent of mounts above).
+# when defined, the sandbox container receives exactly these mounts instead of either all cluster
+# mounts (keep_mounts_for_sandbox=True) or no mounts (keep_mounts_for_sandbox=False, the default).
+# supports src:dst or src:dst:mode format, where mode must be ro or rw (e.g. src:dst:ro for read-only).
+# if absent, the existing keep_mounts_for_sandbox behaviour is used as fallback.
+# sandbox_mounts:
+#   - <path on slurm>/sandbox-data:/sandbox-data
+#   - <path on slurm>/readonly-data:/readonly-data:ro
+
 # can use this section to set timeouts for different partitions
 # this will be used as a slurm parameter + to signal SFT job to finish
 # before the timeout to have time to save the last checkpoint

--- a/docs/basics/cluster-configs.md
+++ b/docs/basics/cluster-configs.md
@@ -53,6 +53,44 @@ export AZURE_OPENAI_API_KEY=...
 export NVIDIA_API_KEY=...
 ```
 
+## Mounts
+
+Cluster configs support two separate mount lists:
+
+```yaml
+mounts:
+  - <host path>:/container/path
+
+sandbox_mounts:
+  - <host path>:/container/path:ro
+  - <host scratch>:/scratch:rw
+```
+
+### `mounts`
+
+Use `mounts` for the main job containers: generation clients, eval jobs, servers, training jobs, and any other
+non-sandbox workload. This is the existing mount mechanism and nothing changes about its behavior.
+
+### `sandbox_mounts`
+
+Use `sandbox_mounts` only for the code-execution sandbox sidecar. It is processed in parallel to `mounts`, but applies
+only to sandbox containers.
+
+- If `sandbox_mounts` is present and non-empty, the sandbox uses exactly that list — this takes precedence over `--keep-mounts-for-sandbox`.
+- `sandbox_mounts` supports `src:dst:mode`, where `mode` can be `ro` or `rw`.
+- If `sandbox_mounts` is absent, behavior falls back to the existing `keep_mounts_for_sandbox` logic:
+  - default: sandbox gets no filesystem mounts
+  - with `--keep_mounts_for_sandbox`: sandbox inherits the main `mounts`
+
+This makes `sandbox_mounts` the safer option when a benchmark or workflow needs the sandbox to see only a small subset
+of files, instead of all cluster mounts.
+
+### When To Use Which
+
+- Use `mounts` when the main job needs access to models, datasets, caches, or patched libraries.
+- Use `sandbox_mounts` when only the sandbox needs filesystem access — it overrides `--keep_mounts_for_sandbox` when present.
+- Use `--keep_mounts_for_sandbox` only when `sandbox_mounts` is absent and you intentionally want the sandbox to inherit the full main mount set.
+
 
 ## Useful tips
 

--- a/nemo_skills/pipeline/utils/__init__.py
+++ b/nemo_skills/pipeline/utils/__init__.py
@@ -61,6 +61,7 @@ from nemo_skills.pipeline.utils.mounts import (
     create_remote_directory,
     get_mounted_path,
     get_mounts_from_config,
+    get_sandbox_mounts_from_config,
     get_unmounted_path,
     is_mounted_filepath,
     resolve_mount_paths,

--- a/nemo_skills/pipeline/utils/declarative.py
+++ b/nemo_skills/pipeline/utils/declarative.py
@@ -248,18 +248,22 @@ class Command:
         # Build execution config from Script fields.
         # Non-sandbox scripts dont define keep_mounts attribute and default to mounts=None (inherit cluster mounts).
         # For SandboxScript, keep_mounts=False (the safe default) is set unless overridden by --keep_mounts_for_sandbox
-        # sandbox mounts resolve in three ways (in priority order):
+        # sandbox mounts resolve in three ways (in priority order), but only for scripts that declare keep_mounts:
         #   sandbox_mounts in config (non-empty) -> use sandbox_mounts exactly  (takes precedence over keep_mounts)
         #   keep_mounts=True + no sandbox_mounts -> mounts=None  (inherit all cluster mounts, risky)
         #   keep_mounts=False + no sandbox_mounts -> mounts=[] (no filesystem access, safe default)
         keep_mounts = getattr(self.script, "keep_mounts", True)
-        sandbox_mounts = get_sandbox_mounts_from_config(cluster_config)
-        if sandbox_mounts:
-            exec_mounts = sandbox_mounts
-        elif keep_mounts:
+        if not hasattr(self.script, "keep_mounts"):
+            # Non-sandbox script: always inherit cluster mounts
             exec_mounts = None
         else:
-            exec_mounts = []
+            sandbox_mounts = get_sandbox_mounts_from_config(cluster_config)
+            if sandbox_mounts:
+                exec_mounts = sandbox_mounts
+            elif keep_mounts:
+                exec_mounts = None
+            else:
+                exec_mounts = []
         execution_config = {
             "log_prefix": getattr(self.script, "log_prefix", "main"),
             "environment": runtime_metadata.get("environment", {}),

--- a/nemo_skills/pipeline/utils/declarative.py
+++ b/nemo_skills/pipeline/utils/declarative.py
@@ -36,7 +36,7 @@ from nemo_skills.pipeline.utils.exp import (
     get_packaging_job_key,
     tunnel_hash,
 )
-from nemo_skills.pipeline.utils.mounts import is_mounted_filepath
+from nemo_skills.pipeline.utils.mounts import get_sandbox_mounts_from_config, is_mounted_filepath
 from nemo_skills.pipeline.utils.scripts import SandboxScript
 from nemo_skills.pipeline.utils.server import wrap_python_path
 from nemo_skills.utils import get_logger_name
@@ -246,15 +246,24 @@ class Command:
             self.script.set_inline(evaluated_command)
 
         # Build execution config from Script fields.
-        # For SandboxScript, keep_mounts=False (the safe default) maps to mounts=[]
-        # so the sandbox container has no access to cluster filesystems.
-        # keep_mounts=True maps to mounts=None, which inherits cluster mounts.
-        # Other scripts default to mounts=None (inherit cluster mounts).
+        # Non-sandbox scripts dont define keep_mounts attribute and default to mounts=None (inherit cluster mounts).
+        # For SandboxScript, keep_mounts=False (the safe default) is set unless overridden by --keep_mounts_for_sandbox
+        # sandbox mounts resolve in three ways (in priority order):
+        #   sandbox_mounts in config (non-empty) -> use sandbox_mounts exactly  (takes precedence over keep_mounts)
+        #   keep_mounts=True + no sandbox_mounts -> mounts=None  (inherit all cluster mounts, risky)
+        #   keep_mounts=False + no sandbox_mounts -> mounts=[] (no filesystem access, safe default)
         keep_mounts = getattr(self.script, "keep_mounts", True)
+        sandbox_mounts = get_sandbox_mounts_from_config(cluster_config)
+        if sandbox_mounts:
+            exec_mounts = sandbox_mounts
+        elif keep_mounts:
+            exec_mounts = None
+        else:
+            exec_mounts = []
         execution_config = {
             "log_prefix": getattr(self.script, "log_prefix", "main"),
             "environment": runtime_metadata.get("environment", {}),
-            "mounts": None if keep_mounts else [],
+            "mounts": exec_mounts,
             "container": self.container,
         }
 

--- a/nemo_skills/pipeline/utils/exp.py
+++ b/nemo_skills/pipeline/utils/exp.py
@@ -39,6 +39,7 @@ from nemo_skills.pipeline.utils.docker_images import resolve_container_image
 from nemo_skills.pipeline.utils.mounts import (
     check_remote_mount_directories,
     get_mounts_from_config,
+    get_sandbox_mounts_from_config,
     get_unmounted_path,
     is_mounted_filepath,
 )
@@ -654,6 +655,17 @@ def add_task(
                     override = override[11:]
                 sandbox_env_updates["PYTHONPATH"] = override + ":/app"
 
+        # Determine sandbox mounts (in priority order):
+        #   sandbox_mounts in config (non-empty) -> use those exactly  (takes precedence over keep_mounts_for_sandbox)
+        #   keep_mounts_for_sandbox=True + no sandbox_mounts -> None  (inherit all cluster mounts, risky)
+        #   keep_mounts_for_sandbox=False + no sandbox_mounts -> []  (no filesystem access, safe default)
+        _sandbox_mounts = get_sandbox_mounts_from_config(cluster_config)
+        if _sandbox_mounts:
+            sandbox_exec_mounts = _sandbox_mounts
+        elif keep_mounts_for_sandbox:
+            sandbox_exec_mounts = None
+        else:
+            sandbox_exec_mounts = []
         with temporary_env_update(cluster_config, sandbox_env_updates):
             commands.append(get_sandbox_command(cluster_config))
             sandbox_executor = get_executor(
@@ -664,7 +676,7 @@ def add_task(
                 gpus_per_node=0,
                 partition=partition,
                 account=account,
-                mounts=None if keep_mounts_for_sandbox else [],
+                mounts=sandbox_exec_mounts,
                 dependencies=dependencies,
                 job_name=task_name,
                 log_dir=log_dir,
@@ -780,6 +792,17 @@ def run_exp(exp, cluster_config, sequential=False, dry_run=False):
         mount_sources = [m.split(":")[0] for m in mounts]
 
         LOG.info("Checking mount paths: %s", mount_sources)
+        exit_if_failure = os.environ.get("NEMO_SKILLS_DISABLE_MOUNT_CHECK", "False").lower() not in (
+            "1",
+            "true",
+            "yes",
+        )
+        check_remote_mount_directories(mount_sources, cluster_config, exit_on_failure=exit_if_failure)
+
+    if "sandbox_mounts" in cluster_config:
+        sandbox_mounts = get_sandbox_mounts_from_config(cluster_config)
+        mount_sources = [m.split(":")[0] for m in sandbox_mounts]
+        LOG.info("Checking sandbox mount paths: %s", mount_sources)
         exit_if_failure = os.environ.get("NEMO_SKILLS_DISABLE_MOUNT_CHECK", "False").lower() not in (
             "1",
             "true",

--- a/nemo_skills/pipeline/utils/mounts.py
+++ b/nemo_skills/pipeline/utils/mounts.py
@@ -68,6 +68,86 @@ def _resolve_path_placeholders(path: str) -> str:
     return path
 
 
+def _resolve_mount_path_with_env_variables(mount: str, allow_rw_mode: bool = True) -> str:
+    """Resolve environment variable placeholders in a single mount string and return the resolved mount.
+
+    Handles two environment variable styles in the source and target fields:
+      - `${VAR}` style: allows partial path substitution, e.g. `/path/${USER}/subdir:/dst`
+      - `{VAR}` style: legacy full-field replacement, e.g. `{SRC_VAR}:{DST_VAR}`
+
+    Supports both two-field (`src:dst`) and, when `allow_rw_mode=True`, three-field
+    (`src:dst:mode`) mount formats. The mode field (e.g. `ro` for read-only) is
+    passed through unchanged.
+
+    Args:
+        mount (str): raw mount string from cluster config, e.g. `src:dst` or `src:dst:mode`
+        allow_rw_mode (bool): whether to allow an optional third mode field
+
+    Returns:
+        str: resolved mount string with environment variables substituted
+
+    Raises:
+        ValueError: if the mount string has an invalid number of fields, or if a required
+            environment variable is not set
+    """
+    if ":" not in mount:
+        raise ValueError(f"Invalid mount format: {mount}. The mount path must be separated by a colon.")
+
+    # First, expand any ${VAR} style environment variables in the entire mount string
+    # This allows partial path substitution like /path/${USER}/subdir
+    if "$" in mount:
+        mount = os.path.expandvars(mount)
+        if "${" in mount and "}" in mount:
+            raise ValueError(
+                f"Mount `{mount}` contains env variable placeholders, but the required env var is "
+                f"not provided in the environment to resolve."
+            )
+
+    parts = mount.split(":")
+    if len(parts) not in (2, 3):
+        raise ValueError(
+            f"Invalid mount format: {mount}. The mount path must be in the format `src:dst`"
+            f"{' or `src:dst:mode`' if allow_rw_mode else ''}."
+        )
+    if not allow_rw_mode and len(parts) == 3:
+        raise ValueError(f"Invalid mount format: {mount}. The mount path must be in the format `src:dst`.")
+
+    mount_source = parts[0]
+    mount_target = parts[1]
+    mount_mode = parts[2] if len(parts) > 2 else None
+    if mount_mode is not None and mount_mode not in {"ro", "rw"}:
+        raise ValueError(f"Invalid mount mode: {mount_mode} in `{mount}`. Supported mount modes are `ro` and `rw`.")
+
+    # Then handle {VAR} style for full path replacement (legacy support)
+    if mount_source[0] == "{" and mount_source[-1] == "}":
+        # Resolve the environment variable for the mount source
+        mount_source = mount_source[1:-1]
+
+        if mount_source not in os.environ:
+            raise ValueError(
+                f"Required environment variable {mount_source} not found in env variables passed in cluster configs."
+            )
+
+        mount_source = os.environ[mount_source]
+
+    if mount_target[0] == "{" and mount_target[-1] == "}":
+        # Resolve the environment variable for the mount target
+        mount_target = mount_target[1:-1]
+
+        if mount_target not in os.environ:
+            raise ValueError(
+                f"Required environment variable {mount_target} not found in env variables passed in cluster configs."
+            )
+
+        mount_target = os.environ[mount_target]
+
+    # reconstruct the mount string, preserving the optional mode field
+    resolved_mount = f"{mount_source}:{mount_target}"
+    if mount_mode is not None:
+        resolved_mount = f"{resolved_mount}:{mount_mode}"
+    return resolved_mount
+
+
 def check_mounts(
     cluster_config,
     log_dir: str,
@@ -413,43 +493,31 @@ def get_mounts_from_config(cluster_config: dict):
 
     # if there are env_mounts, we will add the mounts from the env_mounts
     for mount_id in range(len(mounts)):
-        mount = mounts[mount_id]
+        mounts[mount_id] = _resolve_mount_path_with_env_variables(mounts[mount_id], allow_rw_mode=False)
 
-        if ":" not in mount:
-            raise ValueError(f"Invalid mount format: {mount}. The mount path must be separated by a colon.")
+    return mounts
 
-        # First, expand any ${VAR} style environment variables in the entire mount string
-        # This allows partial path substitution like /path/${USER}/subdir
-        if "$" in mount:
-            mount = os.path.expandvars(mount)
 
-        mount_source, mount_target = mount.split(":")
+def get_sandbox_mounts_from_config(cluster_config: dict):
+    """
+    Like get_mounts_from_config but reads the `sandbox_mounts` key instead of `mounts`.
+    Returns None if `sandbox_mounts` is not defined (signals callers to fall back to the
+    keep_mounts_for_sandbox behaviour). Supports an optional mode field: `src:dst:mode`
+    (e.g. `src:dst:ro` for read-only) in addition to the standard `src:dst` format.
 
-        # Then handle {VAR} style for full path replacement (legacy support)
-        if mount_source[0] == "{" and mount_source[-1] == "}":
-            # Resolve the environment variable for the mount source
-            mount_source = mount_source[1:-1]
+    Args:
+        cluster_config (dict): cluster config dictionary
 
-            if mount_source not in os.environ:
-                raise ValueError(
-                    f"Required environment variable {mount_source} not found in env variables passed in cluster configs."
-                )
+    Returns:
+        list or None: resolved list of sandbox mounts, or None if `sandbox_mounts`
+            is not defined in the cluster config
+    """
+    if "sandbox_mounts" not in cluster_config:
+        return None
 
-            mount_source = os.environ[mount_source]
+    mounts = cluster_config.get("sandbox_mounts", [])
 
-        if mount_target[0] == "{" and mount_target[-1] == "}":
-            # Resolve the environment variable for the mount target
-            mount_target = mount_target[1:-1]
-
-            if mount_target not in os.environ:
-                raise ValueError(
-                    f"Required environment variable {mount_target} not found in env variables passed in cluster configs."
-                )
-
-            mount_target = os.environ[mount_target]
-
-        # add the mount to the list of mounts
-        resolved_mount = f"{mount_source}:{mount_target}"
-        mounts[mount_id] = resolved_mount
+    for mount_id in range(len(mounts)):
+        mounts[mount_id] = _resolve_mount_path_with_env_variables(mounts[mount_id], allow_rw_mode=True)
 
     return mounts

--- a/nemo_skills/pipeline/utils/mounts.py
+++ b/nemo_skills/pipeline/utils/mounts.py
@@ -115,6 +115,10 @@ def _resolve_mount_path_with_env_variables(mount: str, allow_rw_mode: bool = Tru
     mount_source = parts[0]
     mount_target = parts[1]
     mount_mode = parts[2] if len(parts) > 2 else None
+
+    if not mount_source or not mount_target:
+        raise ValueError(f"Invalid mount format: {mount}. Source and target paths must not be empty.")
+
     if mount_mode is not None and mount_mode not in {"ro", "rw"}:
         raise ValueError(f"Invalid mount mode: {mount_mode} in `{mount}`. Supported mount modes are `ro` and `rw`.")
 
@@ -515,7 +519,7 @@ def get_sandbox_mounts_from_config(cluster_config: dict):
     if "sandbox_mounts" not in cluster_config:
         return None
 
-    mounts = cluster_config.get("sandbox_mounts", [])
+    mounts = cluster_config["sandbox_mounts"]
 
     for mount_id in range(len(mounts)):
         mounts[mount_id] = _resolve_mount_path_with_env_variables(mounts[mount_id], allow_rw_mode=True)

--- a/tests/test_pipeline_utils.py
+++ b/tests/test_pipeline_utils.py
@@ -671,3 +671,36 @@ def test_add_task_no_sandbox_mounts_falls_back_to_empty(mock_port, mock_get_exec
 
     sandbox_mounts = mock_get_executor.call_args_list[-1].kwargs["mounts"]
     assert sandbox_mounts == []
+
+
+@patch("nemo_skills.pipeline.utils.exp.get_executor")
+@patch("nemo_skills.pipeline.utils.exp.get_free_port", return_value=12345)
+def test_add_task_sandbox_mounts_takes_precedence_over_keep_mounts_for_sandbox_true(mock_port, mock_get_executor):
+    """add_task: sandbox_mounts wins even when keep_mounts_for_sandbox=True."""
+    from types import SimpleNamespace
+
+    from nemo_skills.pipeline.utils.exp import add_task
+
+    mock_get_executor.return_value = MagicMock()
+    exp = SimpleNamespace(add=MagicMock(return_value="task_handle"))
+    cluster_config = {
+        "executor": "local",
+        "containers": {"sandbox": "sandbox:latest"},
+        "sandbox_mounts": ["/host/data:/sandbox/data:ro"],
+    }
+
+    add_task(
+        exp=exp,
+        cmd="echo hello",
+        task_name="test-task",
+        cluster_config=cluster_config,
+        container="main:latest",
+        log_dir="/tmp/logs",
+        with_sandbox=True,
+        keep_mounts_for_sandbox=True,
+        skip_hf_home_check=True,
+        reuse_code=False,
+    )
+
+    sandbox_mounts = mock_get_executor.call_args_list[-1].kwargs["mounts"]
+    assert sandbox_mounts == ["/host/data:/sandbox/data:ro"]

--- a/tests/test_pipeline_utils.py
+++ b/tests/test_pipeline_utils.py
@@ -404,3 +404,243 @@ def test_non_sandbox_command_mounts_unchanged():
     cmd = Command(script=script, container="nemo-skills:latest", name="client")
     _, exec_config = cmd.prepare_for_execution({"executor": "slurm"})
     assert exec_config["mounts"] is None, "Non-sandbox commands should inherit cluster mounts (mounts=None)"
+
+
+# --- sandbox_mounts resolution: full 2x2 matrix (keep_mounts_for_sandbox x sandbox_mounts) ---
+#
+# Priority order: sandbox_mounts (if non-empty) > keep_mounts_for_sandbox > safe default ([])
+#
+# sandbox_mounts present  (any keep_mounts)      -> sandbox_mounts exactly  (cases 2 & 4)
+# sandbox_mounts absent + keep_mounts=False      -> []     safe default     (case 1, existing test)
+# sandbox_mounts absent + keep_mounts=True       -> None   inherit cluster  (case 3, existing test)
+
+
+@patch("nemo_skills.pipeline.utils.scripts.sandbox_command", return_value=("echo sandbox", {}))
+@patch("nemo_skills.pipeline.utils.scripts.get_free_port", return_value=12345)
+def test_sandbox_mounts_used_when_keep_mounts_false(mock_port, mock_cmd):
+    """Case 2: keep_mounts_for_sandbox=False + sandbox_mounts defined -> sandbox gets exactly those mounts.
+
+    This is the primary new code path: sandbox_mounts in cluster config replaces the default
+    empty-list fallback, giving the sandbox access to specific paths without granting full
+    cluster filesystem access (which keep_mounts_for_sandbox=True would do).
+    """
+    from nemo_skills.pipeline.utils.scripts import SandboxScript
+
+    cluster_config = {
+        "executor": "slurm",
+        "containers": {"sandbox": "sandbox:latest"},
+        "sandbox_mounts": ["/data/sandbox:/sandbox-data", "/models/readonly:/models:ro"],
+    }
+    # keep_mounts_for_sandbox=False is the default; mirrors how generate.py constructs SandboxScript
+    sandbox = SandboxScript(cluster_config=cluster_config, keep_mounts=False)
+    cmd = Command(script=sandbox, container="sandbox:latest", name="sandbox")
+    _, exec_config = cmd.prepare_for_execution(cluster_config)
+
+    assert exec_config["mounts"] == ["/data/sandbox:/sandbox-data", "/models/readonly:/models:ro"], (
+        "sandbox_mounts must be passed through exactly when keep_mounts_for_sandbox=False"
+    )
+
+
+@patch("nemo_skills.pipeline.utils.scripts.sandbox_command", return_value=("echo sandbox", {}))
+@patch("nemo_skills.pipeline.utils.scripts.get_free_port", return_value=12345)
+def test_sandbox_mounts_takes_precedence_over_keep_mounts_true(mock_port, mock_cmd):
+    """Case 4: keep_mounts_for_sandbox=True + sandbox_mounts defined -> sandbox_mounts wins.
+
+    sandbox_mounts in config takes precedence over keep_mounts_for_sandbox=True, making the
+    risky 'inherit all cluster mounts' behaviour opt-out rather than opt-in when sandbox_mounts
+    is explicitly configured.
+    """
+    from nemo_skills.pipeline.utils.scripts import SandboxScript
+
+    cluster_config = {
+        "executor": "slurm",
+        "containers": {"sandbox": "sandbox:latest"},
+        "sandbox_mounts": ["/data/sandbox:/sandbox-data"],
+    }
+    sandbox = SandboxScript(cluster_config=cluster_config, keep_mounts=True)
+    cmd = Command(script=sandbox, container="sandbox:latest", name="sandbox")
+    _, exec_config = cmd.prepare_for_execution(cluster_config)
+
+    assert exec_config["mounts"] == ["/data/sandbox:/sandbox-data"], (
+        "sandbox_mounts must take precedence over keep_mounts_for_sandbox=True"
+    )
+
+
+@patch("nemo_skills.pipeline.utils.scripts.sandbox_command", return_value=("echo sandbox", {}))
+@patch("nemo_skills.pipeline.utils.scripts.get_free_port", return_value=12345)
+def test_sandbox_mounts_env_var_expansion(mock_port, mock_cmd, monkeypatch):
+    """sandbox_mounts entries with ${VAR} placeholders are resolved before being passed to executor."""
+    from nemo_skills.pipeline.utils.scripts import SandboxScript
+
+    monkeypatch.setenv("SANDBOX_DATA", "/cluster/storage/sandbox")
+    cluster_config = {
+        "executor": "slurm",
+        "containers": {"sandbox": "sandbox:latest"},
+        "sandbox_mounts": ["${SANDBOX_DATA}:/sandbox-data:ro"],
+    }
+    sandbox = SandboxScript(cluster_config=cluster_config, keep_mounts=False)
+    cmd = Command(script=sandbox, container="sandbox:latest", name="sandbox")
+    _, exec_config = cmd.prepare_for_execution(cluster_config)
+
+    assert exec_config["mounts"] == ["/cluster/storage/sandbox:/sandbox-data:ro"]
+
+
+@patch("nemo_skills.pipeline.utils.scripts.sandbox_command", return_value=("echo sandbox", {}))
+@patch("nemo_skills.pipeline.utils.scripts.get_free_port", return_value=12345)
+def test_sandbox_mounts_absent_falls_back_to_empty(mock_port, mock_cmd):
+    """sandbox_mounts absent with keep_mounts=False falls back to [] (no filesystem access).
+
+    Explicit counterpart to test_sandbox_mounts_used_when_keep_mounts_false: confirms the
+    fallback path is taken when sandbox_mounts is not in the cluster config at all, even when
+    a regular mounts section is present.
+    """
+    from nemo_skills.pipeline.utils.scripts import SandboxScript
+
+    cluster_config = {
+        "executor": "slurm",
+        "containers": {"sandbox": "sandbox:latest"},
+        "mounts": ["/models:/models"],  # regular mounts present but no sandbox_mounts
+    }
+    sandbox = SandboxScript(cluster_config=cluster_config, keep_mounts=False)
+    cmd = Command(script=sandbox, container="sandbox:latest", name="sandbox")
+    _, exec_config = cmd.prepare_for_execution(cluster_config)
+
+    assert exec_config["mounts"] == [], (
+        "without sandbox_mounts, keep_mounts=False must fall back to [] not the regular cluster mounts"
+    )
+
+
+# --- get_executor: mounts parameter overrides cluster config mounts ---
+
+
+@patch("nemo_skills.pipeline.utils.exp.get_packager")
+@patch("nemo_skills.pipeline.utils.exp.resolve_container_image", return_value="nemo:latest")
+def test_get_executor_mounts_none_falls_back_to_config(mock_resolve, mock_packager):
+    """get_executor with mounts=None should use cluster config mounts."""
+    from nemo_skills.pipeline.utils.exp import get_executor
+
+    cluster_config = {"executor": "local", "mounts": ["/host/models:/models"]}
+    executor = get_executor(cluster_config=cluster_config, container="nemo:latest", mounts=None)
+    assert executor.volumes == ["/host/models:/models"]
+
+
+@patch("nemo_skills.pipeline.utils.exp.get_packager")
+@patch("nemo_skills.pipeline.utils.exp.resolve_container_image", return_value="nemo:latest")
+def test_get_executor_empty_mounts_overrides_config(mock_resolve, mock_packager):
+    """get_executor with mounts=[] should use empty list, not cluster config mounts."""
+    from nemo_skills.pipeline.utils.exp import get_executor
+
+    cluster_config = {"executor": "local", "mounts": ["/host/models:/models"]}
+    executor = get_executor(cluster_config=cluster_config, container="nemo:latest", mounts=[])
+    assert executor.volumes == []
+
+
+@patch("nemo_skills.pipeline.utils.exp.get_packager")
+@patch("nemo_skills.pipeline.utils.exp.resolve_container_image", return_value="nemo:latest")
+def test_get_executor_explicit_mounts_overrides_config(mock_resolve, mock_packager):
+    """get_executor with explicit mounts should use those, not cluster config mounts."""
+    from nemo_skills.pipeline.utils.exp import get_executor
+
+    cluster_config = {"executor": "local", "mounts": ["/host/models:/models"]}
+    executor = get_executor(cluster_config=cluster_config, container="nemo:latest", mounts=["/sandbox/data:/data:ro"])
+    assert executor.volumes == ["/sandbox/data:/data:ro"]
+
+
+# --- add_task: sandbox mount resolution ---
+
+
+@patch("nemo_skills.pipeline.utils.exp.get_executor")
+@patch("nemo_skills.pipeline.utils.exp.get_free_port", return_value=12345)
+def test_add_task_sandbox_mounts_used_when_configured(mock_port, mock_get_executor):
+    """add_task: sandbox_mounts in config takes precedence over keep_mounts_for_sandbox."""
+    from types import SimpleNamespace
+
+    from nemo_skills.pipeline.utils.exp import add_task
+
+    mock_get_executor.return_value = MagicMock()
+    exp = SimpleNamespace(add=MagicMock(return_value="task_handle"))
+    cluster_config = {
+        "executor": "local",
+        "containers": {"sandbox": "sandbox:latest"},
+        "sandbox_mounts": ["/host/data:/sandbox/data:ro"],
+    }
+
+    add_task(
+        exp=exp,
+        cmd="echo hello",
+        task_name="test-task",
+        cluster_config=cluster_config,
+        container="main:latest",
+        log_dir="/tmp/logs",
+        with_sandbox=True,
+        keep_mounts_for_sandbox=False,
+        skip_hf_home_check=True,
+        reuse_code=False,
+    )
+
+    sandbox_mounts = mock_get_executor.call_args_list[-1].kwargs["mounts"]
+    assert sandbox_mounts == ["/host/data:/sandbox/data:ro"]
+
+
+@patch("nemo_skills.pipeline.utils.exp.get_executor")
+@patch("nemo_skills.pipeline.utils.exp.get_free_port", return_value=12345)
+def test_add_task_keep_mounts_for_sandbox_true_no_sandbox_mounts(mock_port, mock_get_executor):
+    """add_task: keep_mounts_for_sandbox=True with no sandbox_mounts → None (inherit cluster mounts)."""
+    from types import SimpleNamespace
+
+    from nemo_skills.pipeline.utils.exp import add_task
+
+    mock_get_executor.return_value = MagicMock()
+    exp = SimpleNamespace(add=MagicMock(return_value="task_handle"))
+    cluster_config = {
+        "executor": "local",
+        "containers": {"sandbox": "sandbox:latest"},
+    }
+
+    add_task(
+        exp=exp,
+        cmd="echo hello",
+        task_name="test-task",
+        cluster_config=cluster_config,
+        container="main:latest",
+        log_dir="/tmp/logs",
+        with_sandbox=True,
+        keep_mounts_for_sandbox=True,
+        skip_hf_home_check=True,
+        reuse_code=False,
+    )
+
+    sandbox_mounts = mock_get_executor.call_args_list[-1].kwargs["mounts"]
+    assert sandbox_mounts is None
+
+
+@patch("nemo_skills.pipeline.utils.exp.get_executor")
+@patch("nemo_skills.pipeline.utils.exp.get_free_port", return_value=12345)
+def test_add_task_no_sandbox_mounts_falls_back_to_empty(mock_port, mock_get_executor):
+    """add_task: no sandbox_mounts + keep_mounts_for_sandbox=False → [] (safe default)."""
+    from types import SimpleNamespace
+
+    from nemo_skills.pipeline.utils.exp import add_task
+
+    mock_get_executor.return_value = MagicMock()
+    exp = SimpleNamespace(add=MagicMock(return_value="task_handle"))
+    cluster_config = {
+        "executor": "local",
+        "containers": {"sandbox": "sandbox:latest"},
+    }
+
+    add_task(
+        exp=exp,
+        cmd="echo hello",
+        task_name="test-task",
+        cluster_config=cluster_config,
+        container="main:latest",
+        log_dir="/tmp/logs",
+        with_sandbox=True,
+        keep_mounts_for_sandbox=False,
+        skip_hf_home_check=True,
+        reuse_code=False,
+    )
+
+    sandbox_mounts = mock_get_executor.call_args_list[-1].kwargs["mounts"]
+    assert sandbox_mounts == []

--- a/tests/test_pipeline_utils.py
+++ b/tests/test_pipeline_utils.py
@@ -520,7 +520,16 @@ def test_get_executor_mounts_none_falls_back_to_config(mock_resolve, mock_packag
     from nemo_skills.pipeline.utils.exp import get_executor
 
     cluster_config = {"executor": "local", "mounts": ["/host/models:/models"]}
-    executor = get_executor(cluster_config=cluster_config, container="nemo:latest", mounts=None)
+    executor = get_executor(
+        cluster_config=cluster_config,
+        container="nemo:latest",
+        num_nodes=1,
+        tasks_per_node=1,
+        gpus_per_node=0,
+        job_name="test",
+        log_dir="/tmp",
+        mounts=None,
+    )
     assert executor.volumes == ["/host/models:/models"]
 
 
@@ -531,7 +540,16 @@ def test_get_executor_empty_mounts_overrides_config(mock_resolve, mock_packager)
     from nemo_skills.pipeline.utils.exp import get_executor
 
     cluster_config = {"executor": "local", "mounts": ["/host/models:/models"]}
-    executor = get_executor(cluster_config=cluster_config, container="nemo:latest", mounts=[])
+    executor = get_executor(
+        cluster_config=cluster_config,
+        container="nemo:latest",
+        num_nodes=1,
+        tasks_per_node=1,
+        gpus_per_node=0,
+        job_name="test",
+        log_dir="/tmp",
+        mounts=[],
+    )
     assert executor.volumes == []
 
 
@@ -542,7 +560,16 @@ def test_get_executor_explicit_mounts_overrides_config(mock_resolve, mock_packag
     from nemo_skills.pipeline.utils.exp import get_executor
 
     cluster_config = {"executor": "local", "mounts": ["/host/models:/models"]}
-    executor = get_executor(cluster_config=cluster_config, container="nemo:latest", mounts=["/sandbox/data:/data:ro"])
+    executor = get_executor(
+        cluster_config=cluster_config,
+        container="nemo:latest",
+        num_nodes=1,
+        tasks_per_node=1,
+        gpus_per_node=0,
+        job_name="test",
+        log_dir="/tmp",
+        mounts=["/sandbox/data:/data:ro"],
+    )
     assert executor.volumes == ["/sandbox/data:/data:ro"]
 
 


### PR DESCRIPTION
Introduces a new optional `sandbox_mounts` key in cluster configs that lets users specify exactly which paths are mounted into the sandbox container, with optional read/write mode (`src:dst` or `src:dst:ro` / `src:dst:rw`).

Mount resolution priority (highest to lowest):
1. `sandbox_mounts` in config (non-empty) — used as-is, overrides `--keep_mounts_for_sandbox`
2. `keep_mounts_for_sandbox=True` with no `sandbox_mounts` — inherit all cluster mounts
3. `keep_mounts_for_sandbox=False` with no `sandbox_mounts` — no mounts (safe default)

Fully backward compatible: without `sandbox_mounts` in cluster congig, the existing configs and cli flags `--with_sandbox` and `--keep_mounts_for_sandbox` behave identically to before.

## Code design choices
- Both the declarative pipeline (`Command.prepare_for_execution`) and the legacy `add_task` path in `exp.py` are updated. 
- Source paths in `sandbox_mounts` are validated at launch time via run_exp, consistent with how regular mounts are checked.
- Specifying `sandbox_mounts` overrides the `--keep_mounts_for_sandbox` flag as a safer priority. 
- Intentionally kept this simple rather than introducing more fine-grained mount resolution logic - in future we can potentially add more flags/sub-keys to selectively control mounth paths at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sandbox_mounts config to explicitly control mounts for sandbox containers (supports src:dst and src:dst:mode with ro/rw).

* **Behavior Changes**
  * sandbox_mounts now takes precedence over the previous keep-mounts behavior; when absent, previous fallback remains.
  * Mount entries support environment-variable expansion and stricter validation.

* **Documentation**
  * Added docs describing syntax, precedence, and guidance.

* **Tests**
  * Added tests for parsing, expansion, validation, and precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->