### PR TITLE
Add document-level translation benchmarks 

### DIFF
--- a/dockerfiles/Dockerfile.segale
+++ b/dockerfiles/Dockerfile.segale
@@ -1,0 +1,119 @@
+# Dockerfile for document-level MT evaluation with SEGALE.
+# Provides the SEGALE evaluation stack (COMET, COMETKiwi, MetricX-24, ersatz,
+# laser_encoders, vecalign) on Ubuntu 22.04 / Python 3.10.
+#
+# Uses nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu22.04 + Python 3.10 rather than
+# vllm-openai. fairseq 0.12.2 (required by laser_encoders for LASER2 loading) is
+# incompatible with Python 3.12's stricter dataclass validation, so the vLLM base
+# (which ships Python 3.12) cannot be used here. The CUDA runtime base (vs plain
+# ubuntu:22.04) is required so that torch.cuda.is_available() returns True when a
+# GPU is allocated — ubuntu:22.04 lacks the ldconfig paths the NVIDIA container
+# runtime injects libraries into.
+#
+# Build from the NeMo-Skills repo root:
+#   docker build -f dockerfiles/Dockerfile.segale -t segale:latest .
+#
+# Runtime env vars (set in cluster_config env_vars, not here):
+#   HF_HUB_CACHE   — path to shared model storage (flat layout, no hub/ subdir)
+#   HF_HOME        — same path as HF_HUB_CACHE (satisfies NeMo-Skills validation)
+#   HF_HUB_OFFLINE — set to 1 on clusters with no outbound internet from compute nodes
+#   ERSATZ         — path to ersatz model weights directory
+#   LASER_HOME     — path to LASER2 weights directory
+#   WANDB_DISABLED — set to true to suppress MetricX trainer logging
+
+# nvidia/cuda:12.8.0-runtime-ubuntu22.04 provides the CUDA runtime libraries and
+# correct ldconfig paths so that the NVIDIA container runtime's GPU injection is
+# visible to PyTorch at startup. Plain ubuntu:22.04 lacks these paths, causing
+# torch.cuda.is_available() to return False even when a GPU is allocated.
+FROM nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu22.04
+
+# 0. System deps.
+#    python -> python3 symlink needed because segale_eval invokes metricx as "python -m ...".
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3.10 python3.10-dev python3-pip git \
+        build-essential && \
+    ln -s /usr/bin/python3 /usr/local/bin/python && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip
+
+# 1. CUDA-enabled PyTorch.
+#    cu128 wheels are compatible with the cluster's CUDA 12.9 driver.
+#    Install before everything else so downstream packages link against this torch.
+RUN pip install torch==2.11.0+cu128 --index-url https://download.pytorch.org/whl/cu128
+
+# 2. SEGALE (alignment + evaluation pipeline).
+#    Install without its pinned deps — torch/transformers/numpy pins would conflict.
+#    Pinned to bc19b2b (2025-04-03).
+RUN pip install --no-deps git+https://github.com/nvlabs/SEGALE.git@bc19b2bb2bcde0bc2d6154dc2b86024b673e319c
+
+# 3. SEGALE's dependencies.
+#    hydra-core: NeMo-Skills needs >=1.3; SEGALE pins 1.3.2 which is compatible.
+#    laser_encoders + fairseq installed --no-deps: fairseq pins hydra-core<1.1 (training
+#    CLI only), but we only use fairseq's encoder modules, not its hydra-based CLI.
+#    Installing fairseq with --no-deps skips the pin; we then manually install fairseq's
+#    non-hydra runtime deps that the encoder path actually uses.
+#    unicategories is a runtime dep of laser_encoders (laser_tokenizer imports it);
+#    not pulled automatically because laser_encoders was installed with --no-deps.
+RUN pip install \
+    "transformers==4.57.6" \
+    "sentencepiece==0.2.1" \
+    "datasets==4.8.4" \
+    "spacy==3.8.4" \
+    "pandas==2.2.3" \
+    "tqdm==4.67.1" \
+    "unbabel-comet==2.2.7" \
+    "hydra-core>=1.3.2" \
+    "accelerate>=0.26.0" && \
+    pip install --no-deps "laser_encoders==0.0.2" "fairseq==0.12.2" && \
+    pip install "sacrebleu>=1.4.12" "bitarray" "omegaconf>=2.1" \
+        "regex" "sacremoses" "portalocker" "aiohttp" "unicategories" \
+        "langdetect"
+
+# 4. Build vecalign's Cython extension for this image's Python version.
+#    vecalign is not on PyPI — it is bundled inside the SEGALE repo and installed as a
+#    top-level package when SEGALE builds. The installed package contains only .py files;
+#    dp_core.pyx is in the repo source but is not copied into the installed package dir.
+#    Fix: shallow-clone SEGALE (with submodules — vecalign is a git submodule) to recover
+#    dp_core.pyx, copy it into the installed vecalign directory, then compile it in-place.
+#    The clone is deleted after compilation to keep the image small.
+RUN pip install "Cython==3.0.11" "numpy>=1.25.0" && \
+    git clone --recurse-submodules https://github.com/nvlabs/SEGALE.git /tmp/segale-src && \
+    cd /tmp/segale-src && git checkout bc19b2bb2bcde0bc2d6154dc2b86024b673e319c && cd / && \
+    VECALIGN_DIR=$(python3 -c "import vecalign, os; print(os.path.dirname(vecalign.__file__))") && \
+    cp /tmp/segale-src/vecalign/dp_core.pyx "$VECALIGN_DIR/" && \
+    rm -rf /tmp/segale-src && \
+    cd "$VECALIGN_DIR" && \
+    python3 -c "\
+import numpy; \
+from Cython.Build import cythonize; \
+from setuptools import setup, Extension; \
+setup(ext_modules=cythonize(Extension('dp_core', ['dp_core.pyx'], include_dirs=[numpy.get_include()]), language_level=3), script_args=['build_ext', '--inplace'])" && \
+    cd / && python3 -c "from vecalign.dp_utils import yield_overlaps; print('vecalign OK')"
+
+# 5. MetricX — patched for transformers >=4.52.
+#    google-research/metricx has no setup.py; segale_eval invokes it as a subprocess
+#    ("python -m metricx24.predict"), so we only need metricx24/ on sys.path.
+#    Copy it directly to site-packages.
+#    Patch: transformers>=4.52 DynamicCache shares self/cross-attn cache layers, causing
+#    a key shape mismatch. Fix: pass use_cache=False to the decoder call in models.py.
+#    TODO: remove patch once upstream fixes the issue.
+RUN git clone --depth=1 https://github.com/google-research/metricx.git /tmp/metricx && \
+    sed -i 's/use_cache=use_cache,/use_cache=False,/' /tmp/metricx/metricx24/models.py && \
+    SITE=$(python3 -c "import site; print(site.getsitepackages()[0])") && \
+    cp -r /tmp/metricx/metricx24 "$SITE/" && \
+    rm -rf /tmp/metricx && \
+    python3 -c "from metricx24 import models; print('metricx24 OK')"
+
+# 6. ersatz sentence segmenter.
+#    PyTorch >=2.6 changed torch.load default to weights_only=True; ersatz does not pass
+#    the argument, causing an error when loading model weights. Patch the one call site.
+#    TODO: remove patch once https://github.com/rewicks/ersatz is fixed upstream.
+RUN pip install "progressbar2" && \
+    pip install --no-deps "ersatz==1.0.0" && \
+    SPLIT_PY=$(python3 -c "import ersatz, os; print(os.path.join(os.path.dirname(ersatz.__file__), 'split.py'))") && \
+    sed -i "s/map_location=torch\.device('cpu'))/map_location=torch.device('cpu'), weights_only=False)/" "$SPLIT_PY"
+
+# 7. antlr4 pin required by NeMo-Skills math_grader; re-pin in case deps clobbered it.
+RUN pip install "antlr4-python3-runtime==4.9.3"

--- a/docs/evaluation/multilingual.md
+++ b/docs/evaluation/multilingual.md
@@ -217,6 +217,73 @@ Some reference numbers for test split (xx corresponds to average over 5 language
         ++inference.tokens_to_generate=2048
     ```
 
+### wmt24pp.doc
+
+- Benchmark is defined in [`nemo_skills/dataset/wmt24pp/doc/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/wmt24pp/doc/__init__.py)
+- Same source data as wmt24pp, but evaluates **document-level** translation (one document per generation request).
+- Uses the [SEGALE](https://github.com/nvlabs/SEGALE) judge for span-level alignment and scoring.
+- Covers 55 languages from google/wmt24pp.
+
+In this mode, the model receives an entire document as input and produces a single translation. SEGALE segments the output, aligns it to the source, and scores each aligned span with QE metrics (COMET-QE, MetricX-QE). A language fidelity score detects when the model's output deviates from the expected target language.
+
+```bash
+ns eval \
+    --cluster=[cluster] \
+    --model=[model] \
+    --benchmarks wmt24pp.doc \
+    --output_dir=[output dir] \
+    --server_type=vllm \
+    --server_gpus=8 \
+    ++chat_template_kwargs.enable_thinking=False \
+    ++parse_reasoning=False \
+    ++inference.tokens_to_generate=4096 \
+    ++skip_filled=True
+```
+
+- Evaluated on (de_DE, es_MX, fr_CA, fr_FR, it_IT, ja_JP), the following are results for document-level translation.
+
+| Model | Doc COMET-QE | Doc MetricX-QE |
+|---|---|---|
+| Nemotron3 Nano 30B | 0.8117 | 2.76 |
+| Qwen3 30B | 0.8223 | 2.50 |
+| Nemotron3 Super 120B | 0.8271 | 2.41 |
+| GPT-OSS 120B | 0.8267 | 2.35 |
+| Qwen3.5 122B | 0.8280 | 2.29 |
+
+### wmt24pp.long
+
+- Benchmark is defined in [`nemo_skills/dataset/wmt24pp/long/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/wmt24pp/long/__init__.py)
+- Same source data as wmt24pp, but all documents for a language are concatenated into a single input (~32K words).
+- Tests long-input / long-output translation capability.
+- Uses the same SEGALE judge as wmt24pp.doc.
+
+```bash
+ns eval \
+    --cluster=[cluster] \
+    --model=[model] \
+    --benchmarks wmt24pp.long \
+    --output_dir=[output dir] \
+    --server_type=vllm \
+    --server_gpus=8 \
+    ++chat_template_kwargs.enable_thinking=False \
+    ++parse_reasoning=False \
+    ++inference.tokens_to_generate=65536 \
+    ++skip_filled=True
+```
+
+!!! note "SEGALE container required"
+    The SEGALE judge runs in a separate container (`segale` in your cluster config) that includes COMET, MetricX-24, LASER2, ersatz, and vecalign. See [`dockerfiles/Dockerfile.segale`](https://github.com/NVIDIA-NeMo/Skills/blob/main/dockerfiles/Dockerfile.segale) for build instructions.
+
+- Evaluated on (de_DE, es_MX, fr_CA, fr_FR, it_IT, ja_JP), the following are results for long-document translation.
+
+| Model | Long COMET-QE | Long MetricX-QE |
+|---|---|---|
+| Nemotron3 Nano 30B | 0.0806 | 22.79 |
+| Qwen3 30B | 0.2205 | 20.62 |
+| Nemotron3 Super 120B | 0.5603 | 11.16 |
+| GPT-OSS 120B | 0.0625 | 24.11 |
+| Qwen3.5 122B | 0.7312 | 5.17 |
+
 ### mmmlu
 
 - Benchmark is defined in [`nemo_skills/dataset/mmmlu/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/mmmlu/__init__.py)
@@ -372,3 +439,13 @@ ns eval \
     --judge_step_fn="nemo_skills.pipeline.judges.comet_judge::create_judge_tasks" \
     --judge_model=[path_to_comet_checkpoint]
 ```
+
+### SEGALE (document-level)
+
+The `wmt24pp.doc` and `wmt24pp.long` benchmarks use [SEGALE](https://github.com/nvlabs/SEGALE) for document-level translation evaluation. SEGALE works by:
+
+1. Segmenting both the source text and the model's generation into sentences using [ersatz](https://github.com/rewicks/ersatz).
+2. Aligning source and MT sentences using [LASER2](https://github.com/facebookresearch/LASER) embeddings and [vecalign](https://github.com/thompsonb/vecalign).
+3. Scoring each aligned span with QE metrics ([COMET-QE](https://huggingface.co/Unbabel/wmt22-cometkiwi-da), [MetricX-QE](https://github.com/google-research/metricx)).
+
+The SEGALE judge is configured automatically for `wmt24pp.doc` and `wmt24pp.long` — no extra flags are needed. It runs in a separate container defined by the `segale` entry in your cluster config.

--- a/nemo_skills/dataset/utils.py
+++ b/nemo_skills/dataset/utils.py
@@ -24,8 +24,6 @@ from pathlib import Path
 from typing import Dict
 from urllib.error import URLError
 
-from nemo_skills.evaluation.math_grader import extract_answer
-
 
 def locate(path):
     """Import an object by path using ``::`` or dotted notation.
@@ -278,6 +276,8 @@ def save_data_from_qwen(dataset, split="test"):
                 entry["expected_answer"] = entry.pop("final_answer")[0].strip("$")
 
             if dataset == "minerva_math":
+                from nemo_skills.evaluation.math_grader import extract_answer
+
                 entry["expected_answer"] = extract_answer(entry["solution"])
 
             data.append(entry)

--- a/nemo_skills/dataset/wmt24pp/__init__.py
+++ b/nemo_skills/dataset/wmt24pp/__init__.py
@@ -11,7 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# settings that define how evaluation should be done by default (all can be changed from cmdline)
 
-METRICS_TYPE = "translation"
-GENERATION_ARGS = "++prompt_config=multilingual/segment-translation"
+# WMT24++ translation benchmark group.
+#
+# Sub-benchmarks:
+#   wmt24pp.sent  — Sentence-level translation (one sentence at a time, BLEU/COMET).
+#   wmt24pp.doc   — Document-level translation (one document at a time, SEGALE scoring).
+#   wmt24pp.long  — Long-context translation (all documents per language, SEGALE scoring).
+#
+# Default: ns eval wmt24pp runs only wmt24pp.sent
+# (preserves existing behavior before adding doc and long variants).
+# To run document-level: ns eval wmt24pp.doc
+# To run all: ns eval wmt24pp.sent,wmt24pp.doc,wmt24pp.long
+
+IS_BENCHMARK_GROUP = True
+
+# Default behavior: only sentence-level (preserves existing behavior).
+BENCHMARKS = {
+    "wmt24pp.sent": {},
+}

--- a/nemo_skills/dataset/wmt24pp/doc/__init__.py
+++ b/nemo_skills/dataset/wmt24pp/doc/__init__.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Document-level translation: one record per (document, target language).
+# Each document is presented as a single generation request. Evaluation uses
+# SEGALE (segment-align-evaluate) to align and score at the span level.
+
+METRICS_TYPE = "translation"
+GENERATION_ARGS = "++prompt_config=multilingual/document-translation ++inference.endpoint_type=text"
+GENERATION_MODULE = "nemo_skills.inference.document_translation"
+NUM_CHUNKS = 11
+
+JUDGE_PIPELINE_ARGS = {
+    "judge_step_fn": "nemo_skills.pipeline.judges.segale_judge_step::create_judge_tasks",
+    "segmenter": "ersatz",
+    "judge_debug": False,
+    "qe_only": True,
+    "save_spans": True,
+    "target_languages": [
+        "ar_EG",
+        "ar_SA",
+        "bg_BG",
+        "bn_IN",
+        "ca_ES",
+        "cs_CZ",
+        "da_DK",
+        "de_DE",
+        "el_GR",
+        "es_MX",
+        "et_EE",
+        "fa_IR",
+        "fi_FI",
+        "fil_PH",
+        "fr_CA",
+        "fr_FR",
+        "gu_IN",
+        "he_IL",
+        "hi_IN",
+        "hr_HR",
+        "hu_HU",
+        "id_ID",
+        "is_IS",
+        "it_IT",
+        "ja_JP",
+        "kn_IN",
+        "ko_KR",
+        "lt_LT",
+        "lv_LV",
+        "ml_IN",
+        "mr_IN",
+        "nl_NL",
+        "no_NO",
+        "pa_IN",
+        "pl_PL",
+        "pt_BR",
+        "pt_PT",
+        "ro_RO",
+        "ru_RU",
+        "sk_SK",
+        "sl_SI",
+        "sr_RS",
+        "sv_SE",
+        "sw_KE",
+        "sw_TZ",
+        "ta_IN",
+        "te_IN",
+        "th_TH",
+        "tr_TR",
+        "uk_UA",
+        "ur_PK",
+        "vi_VN",
+        "zh_CN",
+        "zh_TW",
+        "zu_ZA",
+    ],
+}

--- a/nemo_skills/dataset/wmt24pp/long/__init__.py
+++ b/nemo_skills/dataset/wmt24pp/long/__init__.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Long-context translation: all documents for a language concatenated into
+# one record. Tests long-input / long-output translation capability.
+# Evaluation uses SEGALE (same as wmt24pp.doc).
+
+METRICS_TYPE = "translation"
+GENERATION_ARGS = "++prompt_config=multilingual/document-translation ++inference.endpoint_type=text"
+GENERATION_MODULE = "nemo_skills.inference.document_translation"
+NUM_CHUNKS = 11
+
+JUDGE_PIPELINE_ARGS = {
+    "judge_step_fn": "nemo_skills.pipeline.judges.segale_judge_step::create_judge_tasks",
+    "segmenter": "ersatz",
+    "qe_only": True,
+    "save_spans": True,
+    "target_languages": [
+        "ar_EG",
+        "ar_SA",
+        "bg_BG",
+        "bn_IN",
+        "ca_ES",
+        "cs_CZ",
+        "da_DK",
+        "de_DE",
+        "el_GR",
+        "es_MX",
+        "et_EE",
+        "fa_IR",
+        "fi_FI",
+        "fil_PH",
+        "fr_CA",
+        "fr_FR",
+        "gu_IN",
+        "he_IL",
+        "hi_IN",
+        "hr_HR",
+        "hu_HU",
+        "id_ID",
+        "is_IS",
+        "it_IT",
+        "ja_JP",
+        "kn_IN",
+        "ko_KR",
+        "lt_LT",
+        "lv_LV",
+        "ml_IN",
+        "mr_IN",
+        "nl_NL",
+        "no_NO",
+        "pa_IN",
+        "pl_PL",
+        "pt_BR",
+        "pt_PT",
+        "ro_RO",
+        "ru_RU",
+        "sk_SK",
+        "sl_SI",
+        "sr_RS",
+        "sv_SE",
+        "sw_KE",
+        "sw_TZ",
+        "ta_IN",
+        "te_IN",
+        "th_TH",
+        "tr_TR",
+        "uk_UA",
+        "ur_PK",
+        "vi_VN",
+        "zh_CN",
+        "zh_TW",
+        "zu_ZA",
+    ],
+}

--- a/nemo_skills/dataset/wmt24pp/prepare.py
+++ b/nemo_skills/dataset/wmt24pp/prepare.py
@@ -12,39 +12,219 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Prepare wmt24pp data for all sub-benchmarks (sent, doc, long).
+
+Downloads from google/wmt24pp and writes:
+  sent/<split>.jsonl  — one record per sentence (sentence-level translation)
+  doc/<split>.jsonl   — one record per (document, language) (document-level translation)
+  long/<split>.jsonl  — one record per language (long-context translation)
+"""
+
 import argparse
 import json
+from collections import OrderedDict
 from pathlib import Path
 
 from datasets import load_dataset
 from langcodes import Language
 
 
-def write_data_to_file(output_file, datasets, tgt_languages):
-    with open(output_file, "wt", encoding="utf-8") as fout:
-        for tgt_lang in tgt_languages:
-            for src, tgt in zip(datasets[tgt_lang]["source"], datasets[tgt_lang]["target"], strict=True):
-                json_dict = {
-                    "text": src,
-                    "translation": tgt,
+def _lang_name(lang_code: str) -> str:
+    """Convert a language code like 'fil_PH' to a display name."""
+    return Language(lang_code.split("_")[0]).display_name()
+
+
+def write_sent(output_file, datasets, tgt_languages):
+    """One record per sentence — sentence-level translation."""
+    records = []
+    for tgt_lang in tgt_languages:
+        for row in datasets[tgt_lang]:
+            if row["is_bad_source"]:
+                continue
+            records.append(
+                {
+                    "text": row["source"],
+                    "translation": row["target"],
                     "source_language": "en",
                     "target_language": tgt_lang,
                     "source_lang_name": "English",
-                    "target_lang_name": Language(tgt_lang[:2]).display_name(),
+                    "target_lang_name": _lang_name(tgt_lang),
+                    "doc_id": row["document_id"],
+                    "seg_id": row["segment_id"],
                 }
-                json.dump(json_dict, fout)
-                fout.write("\n")
+            )
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for record in records:
+            json.dump(record, fout)
+            fout.write("\n")
+
+
+def write_doc(output_file, datasets, tgt_languages):
+    """One record per (document, language) — document-level translation."""
+    records = []
+    for tgt_lang in tgt_languages:
+        docs = OrderedDict()
+        for row in datasets[tgt_lang]:
+            if row["is_bad_source"]:
+                continue
+            doc_id = row["document_id"]
+            if doc_id not in docs:
+                docs[doc_id] = []
+            docs[doc_id].append(row)
+
+        for doc_id in docs:
+            docs[doc_id].sort(key=lambda r: r["segment_id"])
+
+        for doc_id, rows in docs.items():
+            source_sentences = [row["source"] for row in rows]
+            reference_sentences = [row["target"] for row in rows]
+            records.append(
+                {
+                    "text": " ".join(source_sentences),
+                    "source_sentences": source_sentences,
+                    "reference_sentences": reference_sentences,
+                    "source_language": "en",
+                    "target_language": tgt_lang,
+                    "source_lang_name": "English",
+                    "target_lang_name": _lang_name(tgt_lang),
+                    "doc_id": doc_id,
+                    "seg_id": 1,
+                }
+            )
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for record in records:
+            json.dump(record, fout)
+            fout.write("\n")
+
+
+def write_long(output_file, datasets, tgt_languages):
+    """One record per language — long-context translation."""
+    records = []
+    for tgt_lang in tgt_languages:
+        docs = OrderedDict()
+        for row in datasets[tgt_lang]:
+            if row["is_bad_source"]:
+                continue
+            doc_id = row["document_id"]
+            if doc_id not in docs:
+                docs[doc_id] = []
+            docs[doc_id].append(row)
+
+        for doc_id in docs:
+            docs[doc_id].sort(key=lambda r: r["segment_id"])
+
+        doc_groups = []
+        source_sentences = []
+        reference_sentences = []
+        for doc_id, rows in docs.items():
+            group_src = [row["source"] for row in rows]
+            group_ref = [row["target"] for row in rows]
+            doc_groups.append({"doc_id": doc_id, "source_sentences": group_src, "reference_sentences": group_ref})
+            source_sentences.extend(group_src)
+            reference_sentences.extend(group_ref)
+
+        records.append(
+            {
+                "text": " ".join(source_sentences),
+                "source_sentences": source_sentences,
+                "reference_sentences": reference_sentences,
+                # doc_groups preserves per-document boundaries so that document order
+                # can be shuffled at inference time for multi-seed runs.
+                "doc_groups": doc_groups,
+                "source_language": "en",
+                "target_language": tgt_lang,
+                "source_lang_name": "English",
+                "target_lang_name": _lang_name(tgt_lang),
+                "doc_id": tgt_lang,
+                "seg_id": 1,
+            }
+        )
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for record in records:
+            json.dump(record, fout)
+            fout.write("\n")
+
+
+SENT_DEFAULT_LANGUAGES = ["de_DE", "es_MX", "fr_FR", "it_IT", "ja_JP"]
+
+ALL_LANGUAGES = [
+    "ar_EG",
+    "ar_SA",
+    "bg_BG",
+    "bn_IN",
+    "ca_ES",
+    "cs_CZ",
+    "da_DK",
+    "de_DE",
+    "el_GR",
+    "es_MX",
+    "et_EE",
+    "fa_IR",
+    "fi_FI",
+    "fil_PH",
+    "fr_CA",
+    "fr_FR",
+    "gu_IN",
+    "he_IL",
+    "hi_IN",
+    "hr_HR",
+    "hu_HU",
+    "id_ID",
+    "is_IS",
+    "it_IT",
+    "ja_JP",
+    "kn_IN",
+    "ko_KR",
+    "lt_LT",
+    "lv_LV",
+    "ml_IN",
+    "mr_IN",
+    "nl_NL",
+    "no_NO",
+    "pa_IN",
+    "pl_PL",
+    "pt_BR",
+    "pt_PT",
+    "ro_RO",
+    "ru_RU",
+    "sk_SK",
+    "sl_SI",
+    "sr_RS",
+    "sv_SE",
+    "sw_KE",
+    "sw_TZ",
+    "ta_IN",
+    "te_IN",
+    "th_TH",
+    "tr_TR",
+    "uk_UA",
+    "ur_PK",
+    "vi_VN",
+    "zh_CN",
+    "zh_TW",
+    "zu_ZA",
+]
 
 
 def main(args):
-    datasets = {}
-    for lang in args.target_languages:
-        datasets[lang] = load_dataset("google/wmt24pp", f"en-{lang}")["train"]
-
     data_dir = Path(__file__).absolute().parent
-    data_dir.mkdir(exist_ok=True)
-    output_file = data_dir / f"{args.split}.jsonl"
-    write_data_to_file(output_file, datasets, tgt_languages=args.target_languages)
+
+    for sub, writer, languages in [
+        ("sent", write_sent, args.sent_languages),
+        ("doc", write_doc, args.target_languages),
+        ("long", write_long, args.target_languages),
+    ]:
+        # Download only the languages needed for this sub-benchmark.
+        datasets = {}
+        for lang in languages:
+            if lang not in datasets:
+                datasets[lang] = load_dataset("google/wmt24pp", f"en-{lang}")["train"]
+
+        sub_dir = data_dir / sub
+        sub_dir.mkdir(exist_ok=True)
+        output_file = sub_dir / f"{args.split}.jsonl"
+        writer(output_file, datasets, tgt_languages=languages)
+        print(f"Wrote {output_file}")
 
 
 if __name__ == "__main__":
@@ -52,9 +232,15 @@ if __name__ == "__main__":
     parser.add_argument("--split", default="test", choices=("test",), help="Dataset split to process.")
     parser.add_argument(
         "--target_languages",
-        default=["de_DE", "es_MX", "fr_FR", "it_IT", "ja_JP"],
+        default=ALL_LANGUAGES,
         nargs="+",
-        help="Languages to translate to.",
+        help="Languages for doc and long sub-benchmarks (default: all 55).",
+    )
+    parser.add_argument(
+        "--sent_languages",
+        default=SENT_DEFAULT_LANGUAGES,
+        nargs="+",
+        help="Languages for sent sub-benchmark (default: 5, preserving original wmt24pp behavior).",
     )
     args = parser.parse_args()
     main(args)

--- a/nemo_skills/dataset/wmt24pp/sent/__init__.py
+++ b/nemo_skills/dataset/wmt24pp/sent/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sentence-level translation: one record per sentence, no document context.
+# Uses BLEU/COMET for scoring (no SEGALE judge).
+
+METRICS_TYPE = "translation"
+GENERATION_ARGS = "++prompt_config=multilingual/segment-translation"

--- a/nemo_skills/evaluation/evaluator/segale_judge.py
+++ b/nemo_skills/evaluation/evaluator/segale_judge.py
@@ -1,0 +1,1186 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+SEGALE judge script for document-level machine translation evaluation.
+
+Runs as a 3-phase disaggregated pipeline invoked with --mode:
+
+  --mode embed  (GPU job)
+    Segments source and generation text with ersatz, computes LASER2
+    embeddings, and saves sentences/overlaps/embeddings to disk.
+    Source embeddings are computed once and shared across all target languages.
+    Writes segale_intermediate/embed/embed.done on success.
+
+  --mode align  (CPU job, no GPU needed)
+    Loads pre-computed embeddings from the embed phase and runs vecalign
+    alignment in parallel across all target languages using all available CPUs.
+    Writes per-language aligned_spans.jsonl and align.done files.
+
+  --mode score  (GPU job)
+    Loads all aligned spans across all languages and batch-scores them with
+    COMET-QE (COMETKiwi wmt22) and MetricX-QE in a single GPU pass.
+    Writes per-language output.jsonl files under per_lang/<lang>/.
+
+  --merge-input / --merge-langs-dir  (CPU, no mode flag)
+    Reassembles per-language scored outputs into the final output.jsonl
+    in the original record order.
+
+Output fields per document: segale_comet_qe, segale_metricx_qe,
+                             segale_lang_fidelity, segale_total_seg,
+                             segale_misaligned_seg
+
+Score sentinels (from segale_eval)
+-----------------------------------
+segale_eval's scoring functions return sentinel values for spans that cannot
+be meaningfully scored due to alignment edge cases:
+
+  -1  Both src and tgt are absent/empty.  Returned for completely invalid
+      windows.  Extremely rare in practice — vecalign almost always produces
+      at least one non-empty side.  Excluded from the doc-level average
+      (filtered by >= 0).
+
+   0  Exactly one of src or tgt is an empty string.  Two causes:
+        deleted      — tgt=""  (src_indices produced content but mt_indices=[])
+                       The model skipped translating this source span.
+        hallucinated — src=""  (mt_indices produced content but src_indices=[])
+                       The model generated content with no corresponding source.
+      Score 0 IS included in the doc-level average, so deletions and
+      hallucinations directly lower segale_comet_qe and segale_metricx_qe.
+
+A span is "misaligned" (counted in segale_misaligned_seg) when its score
+is <= 0, i.e. it is either deleted, hallucinated, or completely invalid.
+In spans.jsonl each span carries explicit "deleted" and "hallucinated" flags
+(derived from empty tgt / empty src respectively) so the two cases can be
+distinguished without relying on the score sentinel.
+
+Model downloads
+---------------
+  * LASER2 (alignment embeddings)
+      Downloaded by laser_encoders to $LASER_HOME or ~/.cache/laser_encoders/
+
+  * COMETKiwi (scoring)
+      Downloaded by unbabel-comet to $HF_HOME/hub/
+      Model: Unbabel/wmt22-cometkiwi-da
+
+  * MetricX-QE (scoring)
+      Downloaded by HuggingFace transformers to $HF_HOME/hub/
+      Model: google/metricx-24-hybrid-large-v2p6
+
+On a cluster with a shared parallel filesystem set HF_HOME to a shared path
+so model weights are downloaded once and reused across all jobs.
+"""
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+LOG = logging.getLogger(__name__)
+
+
+def _clean_sentences(sentences: list[str]) -> list[str]:
+    """Replace line-break characters within sentences with spaces.
+
+    Newlines and carriage returns inside a sentence would corrupt vecalign's
+    overlap file (which is newline-delimited), splitting one entry into
+    multiple lines. SEGALE's generate_overlap_and_embedding uses set() to
+    deduplicate overlaps internally, so no explicit dedup is needed here.
+    """
+    return [s.replace("\r", " ").replace("\n", " ") for s in sentences]
+
+
+def _compute_lang_fidelity(
+    generation: str,
+    reference_text: str,
+    chunk_size: int = 500,
+) -> float:
+    """Compute the fraction of generation chunks in the correct target language.
+
+    Detects the expected target language from the reference text, then checks
+    each chunk of the generation against it. Returns 1.0 if all chunks match
+    the target language, 0.0 if none do.
+
+    This catches models that collapse to the source language (e.g. English)
+    or any other wrong language mid-generation.
+
+    Returns 1.0 for empty/short text or if langdetect is not installed.
+    """
+    if not generation or len(generation) < 50:
+        return 1.0
+
+    try:
+        from langdetect import DetectorFactory, detect
+
+        DetectorFactory.seed = 0
+    except ImportError:
+        LOG.warning("langdetect not installed — skipping language fidelity check.")
+        return 1.0
+
+    # Detect expected target language from the reference
+    try:
+        expected_lang = detect(reference_text[:10000])
+    except Exception:
+        LOG.warning("Could not detect reference language — skipping fidelity check.")
+        return 1.0
+
+    chunks = [generation[i : i + chunk_size] for i in range(0, len(generation), chunk_size)]
+    if len(chunks) > 1 and len(chunks[-1]) < 100:
+        chunks = chunks[:-1]
+    if not chunks:
+        return 1.0
+
+    correct_count = 0
+    detected_count = 0
+    for chunk in chunks:
+        try:
+            detected = detect(chunk)
+            detected_count += 1
+            if detected == expected_lang:
+                correct_count += 1
+        except Exception:
+            pass  # undetectable chunk — excluded from ratio
+
+    if detected_count == 0:
+        return 1.0
+    return correct_count / detected_count
+
+
+# ====================================================================
+# 3-Phase disaggregated pipeline: Embed → Align → Score
+# ====================================================================
+
+
+def _find_ersatz_model_path() -> str | None:
+    """Return the path to the ersatz multilingual model checkpoint.
+
+    Looks inside $ERSATZ for the first *.multilingual file (the pattern
+    used by the default-multilingual model downloaded by the cluster setup).
+    Returns None if ERSATZ is unset or no model is found.
+    """
+    import glob
+
+    ersatz_home = os.environ.get("ERSATZ", "")
+    if not ersatz_home:
+        return None
+    for pattern in [
+        os.path.join(ersatz_home, "**", "*.multilingual"),
+        os.path.join(ersatz_home, "**", "*multilingual"),
+    ]:
+        matches = sorted(glob.glob(pattern, recursive=True))
+        if matches:
+            return matches[0]
+    return None
+
+
+def _batch_segment_ersatz(texts: list[str]) -> list[list[str]]:
+    """Segment all texts in one ersatz subprocess call (one model load total).
+
+    Writes all texts to a single temp file separated by a unique ASCII marker
+    line, calls the ersatz CLI once, then splits the output on that marker to
+    recover per-document sentence lists.  One subprocess = one model load,
+    and ersatz's internal batching handles GPU throughput.
+
+    A canary document is prepended to the batch so the marker behavior can be
+    verified in-band before any real output is trusted.  If the canary check
+    or the marker count check fails, falls back to per-text subprocess calls.
+    """
+    import subprocess
+    import tempfile
+    import time
+
+    # Plain ASCII, no punctuation — ersatz finds no sentence boundary in it.
+    MARKER = "SEGALE-DOC-SEP-XXXXXXXXXXXXXXXXXXX"
+
+    # Canary: a known two-sentence doc prepended to position 0.
+    # After running ersatz we verify it produced exactly two sentences before
+    # the first marker, confirming the marker is acting as a clean boundary.
+    CANARY_TEXT = "The canary document has exactly two sentences. This is the second one."
+    CANARY_EXPECTED = {"The canary document has exactly two sentences.", "This is the second one."}
+
+    all_texts = [CANARY_TEXT] + texts
+    n_chars = sum(len(t) for t in all_texts)
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", encoding="utf-8", suffix=".txt") as fh:
+        for text in all_texts:
+            fh.write(text.strip())
+            fh.write("\n" + MARKER + "\n")
+        input_path = fh.name
+
+    output_path = input_path + ".segmented"
+
+    def _fallback():
+        LOG.warning(
+            "ersatz batch: marker self-test failed — falling back to per-text subprocess to avoid boundary corruption"
+        )
+        import segale_align as sa
+
+        return [_clean_sentences(sa.segment_sentences_by_ersatz(t)) for t in texts]
+
+    LOG.info(
+        "ersatz batch: calling subprocess on %d texts (%d chars) via %s",
+        len(all_texts),
+        n_chars,
+        input_path,
+    )
+    t0 = time.monotonic()
+    try:
+        subprocess.run(
+            ["ersatz", "--input", input_path, "--output", output_path],
+            check=True,
+        )
+    finally:
+        os.remove(input_path)
+    elapsed = time.monotonic() - t0
+    LOG.info("ersatz batch: subprocess finished in %.1fs", elapsed)
+
+    with open(output_path, "r", encoding="utf-8") as fh:
+        output_lines = [line.rstrip("\n") for line in fh]
+    os.remove(output_path)
+
+    LOG.info(
+        "ersatz batch: output has %d lines for %d input texts",
+        len(output_lines),
+        len(all_texts),
+    )
+
+    # Expect one marker per input text (including the canary).
+    # l.strip() == MARKER is True only when the entire line (minus whitespace)
+    # is the marker — if ersatz merged the marker with adjacent text, l.strip()
+    # would contain extra content and NOT equal MARKER, reducing the count and
+    # triggering the fallback.
+    markers_in_output = sum(1 for line in output_lines if line.strip() == MARKER)
+    if markers_in_output != len(all_texts):
+        LOG.warning(
+            "ersatz batch: expected %d isolated marker lines in output, got %d "
+            "(ersatz may have merged or dropped the marker) — falling back",
+            len(all_texts),
+            markers_in_output,
+        )
+        return _fallback()
+
+    # Split on markers.
+    raw_results: list[list[str]] = []
+    current: list[str] = []
+    for line in output_lines:
+        if line.strip() == MARKER:
+            raw_results.append(current)
+            current = []
+        elif line.strip():
+            current.append(line.strip())
+
+    # Verify canary (position 0): ersatz must have produced its two known sentences
+    # and nothing else before the first marker.
+    canary_out = set(raw_results[0]) if raw_results else set()
+    if canary_out != CANARY_EXPECTED:
+        LOG.warning(
+            "ersatz batch: canary check failed (got %s, expected %s) — falling back",
+            canary_out,
+            CANARY_EXPECTED,
+        )
+        return _fallback()
+
+    results = [_clean_sentences(sents) for sents in raw_results[1:]]
+    total_sents = sum(len(s) for s in results)
+    LOG.info(
+        "ersatz batch: canary OK — %d texts → %d sentences (avg %.1f per doc)",
+        len(results),
+        total_sents,
+        total_sents / len(results) if results else 0,
+    )
+    return results
+
+
+def _run_embed_phase(
+    input_file: Path,
+    output_dir: Path,
+    segmenter: str,
+    judge_debug: bool = False,
+    target_languages: set[str] | None = None,
+    embed_batch_size: int = 512,
+):
+    """Phase 1 (GPU): Segment all docs and compute LASER2 embeddings.
+
+    Two-pass approach:
+      Pass 1 (GPU): batch-segment all docs with ersatz (EvalModel loaded once, one GPU
+                    pass over all text), then generate overlap windows via stub encoder.
+      Pass 2 (GPU): encode all overlaps in one flat batched call to model.encode_sentences(),
+                    then slice results back into per-doc numpy arrays.
+
+    Source embeddings are computed once per doc_id and shared across all target languages.
+
+    Output layout in <output_dir>/segale_intermediate/embed/:
+        doc_records.jsonl                 — serialized input doc records
+        sentences/src/<doc_id>.json       — {"sentences": [...]}
+        sentences/mt/<lang>/<doc_id>.json
+        overlaps/src/<doc_id>.json        — {"overlaps": [...]}
+        overlaps/mt/<lang>/<doc_id>.json
+        embeddings/src/<doc_id>.npy       — float32 (n_overlaps, embed_dim)
+        embeddings/mt/<lang>/<doc_id>.npy
+        embed.done                        — sentinel written on success
+    """
+    import numpy as np
+
+    inter_dir = output_dir / "segale_intermediate" / "embed"
+    done_file = inter_dir / "embed.done"
+    if done_file.exists():
+        LOG.info("embed.done exists at %s — skipping embed phase", done_file)
+        return
+
+    inter_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(input_file, "rt", encoding="utf-8") as f:
+        records = [json.loads(line) for line in f if line.strip()]
+
+    doc_records = [r for r in records if "doc_id" in r]
+    if target_languages:
+        doc_records = [r for r in doc_records if r.get("target_language") in target_languages]
+
+    if judge_debug:
+        debug_doc_ids = list(dict.fromkeys(r["doc_id"] for r in doc_records))[:2]
+        doc_records = [r for r in doc_records if r["doc_id"] in debug_doc_ids]
+        LOG.info("--judge-debug: limiting embed phase to %d docs (%s)", len(debug_doc_ids), debug_doc_ids)
+
+    if not doc_records:
+        LOG.warning("embed: no doc records found in %s", input_file)
+        done_file.touch()
+        return
+
+    # Save doc_records for downstream align and score phases.
+    with open(inter_dir / "doc_records.jsonl", "wt", encoding="utf-8") as f:
+        for r in doc_records:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    try:
+        import segale_align as sa
+    except ImportError as e:
+        raise ImportError("segale_align could not be imported. Ensure the SEGALE package is installed.") from e
+
+    sa.VERBOSE = 2 if judge_debug else 0
+    sa.SPACY = segmenter
+    sa.STOP_JUMP = 0.15
+    sa.COST_MIN = 0.30
+    sa.COST_MAX = 0.30
+
+    # ------------------------------------------------------------------ #
+    # Pass 1a (GPU): batch-segment ALL texts with ersatz in one GPU pass  #
+    # ------------------------------------------------------------------ #
+
+    lang_doc_map: dict[str, dict[str, dict]] = defaultdict(dict)
+    for record in doc_records:
+        lang = record.get("target_language", "unknown")
+        lang_doc_map[lang][record["doc_id"]] = record
+
+    # Collect unique source texts and all MT texts.
+    seen_src: set[str] = set()
+    src_doc_ids: list[str] = []  # ordered unique doc_ids for source
+    src_texts: list[str] = []
+    for record in doc_records:
+        doc_id = record["doc_id"]
+        if doc_id not in seen_src:
+            seen_src.add(doc_id)
+            src_doc_ids.append(doc_id)
+            src_texts.append(record.get("text", ""))
+
+    mt_keys: list[tuple[str, str]] = []  # (lang, doc_id)
+    mt_texts: list[str] = []
+    for lang, doc_map in lang_doc_map.items():
+        for doc_id, record in doc_map.items():
+            # Use a placeholder for empty generations so the pair still flows
+            # through embed → align → score and receives a legitimate (very low)
+            # COMET-QE score rather than being silently dropped. The placeholder
+            # is a nonsense string that segments to exactly one sentence and
+            # scores near zero against any real source.
+            tgt_text = record.get("generation", "").strip() or "___null_translation___"
+            mt_keys.append((lang, doc_id))
+            mt_texts.append(tgt_text)
+
+    if segmenter != "spacy":
+        all_sentence_lists = _batch_segment_ersatz(src_texts + mt_texts)
+    else:
+        all_sentence_lists = [_clean_sentences(sa.segment_sentences_by_spacy(t)) for t in src_texts + mt_texts]
+
+    src_sentences_map: dict[str, list[str]] = {
+        doc_id: _clean_sentences(sents) for doc_id, sents in zip(src_doc_ids, all_sentence_lists[: len(src_doc_ids)])
+    }
+    mt_sentences_map: dict[tuple[str, str], list[str]] = {
+        key: _clean_sentences(sents) for key, sents in zip(mt_keys, all_sentence_lists[len(src_doc_ids) :])
+    }
+
+    LOG.info(
+        "embed pass 1a: segmented %d source docs + %d MT pairs",
+        len(src_doc_ids),
+        len(mt_keys),
+    )
+
+    # ------------------------------------------------------------------ #
+    # Pass 1b: overlap generation via stub encoder                        #
+    #                                                                      #
+    # generate_overlap_and_embedding does internal sub-sentence splitting  #
+    # we cannot replicate independently, so we feed it a fast stub that   #
+    # returns a throwaway scalar. All CPU logic runs, we get the correct   #
+    # overlap strings, and the GPU is untouched until pass 2.             #
+    # ------------------------------------------------------------------ #
+
+    class _StubEncoder:
+        """Returns a throwaway scalar so generate_overlap_and_embedding runs
+        its full CPU logic without touching the GPU."""
+
+        def encode_sentences(self, sentences):
+            return np.empty(1, dtype=np.float32)
+
+    stub = _StubEncoder()
+
+    sents_src_dir = inter_dir / "sentences" / "src"
+    overlaps_src_dir = inter_dir / "overlaps" / "src"
+    embeds_src_dir = inter_dir / "embeddings" / "src"
+    for d in (sents_src_dir, overlaps_src_dir, embeds_src_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    # overlap_index maps (side, lang_or_None, doc_id) -> (flat_start, flat_end)
+    all_overlap_strings: list[str] = []
+    overlap_index: dict[tuple, tuple[int, int]] = {}
+
+    # -- Source overlaps --
+    for doc_id in src_doc_ids:
+        src_sentences = src_sentences_map[doc_id]
+        (sents_src_dir / f"{doc_id}.json").write_text(json.dumps({"sentences": src_sentences}, ensure_ascii=False))
+
+        if not src_sentences:
+            LOG.warning("embed: empty source sentences for doc_id=%s", doc_id)
+            continue
+
+        src_overlaps, _ = sa.generate_overlap_and_embedding(src_sentences, stub, None, max_size=8)
+        (overlaps_src_dir / f"{doc_id}.json").write_text(json.dumps({"overlaps": src_overlaps}, ensure_ascii=False))
+
+        start = len(all_overlap_strings)
+        all_overlap_strings.extend(src_overlaps)
+        overlap_index[("src", None, doc_id)] = (start, len(all_overlap_strings))
+
+    # -- MT overlaps --
+    for lang, doc_map in lang_doc_map.items():
+        sents_mt_dir = inter_dir / "sentences" / "mt" / lang
+        overlaps_mt_dir = inter_dir / "overlaps" / "mt" / lang
+        embeds_mt_dir = inter_dir / "embeddings" / "mt" / lang
+        for d in (sents_mt_dir, overlaps_mt_dir, embeds_mt_dir):
+            d.mkdir(parents=True, exist_ok=True)
+
+        for doc_id, record in doc_map.items():
+            key = (lang, doc_id)
+            if key not in mt_sentences_map:
+                LOG.warning("embed: empty generation for doc_id=%s lang=%s — skipping", doc_id, lang)
+                continue
+
+            mt_sentences = mt_sentences_map[key]
+            (sents_mt_dir / f"{doc_id}.json").write_text(json.dumps({"sentences": mt_sentences}, ensure_ascii=False))
+
+            if not mt_sentences:
+                LOG.warning("embed: empty MT sentences for doc_id=%s lang=%s — skipping", doc_id, lang)
+                continue
+
+            mt_overlaps, _ = sa.generate_overlap_and_embedding(mt_sentences, stub, None, max_size=8)
+            (overlaps_mt_dir / f"{doc_id}.json").write_text(json.dumps({"overlaps": mt_overlaps}, ensure_ascii=False))
+
+            start = len(all_overlap_strings)
+            all_overlap_strings.extend(mt_overlaps)
+            overlap_index[("mt", lang, doc_id)] = (start, len(all_overlap_strings))
+
+    n_mt_pairs = sum(len(d) for d in lang_doc_map.values())
+    LOG.info(
+        "embed pass 1b complete: %d total overlaps across %d source docs + %d MT pairs",
+        len(all_overlap_strings),
+        len(seen_src),
+        n_mt_pairs,
+    )
+
+    if not all_overlap_strings:
+        LOG.warning("embed: no overlaps generated — nothing to embed")
+        done_file.touch()
+        return
+
+    # ------------------------------------------------------------------ #
+    # Pass 2 (GPU): batch-encode all overlaps, slice back to per-doc .npy #
+    # ------------------------------------------------------------------ #
+
+    try:
+        from laser_encoders import LaserEncoderPipeline
+    except ImportError as e:
+        raise ImportError("laser_encoders is required for the embed phase.") from e
+
+    laser_home = os.environ.get("LASER_HOME")
+    LOG.info("embed pass 2: loading LASER2 model from %s", laser_home)
+    model = LaserEncoderPipeline(laser="laser2", model_dir=laser_home)
+
+    n_total = len(all_overlap_strings)
+
+    # Sort overlaps by character length so each batch contains similarly-sized
+    # sequences.  This minimises padding waste inside LASER2's BiLSTM encoder
+    # and improves GPU utilisation.  We restore the original order afterwards.
+    # Sorting is deterministic: same input → same sort_idx on every run.
+    sort_idx = np.argsort([len(s) for s in all_overlap_strings])
+    restore_idx = np.empty(n_total, dtype=np.int64)
+    restore_idx[sort_idx] = np.arange(n_total)
+    sorted_overlaps = [all_overlap_strings[i] for i in sort_idx]
+
+    sorted_embeddings = np.empty((n_total, 1024), dtype=np.float32)
+
+    # Warm restart: if a checkpoint exists from a previous timed-out run, load
+    # it and resume encoding from where it left off.  The sort order is
+    # deterministic so no index file is needed — n_encoded is derived from the
+    # saved array shape.
+    checkpoint_file = inter_dir / "embed_checkpoint.npy"
+    n_encoded = 0
+    if checkpoint_file.exists():
+        try:
+            saved = np.load(str(checkpoint_file))
+            n_encoded = saved.shape[0]
+            sorted_embeddings[:n_encoded] = saved
+            del saved
+            LOG.info(
+                "embed pass 2: warm restart — resuming from %d / %d overlaps (%.1f%%)",
+                n_encoded,
+                n_total,
+                100.0 * n_encoded / n_total,
+            )
+        except Exception as exc:
+            LOG.warning("embed pass 2: checkpoint load failed (%s) — encoding from scratch", exc)
+            n_encoded = 0
+
+    # Save a checkpoint every ~10% of total overlaps so a timeout loses at most
+    # ~10% of work on the next restart.
+    checkpoint_every = max(embed_batch_size, n_total // 10)
+    next_checkpoint_at = ((n_encoded // checkpoint_every) + 1) * checkpoint_every
+
+    LOG.info(
+        "embed pass 2: encoding %d overlaps in batches of %d (length-sorted, checkpoint every %d)",
+        n_total - n_encoded,
+        embed_batch_size,
+        checkpoint_every,
+    )
+
+    for batch_start in range(n_encoded, n_total, embed_batch_size):
+        batch_end = min(batch_start + embed_batch_size, n_total)
+        sorted_embeddings[batch_start:batch_end] = model.encode_sentences(sorted_overlaps[batch_start:batch_end])
+        LOG.info(
+            "embed pass 2: encoded %d / %d overlaps (%.1f%%)",
+            batch_end,
+            n_total,
+            100.0 * batch_end / n_total,
+        )
+        if batch_end >= next_checkpoint_at:
+            np.save(str(checkpoint_file), sorted_embeddings[:batch_end])
+            LOG.info("embed pass 2: checkpoint saved at %d / %d overlaps", batch_end, n_total)
+            next_checkpoint_at = ((batch_end // checkpoint_every) + 1) * checkpoint_every
+
+    # Restore original order so overlap_index slicing stays correct.
+    all_embeddings = sorted_embeddings[restore_idx]
+    LOG.info("embed pass 2: encoding complete, slicing back to per-doc arrays")
+
+    # -- Slice source embeddings --
+    for doc_id in seen_src:
+        key = ("src", None, doc_id)
+        if key not in overlap_index:
+            continue
+        start, end = overlap_index[key]
+        np.save(str(embeds_src_dir / f"{doc_id}.npy"), all_embeddings[start:end])
+
+    # -- Slice MT embeddings --
+    for lang, doc_map in lang_doc_map.items():
+        embeds_mt_dir = inter_dir / "embeddings" / "mt" / lang
+        for doc_id in doc_map:
+            key = ("mt", lang, doc_id)
+            if key not in overlap_index:
+                continue
+            start, end = overlap_index[key]
+            np.save(str(embeds_mt_dir / f"{doc_id}.npy"), all_embeddings[start:end])
+
+    # Remove checkpoint now that all per-doc .npy files are written.
+    if checkpoint_file.exists():
+        checkpoint_file.unlink()
+        LOG.info("embed pass 2: checkpoint removed")
+
+    done_file.touch()
+    LOG.info("Embed phase complete. Sentinel: %s", done_file)
+
+
+def _align_lang_worker(work_item: dict) -> tuple[str, int]:
+    """Worker function for ProcessPoolExecutor: align one target language.
+
+    Loads pre-computed embeddings and overlaps from the embed phase, runs
+    vecalign per document, and writes aligned_spans.jsonl plus align.done.
+    Must be module-level so it is picklable by ProcessPoolExecutor.
+
+    Returns (lang, n_spans) on success; raises on failure.
+    """
+    import json as _json
+    import logging as _logging
+    import os as _os
+    from pathlib import Path as _Path
+
+    import numpy as _np
+
+    _log = _logging.getLogger(__name__)
+
+    lang: str = work_item["lang"]
+    doc_records: list[dict] = work_item["doc_records"]
+    embed_dir = _Path(work_item["embed_dir"])
+    align_lang_dir = _Path(work_item["align_lang_dir"])
+    segmenter: str = work_item["segmenter"]
+    judge_debug: bool = work_item["judge_debug"]
+
+    done_file = align_lang_dir / "align.done"
+    if done_file.exists():
+        _log.info("align: lang=%s already done — skipping", lang)
+        return lang, 0
+
+    align_lang_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        import segale_align as sa
+    except ImportError as e:
+        raise ImportError("segale_align could not be imported in align worker.") from e
+
+    sa.VERBOSE = 2 if judge_debug else 0
+    sa.SPACY = segmenter
+    sa.STOP_JUMP = 0.15
+    sa.COST_MIN = 0.30
+    sa.COST_MAX = 0.30
+
+    all_spans: list[dict] = []
+    for record in doc_records:
+        doc_id = record["doc_id"]
+
+        src_sents_file = embed_dir / "sentences" / "src" / f"{doc_id}.json"
+        src_overlap_file = embed_dir / "overlaps" / "src" / f"{doc_id}.json"
+        src_embed_file = embed_dir / "embeddings" / "src" / f"{doc_id}.npy"
+
+        if not src_sents_file.exists() or not src_embed_file.exists():
+            _log.warning("align: missing source data for doc_id=%s lang=%s — skipping", doc_id, lang)
+            continue
+
+        src_sentences = _json.loads(src_sents_file.read_text(encoding="utf-8"))["sentences"]
+        src_overlap = _json.loads(src_overlap_file.read_text(encoding="utf-8"))["overlaps"]
+        src_embed = _np.load(str(src_embed_file))
+
+        mt_sents_file = embed_dir / "sentences" / "mt" / lang / f"{doc_id}.json"
+        mt_overlap_file = embed_dir / "overlaps" / "mt" / lang / f"{doc_id}.json"
+        mt_embed_file = embed_dir / "embeddings" / "mt" / lang / f"{doc_id}.npy"
+
+        if not mt_sents_file.exists() or not mt_embed_file.exists():
+            _log.warning("align: missing MT data for doc_id=%s lang=%s — skipping", doc_id, lang)
+            continue
+
+        mt_sentences = _json.loads(mt_sents_file.read_text(encoding="utf-8"))["sentences"]
+        mt_overlap = _json.loads(mt_overlap_file.read_text(encoding="utf-8"))["overlaps"]
+        mt_embed = _np.load(str(mt_embed_file))
+
+        # Each doc gets its own temp folder to avoid vecalign file collisions.
+        save_folder = str(align_lang_dir / "vecalign_tmp" / doc_id)
+        _os.makedirs(save_folder, exist_ok=True)
+
+        src_mt_alignments = sa.run_vecalign_explore(
+            "\n".join(src_sentences),
+            "\n".join(mt_sentences),
+            "\n".join(src_overlap),
+            "\n".join(mt_overlap),
+            src_embed,
+            mt_embed,
+            doc_id,
+            save_folder,
+            max_size=8,
+        )
+
+        for seg_id, (src_indices, mt_indices) in enumerate(src_mt_alignments, start=1):
+            aligned_src = " ".join([src_sentences[i] for i in src_indices]) if src_indices else ""
+            aligned_mt = " ".join([mt_sentences[i] for i in mt_indices]) if mt_indices else ""
+            all_spans.append(
+                {
+                    "doc_id": doc_id,
+                    "src": aligned_src,
+                    "tgt": aligned_mt,
+                    "seg_id": seg_id,
+                }
+            )
+
+    with open(align_lang_dir / "aligned_spans.jsonl", "wt", encoding="utf-8") as fh:
+        for span in all_spans:
+            fh.write(_json.dumps(span, ensure_ascii=False) + "\n")
+
+    done_file.touch()
+    _log.info("align: lang=%s done (%d spans)", lang, len(all_spans))
+    return lang, len(all_spans)
+
+
+def _run_align_phase(
+    output_dir: Path,
+    segmenter: str,
+    judge_debug: bool = False,
+    target_languages: set[str] | None = None,
+):
+    """Phase 2 (CPU): Run vecalign alignment in parallel across all languages.
+
+    Reads pre-computed embeddings from the embed phase intermediate directory,
+    runs vecalign for every (language, doc_id) pair using all available CPUs,
+    and writes per-language aligned_spans.jsonl files.
+
+    No GPU is required.  Set CUDA_VISIBLE_DEVICES="" before invoking to prevent
+    torch from attempting to initialize the CUDA runtime.
+    """
+    from concurrent.futures import ProcessPoolExecutor, as_completed
+
+    inter_dir = output_dir / "segale_intermediate"
+    embed_dir = inter_dir / "embed"
+
+    if not (embed_dir / "embed.done").exists():
+        LOG.error("embed.done not found at %s — run embed phase first", embed_dir)
+        sys.exit(1)
+
+    with open(embed_dir / "doc_records.jsonl", "rt", encoding="utf-8") as f:
+        doc_records = [json.loads(line) for line in f if line.strip()]
+
+    lang_records: dict[str, list] = defaultdict(list)
+    for r in doc_records:
+        lang = r.get("target_language", "unknown")
+        lang_records[lang].append(r)
+
+    if target_languages:
+        lang_records = {lang: rs for lang, rs in lang_records.items() if lang in target_languages}
+
+    all_langs = sorted(lang_records.keys())
+    langs_to_process = [lang for lang in all_langs if not (inter_dir / "align" / lang / "align.done").exists()]
+    skipped = len(all_langs) - len(langs_to_process)
+    if skipped:
+        LOG.info("align: %d languages already complete — skipping", skipped)
+
+    if not langs_to_process:
+        LOG.info("align: all %d languages already complete", len(all_langs))
+        return
+
+    n_workers = min(os.cpu_count() or 1, len(langs_to_process))
+    LOG.info("align: processing %d languages with %d CPU workers", len(langs_to_process), n_workers)
+
+    work_items = [
+        {
+            "lang": lang,
+            "doc_records": lang_records[lang],
+            "embed_dir": str(embed_dir),
+            "align_lang_dir": str(inter_dir / "align" / lang),
+            "segmenter": segmenter,
+            "judge_debug": judge_debug,
+        }
+        for lang in langs_to_process
+    ]
+
+    failed: list[str] = []
+    with ProcessPoolExecutor(max_workers=n_workers) as executor:
+        future_to_lang = {executor.submit(_align_lang_worker, item): item["lang"] for item in work_items}
+        for future in as_completed(future_to_lang):
+            lang = future_to_lang[future]
+            try:
+                _, n_spans = future.result()
+                LOG.info("align: lang=%s finished (%d spans)", lang, n_spans)
+            except Exception as exc:
+                LOG.error("align: lang=%s failed: %s", lang, exc)
+                failed.append(lang)
+
+    if failed:
+        LOG.error("Align phase failed for: %s", failed)
+        sys.exit(1)
+
+    LOG.info("Align phase complete for all %d languages", len(langs_to_process))
+
+
+def _run_score_phase(
+    input_file: Path,
+    output_dir: Path,
+    target_languages: set[str] | None = None,
+    save_spans: bool = False,
+):
+    """Phase 3 (GPU): Batch-score aligned spans with COMET-QE and MetricX-QE.
+
+    Loads all aligned spans across all languages from the align phase, scores
+    them together in a single GPU batch for maximum utilization, aggregates
+    scores to document level, and writes per-language output.jsonl files
+    (same structure consumed by the existing merge step).
+    """
+    try:
+        from segale_eval import run_comet_qe_evaluation, run_metricx_qe_evaluation
+    except ImportError as e:
+        raise ImportError("segale_eval could not be imported. Ensure the SEGALE package is installed.") from e
+
+    inter_dir = output_dir / "segale_intermediate"
+    align_dir = inter_dir / "align"
+    per_lang_base = output_dir / "per_lang"
+
+    # Load original records so scores can be patched back in.
+    with open(input_file, "rt", encoding="utf-8") as f:
+        orig_records = [json.loads(line) for line in f if line.strip()]
+
+    # Determine which languages have completed alignment.
+    if align_dir.exists():
+        available_langs = sorted(d.name for d in align_dir.iterdir() if d.is_dir() and (d / "align.done").exists())
+    else:
+        available_langs = []
+
+    if target_languages:
+        available_langs = [lang for lang in available_langs if lang in target_languages]
+
+    if not available_langs:
+        LOG.warning("score: no completed align languages found in %s", align_dir)
+        return
+
+    # Load aligned spans from each language, tracking which span belongs to which lang.
+    lang_spans: dict[str, list[dict]] = {}
+    for lang in available_langs:
+        spans_file = align_dir / lang / "aligned_spans.jsonl"
+        if not spans_file.exists():
+            LOG.warning("score: aligned_spans.jsonl missing for lang=%s — skipping", lang)
+            continue
+        spans: list[dict] = []
+        with open(spans_file, "rt", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    spans.append(json.loads(line))
+        if spans:
+            lang_spans[lang] = spans
+        else:
+            LOG.warning("score: empty aligned_spans.jsonl for lang=%s — skipping", lang)
+
+    # Flatten all spans into one list for a single GPU batch call.
+    all_spans: list[dict] = []
+    all_span_langs: list[str] = []
+    for lang, spans in lang_spans.items():
+        for span in spans:
+            all_spans.append(span)
+            all_span_langs.append(lang)
+
+    if not all_spans:
+        LOG.warning("score: no aligned spans to score across any language")
+        return
+
+    LOG.info("score: scoring %d spans across %d languages", len(all_spans), len(lang_spans))
+
+    # Single GPU batch for COMET-QE and MetricX-QE.
+    qe_windows = [(s["src"], s["tgt"]) for s in all_spans]
+    comet_qe_scores = run_comet_qe_evaluation(qe_windows)
+    metricx_qe_scores = run_metricx_qe_evaluation(qe_windows)
+
+    for idx, span in enumerate(all_spans):
+        span["comet-qe"] = comet_qe_scores[idx]
+        span["metricx-qe"] = metricx_qe_scores[idx]
+
+    # Compute language fidelity per (doc_id, lang) from original records.
+    # In the fan-out format (document_translation.py), only the first record per
+    # document carries the full generation; all later records have generation="".
+    # Preserve the first non-empty generation to avoid fidelity always collapsing to 1.0.
+    # Result: one entry per (doc_id, target_language) pair — e.g. ~9 350 keys for
+    # wmt24pp.doc (170 docs × 55 langs) or 55 keys for wmt24pp.long (1 mega-doc × 55 langs).
+    orig_by_key: dict[tuple[str, str], dict] = {}
+    for r in orig_records:
+        if "doc_id" in r:
+            key = (r["doc_id"], r.get("target_language", ""))
+            if key not in orig_by_key or (r.get("generation") and not orig_by_key[key].get("generation")):
+                orig_by_key[key] = r
+
+    doc_lang_fidelity: dict[tuple[str, str], float] = {}
+    seen_pairs: set[tuple[str, str]] = set()
+    for span, lang in zip(all_spans, all_span_langs):
+        key = (span["doc_id"], lang)
+        if key in seen_pairs:
+            continue
+        seen_pairs.add(key)
+        rec = orig_by_key.get(key)
+        if rec:
+            ref_text = " ".join(rec.get("reference_sentences", []))
+            fidelity = _compute_lang_fidelity(rec.get("generation", ""), ref_text) if ref_text else 1.0
+        else:
+            fidelity = 1.0
+        doc_lang_fidelity[key] = fidelity
+
+    # Aggregate spans to document-level scores and write per-language outputs.
+    for lang, spans in lang_spans.items():
+        grouped: dict[str, list] = defaultdict(list)
+        for span in spans:
+            grouped[span["doc_id"]].append(span)
+
+        doc_scores: dict[str, dict] = {}
+        for doc_id, doc_spans in grouped.items():
+            valid_comet_qe = [s["comet-qe"] for s in doc_spans if s["comet-qe"] >= 0]
+            valid_metricx_qe = [s["metricx-qe"] for s in doc_spans if s["metricx-qe"] >= 0]
+            fidelity = doc_lang_fidelity.get((doc_id, lang), 1.0)
+            doc_scores[doc_id] = {
+                "segale_comet_qe": (sum(valid_comet_qe) / len(valid_comet_qe) if valid_comet_qe else 0.0),
+                "segale_metricx_qe": (sum(valid_metricx_qe) / len(valid_metricx_qe) if valid_metricx_qe else 0.0),
+                "segale_lang_fidelity": fidelity,
+                "segale_total_seg": len(doc_spans),
+                "segale_misaligned_seg": sum(1 for s in doc_spans if s["comet-qe"] <= 0),
+            }
+
+        lang_out_dir = per_lang_base / lang
+        lang_out_dir.mkdir(parents=True, exist_ok=True)
+        lang_out_file = lang_out_dir / "output.jsonl"
+
+        lang_orig = [r for r in orig_records if r.get("target_language") == lang]
+        for record in lang_orig:
+            doc_id = record.get("doc_id")
+            if doc_id and doc_id in doc_scores:
+                record.update(doc_scores[doc_id])
+
+        with open(lang_out_file, "wt", encoding="utf-8") as f:
+            for record in lang_orig:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+        Path(str(lang_out_file) + ".done").touch()
+        LOG.info("score: wrote %s (%d records, %d docs scored)", lang_out_file, len(lang_orig), len(doc_scores))
+
+        if save_spans:
+            per_lang_spans = []
+            for doc_id, doc_spans in sorted(grouped.items()):
+                sorted_spans = sorted(doc_spans, key=lambda s: s.get("seg_id", 0))
+                per_lang_spans.append(
+                    {
+                        "doc_id": doc_id,
+                        "lang": lang,
+                        "spans": [
+                            {
+                                "comet_qe": s["comet-qe"],
+                                "metricx_qe": s["metricx-qe"],
+                                "deleted": not s.get("tgt"),
+                                "hallucinated": not s.get("src"),
+                            }
+                            for s in sorted_spans
+                        ],
+                    }
+                )
+            spans_file = lang_out_dir / "spans.jsonl"
+            with open(spans_file, "wt", encoding="utf-8") as f:
+                for rec in per_lang_spans:
+                    f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            LOG.info("score: wrote per-span scores to %s (%d docs)", spans_file, len(per_lang_spans))
+
+    LOG.info("Score phase complete for %d languages", len(lang_spans))
+
+
+_SEGALE_SCORE_KEYS = frozenset(
+    {
+        "segale_comet",
+        "segale_comet_qe",
+        "segale_metricx",
+        "segale_metricx_qe",
+        "segale_bleu",
+        "segale_lang_fidelity",
+        "segale_total_seg",
+        "segale_misaligned_seg",
+    }
+)
+
+
+def merge_per_language_outputs(
+    original_input: Path,
+    langs_dir: Path,
+    output_file: Path,
+):
+    """Merge per-language scored outputs back into the original record order.
+
+    Each per-language judge task writes its scored records to
+    ``<langs_dir>/<target_language>/output.jsonl``.  This function reads the
+    original input file to recover global record order, builds a score map
+    keyed by ``(doc_id, seg_id, target_language)``, patches those scores into
+    the original records, and writes the final combined output.
+    """
+    with open(original_input, "rt", encoding="utf-8") as f:
+        original_records = [json.loads(line) for line in f if line.strip()]
+
+    score_map: dict[tuple, dict] = {}
+    for lang_file in sorted(langs_dir.glob("*/output.jsonl")):
+        with open(lang_file, "rt", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                r = json.loads(line)
+                if "doc_id" in r:
+                    key = (r["doc_id"], r.get("seg_id"), r.get("target_language", ""))
+                    scores = {k: v for k, v in r.items() if k in _SEGALE_SCORE_KEYS}
+                    if scores:
+                        score_map[key] = scores
+
+    if not score_map:
+        LOG.warning(
+            "merge: no scored records found in %s — upstream judge jobs likely failed or timed out. "
+            "Preserving intermediate files for next attempt.",
+            langs_dir,
+        )
+        return
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_file, "wt", encoding="utf-8") as f:
+        for record in original_records:
+            if "doc_id" in record:
+                key = (record["doc_id"], record.get("seg_id"), record.get("target_language", ""))
+                if key in score_map:
+                    record.update(score_map[key])
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    LOG.info("Merged per-language outputs into %s (%d scored records)", output_file, len(score_map))
+
+    spans_parts = sorted(langs_dir.glob("*/spans.jsonl"))
+    if spans_parts:
+        combined_spans = output_file.parent / "spans.jsonl"
+        with open(combined_spans, "wt", encoding="utf-8") as fout:
+            for part in spans_parts:
+                with open(part, "rt", encoding="utf-8") as fin:
+                    for line in fin:
+                        if line.strip():
+                            fout.write(line)
+        LOG.info("Merged per-language spans into %s (%d languages)", combined_spans, len(spans_parts))
+
+    Path(str(output_file) + ".done").touch()
+
+    # Clean up intermediate files now that the scored output is complete.
+    # segale_intermediate (embeddings + aligned spans) lives alongside per_lang/
+    # in the judge/ subdirectory — langs_dir.parent is that judge/ dir.
+    inter_dir = langs_dir.parent / "segale_intermediate"
+    if inter_dir.exists():
+        shutil.rmtree(inter_dir)
+        LOG.info("Removed intermediate directory %s", inter_dir)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run SEGALE document-level MT evaluation (3-phase pipeline)")
+    parser.add_argument(
+        "--input-file", type=str, help="Path to the input output.jsonl (required for embed and score modes)"
+    )
+    parser.add_argument("--output-dir", type=str, required=True, help="Path to output directory")
+    parser.add_argument(
+        "--segmenter",
+        type=str,
+        choices=["spacy", "ersatz"],
+        default="ersatz",
+        help="Sentence segmenter for source and MT text (default: ersatz)",
+    )
+    parser.add_argument(
+        "--judge-debug",
+        action="store_true",
+        default=False,
+        help="Debug mode: process only the first 2 documents.",
+    )
+    parser.add_argument(
+        "--target-languages",
+        type=str,
+        default=None,
+        help="Comma-separated target_language values to process (e.g. 'de_Latn,fr_Latn'). "
+        "Default: all languages found in the input.",
+    )
+    parser.add_argument(
+        "--merge-input",
+        type=str,
+        default=None,
+        help="Original input file path (merge mode only).",
+    )
+    parser.add_argument(
+        "--merge-langs-dir",
+        type=str,
+        default=None,
+        help="Directory containing per-language subdirs to merge (merge mode only).",
+    )
+    parser.add_argument(
+        "--output-file",
+        type=str,
+        default=None,
+        help="Output file path for merge mode (required for merge).",
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=["embed", "align", "score"],
+        default=None,
+        help="Phase to run: 'embed' (GPU, segment+embed), "
+        "'align' (CPU, vecalign in parallel), or 'score' (GPU, COMET-QE/MetricX-QE).",
+    )
+    parser.add_argument(
+        "--embed-batch-size",
+        type=int,
+        default=512,
+        help="Number of overlap strings per LASER2 encode_sentences() call during embed phase "
+        "(default: 512). Increase for more GPU memory, decrease if OOM.",
+    )
+    parser.add_argument(
+        "--save-spans",
+        action="store_true",
+        default=False,
+        help="Write per-span scores to spans.jsonl in each per_lang/<lang>/ dir during "
+        "the score phase. The merge phase automatically combines them into spans.jsonl "
+        "next to metrics.json when the files are present.",
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    tgt_langs = set(args.target_languages.split(",")) if args.target_languages else None
+
+    if args.mode == "embed":
+        if not args.input_file:
+            LOG.error("--input-file is required for --mode embed")
+            sys.exit(1)
+        _run_embed_phase(
+            input_file=Path(args.input_file),
+            output_dir=output_dir,
+            segmenter=args.segmenter,
+            judge_debug=args.judge_debug,
+            target_languages=tgt_langs,
+            embed_batch_size=args.embed_batch_size,
+        )
+
+    elif args.mode == "align":
+        _run_align_phase(
+            output_dir=output_dir,
+            segmenter=args.segmenter,
+            judge_debug=args.judge_debug,
+            target_languages=tgt_langs,
+        )
+
+    elif args.mode == "score":
+        if not args.input_file:
+            LOG.error("--input-file is required for --mode score")
+            sys.exit(1)
+        _run_score_phase(
+            input_file=Path(args.input_file),
+            output_dir=output_dir,
+            target_languages=tgt_langs,
+            save_spans=args.save_spans,
+        )
+
+    elif args.merge_input and args.merge_langs_dir:
+        if not args.output_file:
+            LOG.error("--output-file is required for merge mode")
+            sys.exit(1)
+        merge_per_language_outputs(
+            original_input=Path(args.merge_input),
+            langs_dir=Path(args.merge_langs_dir),
+            output_file=Path(args.output_file),
+        )
+
+    else:
+        LOG.error("Specify --mode {embed,align,score} or --merge-input/--merge-langs-dir.")
+        sys.exit(1)
+
+    LOG.info("All files processed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_skills/evaluation/metrics/translation_metrics.py
+++ b/nemo_skills/evaluation/metrics/translation_metrics.py
@@ -31,15 +31,27 @@ def install_packages(lang):
     )
 
 
-class TranslationMetrics(BaseMetrics):
-    # TODO: add support for other translation metrics, such as MetricX
+SEGALE_FIELDS = [
+    "segale_comet",
+    "segale_comet_qe",
+    "segale_metricx",
+    "segale_metricx_qe",
+    "segale_bleu",
+    "segale_lang_fidelity",
+]
+# Count fields are summed across documents (not averaged) so that
+# misalignment rate = segale_misaligned_seg / segale_total_seg is meaningful.
+SEGALE_COUNT_FIELDS = ["segale_total_seg", "segale_misaligned_seg"]
 
+
+class TranslationMetrics(BaseMetrics):
     def get_metrics(self):
         metrics_dict = {}
-        for key in self.translation_dict:
-            src_lang, tgt_lang = key.split("->")
-            preds = self.translation_dict[key]["preds"]
-            gts = self.translation_dict[key]["gts"]
+        num_seeds = 0
+        for lang_pair in self.translation_dict:
+            src_lang, tgt_lang = lang_pair.split("->")
+            preds = self.translation_dict[lang_pair]["preds"]
+            gts = self.translation_dict[lang_pair]["gts"]
 
             num_seeds = len(preds[0]) if preds else 0
 
@@ -59,28 +71,58 @@ class TranslationMetrics(BaseMetrics):
                 ground_truths = [gt[i] for gt in gts]
                 bleu_scores.append(corpus_bleu(predictions, [ground_truths], tokenize=tokenize).score)
 
-            metrics_dict[key] = {"bleu": bleu_scores}
+            metrics_dict[lang_pair] = {"bleu": bleu_scores}
             self.bleu_aggregation_dict["xx->xx"].append(bleu_scores)
             self.bleu_aggregation_dict[f"{src_lang}->xx"].append(bleu_scores)
             self.bleu_aggregation_dict[f"xx->{tgt_lang}"].append(bleu_scores)
 
-            if "comets" in self.translation_dict[key]:
-                comets = list(zip(*self.translation_dict[key]["comets"]))
+            if "comets" in self.translation_dict[lang_pair]:
+                comets = list(zip(*self.translation_dict[lang_pair]["comets"]))
                 comet_scores = [np.mean(comets[i]) for i in range(num_seeds)]
-                metrics_dict[key]["comet"] = comet_scores
+                metrics_dict[lang_pair]["comet"] = comet_scores
                 self.comet_aggregation_dict["xx->xx"].append(comet_scores)
                 self.comet_aggregation_dict[f"{src_lang}->xx"].append(comet_scores)
                 self.comet_aggregation_dict[f"xx->{tgt_lang}"].append(comet_scores)
 
-        for key in self.bleu_aggregation_dict:
-            bleus = list(zip(*self.bleu_aggregation_dict[key]))
-            bleu_scores = [np.mean(bleus[i]) for i in range(num_seeds)]
-            metrics_dict[key] = {"bleu": bleu_scores}
+            for field in SEGALE_FIELDS:
+                storage_key = field + "s"
+                if storage_key in self.translation_dict[lang_pair]:
+                    scores = list(zip(*self.translation_dict[lang_pair][storage_key]))
+                    field_scores = [np.mean(scores[i]) for i in range(num_seeds)]
+                    metrics_dict[lang_pair][field] = field_scores
+                    self.segale_aggregation_dicts[field]["xx->xx"].append(field_scores)
+                    self.segale_aggregation_dicts[field][f"{src_lang}->xx"].append(field_scores)
+                    self.segale_aggregation_dicts[field][f"xx->{tgt_lang}"].append(field_scores)
 
-            if self.comet_aggregation_dict:
-                comets = list(zip(*self.comet_aggregation_dict[key]))
+            for field in SEGALE_COUNT_FIELDS:
+                storage_key = field + "s"
+                if storage_key in self.translation_dict[lang_pair]:
+                    counts = list(zip(*self.translation_dict[lang_pair][storage_key]))
+                    field_counts = [np.sum(counts[i]) for i in range(num_seeds)]
+                    metrics_dict[lang_pair][field] = field_counts
+                    self.segale_count_aggregation_dicts[field]["xx->xx"].append(field_counts)
+                    self.segale_count_aggregation_dicts[field][f"{src_lang}->xx"].append(field_counts)
+                    self.segale_count_aggregation_dicts[field][f"xx->{tgt_lang}"].append(field_counts)
+
+        for lang_pair in self.bleu_aggregation_dict:
+            bleus = list(zip(*self.bleu_aggregation_dict[lang_pair]))
+            bleu_scores = [np.mean(bleus[i]) for i in range(num_seeds)]
+            metrics_dict[lang_pair] = {"bleu": bleu_scores}
+
+            if self.comet_aggregation_dict.get(lang_pair):
+                comets = list(zip(*self.comet_aggregation_dict[lang_pair]))
                 comet_scores = [np.mean(comets[i]) for i in range(num_seeds)]
-                metrics_dict[key]["comet"] = comet_scores
+                metrics_dict[lang_pair]["comet"] = comet_scores
+
+            for field in SEGALE_FIELDS:
+                if self.segale_aggregation_dicts[field].get(lang_pair):
+                    scores = list(zip(*self.segale_aggregation_dicts[field][lang_pair]))
+                    metrics_dict[lang_pair][field] = [np.mean(scores[i]) for i in range(num_seeds)]
+
+            for field in SEGALE_COUNT_FIELDS:
+                if self.segale_count_aggregation_dicts[field].get(lang_pair):
+                    counts = list(zip(*self.segale_count_aggregation_dicts[field][lang_pair]))
+                    metrics_dict[lang_pair][field] = [np.sum(counts[i]) for i in range(num_seeds)]
 
         self._add_std_metrics(metrics_dict)
 
@@ -91,12 +133,28 @@ class TranslationMetrics(BaseMetrics):
             metrics_list = ["bleu"]
             if "comet" in metrics_dict[key]:
                 metrics_list.append("comet")
+            for field in SEGALE_FIELDS:
+                if field in metrics_dict[key]:
+                    metrics_list.append(field)
 
             for metric in metrics_list:
                 avg = np.mean(metrics_dict[key][metric])
                 std = np.std(metrics_dict[key][metric])
-
                 metrics_dict[key].update({metric: avg, f"{metric}_statistics": {"std_dev_across_runs": std}})
+
+            # Count fields: collapse multi-seed list to a single value (sum).
+            # std_dev is not meaningful for segment counts.
+            for field in SEGALE_COUNT_FIELDS:
+                if field in metrics_dict[key]:
+                    metrics_dict[key][field] = int(np.sum(metrics_dict[key][field]))
+
+            # Misalignment rate: fraction of spans flagged as misaligned.
+            total = metrics_dict[key].get("segale_total_seg", 0)
+            misaligned = metrics_dict[key].get("segale_misaligned_seg", 0)
+            if total > 0:
+                metrics_dict[key]["segale_misalignment_rate"] = misaligned / total
+            else:
+                metrics_dict[key]["segale_misalignment_rate"] = None
 
     def update(self, predictions):
         """Updating the evaluation results with the current element.
@@ -108,6 +166,8 @@ class TranslationMetrics(BaseMetrics):
         super().update(predictions)
 
         generations, ground_truths, comets = [], [], []
+        segale_scores = {field: [] for field in SEGALE_FIELDS}
+        segale_counts = {field: [] for field in SEGALE_COUNT_FIELDS}
         for pred in predictions:
             src_lang = pred["source_language"]
             tgt_lang = pred["target_language"]
@@ -117,21 +177,53 @@ class TranslationMetrics(BaseMetrics):
                 generation = ""
 
             generations.append(generation)
-            ground_truths.append(pred["translation"])
+            if "translation" in pred:
+                ground_truth = pred["translation"]
+            elif "reference_sentences" in pred:
+                ground_truth = " ".join(pred["reference_sentences"])
+            else:
+                raise KeyError("Expected 'translation' or 'reference_sentences' in prediction record")
+            ground_truths.append(ground_truth)
             if "comet" in pred:
                 comets.append(pred["comet"] * 100)
+            # SEGALE writes the same doc-level score to every sentence record in
+            # a document. Collect once per doc_id to avoid inflating averages.
+            # Records without doc_id are sentence-level data — SEGALE does not
+            # apply to them.
+            doc_id = pred.get("doc_id")
+            seen_key = (src_lang, tgt_lang, doc_id)
+            if doc_id and seen_key not in self.seen_doc_ids:
+                self.seen_doc_ids.add(seen_key)
+                for field in SEGALE_FIELDS:
+                    if field in pred:
+                        segale_scores[field].append(pred[field])
+                for field in SEGALE_COUNT_FIELDS:
+                    if field in pred:
+                        segale_counts[field].append(pred[field])
 
-        self.translation_dict[f"{src_lang}->{tgt_lang}"]["preds"].append(generations)
-        self.translation_dict[f"{src_lang}->{tgt_lang}"]["gts"].append(ground_truths)
+        lang_pair = f"{src_lang}->{tgt_lang}"
+        self.translation_dict[lang_pair]["preds"].append(generations)
+        self.translation_dict[lang_pair]["gts"].append(ground_truths)
 
-        if "comet" in pred:
-            self.translation_dict[f"{src_lang}->{tgt_lang}"]["comets"].append(comets)
+        if len(comets) > 0:
+            self.translation_dict[lang_pair]["comets"].append(comets)
+
+        for field, values in segale_scores.items():
+            if values:
+                self.translation_dict[lang_pair][field + "s"].append(values)
+
+        for field, values in segale_counts.items():
+            if values:
+                self.translation_dict[lang_pair][field + "s"].append(values)
 
     def reset(self):
         super().reset()
         self.translation_dict = defaultdict(lambda: defaultdict(list))
         self.bleu_aggregation_dict = defaultdict(list)
         self.comet_aggregation_dict = defaultdict(list)
+        self.seen_doc_ids = set()
+        self.segale_aggregation_dicts = {field: defaultdict(list) for field in SEGALE_FIELDS}
+        self.segale_count_aggregation_dicts = {field: defaultdict(list) for field in SEGALE_COUNT_FIELDS}
 
     def evaluations_to_print(self):
         """Returns all translation pairs and aggregated multilingual dictionaries."""
@@ -139,4 +231,11 @@ class TranslationMetrics(BaseMetrics):
 
     def metrics_to_print(self):
         metrics_to_print = {"bleu": as_float, "comet": as_float}
+        metrics_to_print.update({field: as_float for field in SEGALE_FIELDS})
+        metrics_to_print.update({field: as_float for field in SEGALE_COUNT_FIELDS})
+
+        def as_float_or_none(key, value, all_metrics):
+            return None if value is None else as_float(key, value, all_metrics)
+
+        metrics_to_print["segale_misalignment_rate"] = as_float_or_none
         return metrics_to_print

--- a/nemo_skills/inference/document_translation.py
+++ b/nemo_skills/inference/document_translation.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DocumentTranslationTask: groups sentence records by doc_id, sends the full
+document as a single natural-prose string to the model, then fans the result
+back out to per-sentence records (full generation on seg_id=0, "" on rest).
+
+This is designed for use with wmt24pp and any other benchmark that provides
+doc_id and seg_id fields. SEGALE's judge script reads the output.jsonl and
+expects this exact format.
+"""
+
+import json
+import logging
+import random
+import re
+import sys
+from pathlib import Path
+
+import hydra
+
+from nemo_skills.code_execution.sandbox import sandbox_params
+from nemo_skills.inference.generate import GenerationTask, GenerationTaskConfig
+from nemo_skills.inference.model import server_params
+from nemo_skills.utils import get_help_message, get_logger_name, setup_logging
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+
+class DocumentTranslationTask(GenerationTask):
+    """GenerationTask subclass for document-level MT.
+
+    Input: one record per source sentence (with doc_id and seg_id fields).
+
+    Processing:
+      - preprocess_data groups sentences by doc_id, joins source sentences with
+        a space into natural prose, and presents each document as a single
+        generation request.
+      - restore_async_order fans the model's document-level output back out to
+        per-sentence records: full generation stored on seg_id=0, "" on all
+        subsequent records within the same document.
+
+    This matches the format expected by segale_judge.py:
+      seg_id=0: generation = full document translation string
+      seg_id>0: generation = "" (ignored by SEGALE; source/reference used instead)
+    """
+
+    def skip_completed_samples(self, data):
+        # Build a map from each sentence's index to its (doc_id, target_language)
+        # key so that when a completed doc's sentinel position (sentence[0]'s idx)
+        # is found in the async file, we can mark ALL sentences in that doc as
+        # filled — not just sentence[0].  The base class only records sentence[0]'s
+        # position in the async file, so without this override the other sentences
+        # of already-translated docs would be re-submitted on resume.
+        doc_to_indices = {}  # (doc_id, tgt_lang) -> sorted list of (seg_id, idx)
+        for idx, record in enumerate(data):
+            key = (record["doc_id"], record["target_language"])
+            if key not in doc_to_indices:
+                doc_to_indices[key] = []
+            doc_to_indices[key].append((record["seg_id"], idx))
+        for key in doc_to_indices:
+            doc_to_indices[key].sort()  # sort by seg_id so index 0 is sentence[0]
+
+        # Map from sentence[0]'s idx -> set of ALL indices in that doc.
+        sentinel_to_all = {}
+        for key, seg_idx_pairs in doc_to_indices.items():
+            sentinel_idx = seg_idx_pairs[0][1]  # idx of the lowest-seg_id sentence
+            all_indices = {idx for _, idx in seg_idx_pairs}
+            sentinel_to_all[sentinel_idx] = all_indices
+
+        # Let the base class read filled sentinel positions from the async file,
+        # then expand each sentinel to cover every sentence in its document.
+        remaining = super().skip_completed_samples(data)
+        if not self.cfg.skip_filled:
+            return remaining
+
+        # Determine which sentinel positions were already filled.
+        filled_sentinels = set()
+        try:
+            with open(self.cfg.output_file + "-async", "rt", encoding="utf-8") as fin:
+                for line in fin:
+                    pos = int(json.loads(line)[self.cfg.async_position_key])
+                    if pos in sentinel_to_all:
+                        filled_sentinels.add(pos)
+        except FileNotFoundError:
+            pass
+
+        if not filled_sentinels:
+            return remaining
+
+        # Expand: all sentence indices belonging to filled docs.
+        all_filled = set()
+        for sentinel in filled_sentinels:
+            all_filled |= sentinel_to_all[sentinel]
+
+        # Re-filter: keep only records whose original index is not fully filled.
+        return [dp for dp in remaining if dp[self.cfg.async_position_key] not in all_filled]
+
+    def preprocess_data(self, data):
+        # Filter by target_languages if specified.
+        target_languages = self.cfg.target_languages
+        if target_languages:
+            available_languages = {r["target_language"] for r in data if "target_language" in r}
+            missing_languages = sorted(set(target_languages) - available_languages)
+            if missing_languages:
+                raise ValueError(
+                    f"Unsupported target_languages={missing_languages}; "
+                    f"available languages: {sorted(available_languages)}"
+                )
+            data = [r for r in data if r["target_language"] in target_languages]
+            if not data:
+                raise ValueError(f"No records found for target_languages={target_languages}")
+            LOG.info("Filtered to %d records for languages: %s", len(data), target_languages)
+
+        # Group sentence records by (doc_id, target_language), preserving document
+        # order. Keying on both fields is necessary when a single test.jsonl contains
+        # multiple languages that share the same doc_id (e.g. wmt24pp.doc).
+        docs = {}  # (doc_id, target_language) -> list of sentence records
+        for record in data:
+            key = (record["doc_id"], record["target_language"])
+            if key not in docs:
+                docs[key] = []
+            docs[key].append(record)
+
+        # Sort each document's sentences by seg_id.
+        for key in docs:
+            docs[key].sort(key=lambda r: r["seg_id"])
+
+        # Save for use in restore_async_order.
+        self._doc_records = docs
+        self._doc_order = list(docs.keys())
+
+        # Build one record per document.
+        # Join source sentences with a space so the input reads as natural prose.
+        # Newlines would give the model artificial sentence boundary hints,
+        # defeating SEGALE's alignment step.
+        #
+        # For long-context records (identified by a "doc_groups" field), shuffle
+        # document order when the output file carries a random-seed suffix (-rsN).
+        # This creates statistically independent runs across seeds while keeping
+        # canonical ordering for the default single-seed case.
+        is_seeded_run = bool(re.search(r"-rs\d+", Path(self.cfg.output_file).name))
+
+        doc_records = []
+        for key in self._doc_order:
+            sentences = docs[key]
+            doc_record = dict(sentences[0])
+
+            if is_seeded_run and "doc_groups" in doc_record:
+                seed = self.cfg.inference.random_seed
+                groups = list(doc_record["doc_groups"])
+                random.Random(seed).shuffle(groups)
+                doc_record["source_sentences"] = [s for g in groups for s in g["source_sentences"]]
+                doc_record["reference_sentences"] = [s for g in groups for s in g["reference_sentences"]]
+                doc_record["text"] = " ".join(doc_record["source_sentences"])
+            else:
+                doc_record["text"] = " ".join(r["text"] for r in sentences)
+
+            doc_records.append(doc_record)
+
+        return doc_records
+
+    def restore_async_order(self):
+        # Read document-level outputs from the async file.
+        with open(self.cfg.output_file + "-async", "rt", encoding="utf-8") as fin:
+            doc_outputs = [json.loads(line) for line in fin]
+
+        # Sort by async position to recover document order.
+        # Positions are inherited from the original sentence-level indices set by
+        # skip_completed_samples() before preprocess_data() runs, so they are not
+        # necessarily 0..N-1 — sort by value rather than using as a direct index.
+        ordered = sorted(doc_outputs, key=lambda d: d[self.cfg.async_position_key])
+        for d in ordered:
+            d.pop(self.cfg.async_position_key)
+
+        generation_key = self.cfg.generation_key
+
+        # Rebuild sentence-level records from the original input file.
+        # We cannot rely on self._doc_records/_doc_order here because preprocess_data
+        # is called with only the *remaining* (unfinished) documents — on a resume run
+        # those dicts cover a subset of the async file, causing an IndexError when
+        # restore_async_order tries to index beyond len(_doc_order).
+        with open(self.cfg.input_file, "rt", encoding="utf-8") as fin:
+            all_sentences = [json.loads(line) for line in fin if line.strip()]
+
+        input_docs = {}
+        for record in all_sentences:
+            key = (record["doc_id"], record["target_language"])
+            if key not in input_docs:
+                input_docs[key] = []
+            input_docs[key].append(record)
+        for key in input_docs:
+            input_docs[key].sort(key=lambda r: r["seg_id"])
+
+        # Fan out: one document output -> N per-sentence records.
+        with open(self.cfg.output_file, "wt", encoding="utf-8") as fout:
+            for doc_output in ordered:
+                key = (doc_output["doc_id"], doc_output["target_language"])
+                sentences = input_docs[key]
+                doc_generation = doc_output[generation_key]
+
+                for i, sentence in enumerate(sentences):
+                    # Start from the original per-sentence record so that
+                    # fields like text, seg_id, translation are preserved correctly.
+                    record = dict(sentence)
+                    record[generation_key] = doc_generation if i == 0 else ""
+                    # For long-context records, preprocess_data may have shuffled
+                    # doc_groups and written shuffled text/source_sentences/reference_sentences
+                    # into the async record. Propagate them so SEGALE embeds source text in
+                    # the same order as the model's actual input.
+                    # "text" is only propagated when the fan-out is 1-to-1 (one sentence per
+                    # doc): in the sentence-level fan-out case each sentence has its own
+                    # per-sentence source text that must not be overwritten with the full
+                    # concatenated doc text.
+                    if i == 0:
+                        fields = ("source_sentences", "reference_sentences")
+                        if len(sentences) == 1:
+                            fields = ("text",) + fields
+                        for field in fields:
+                            if field in doc_output:
+                                record[field] = doc_output[field]
+                    fout.write(json.dumps(record) + "\n")
+
+        Path(self.cfg.output_file + "-async").unlink()
+        self.cleanup_litellm_cache()
+
+    def generate(self):
+        super().generate()
+        # If the async file still exists after generate(), it means skip_completed_samples
+        # returned empty (all docs already done), async_loop was skipped entirely, and
+        # restore_async_order was never called. Reconstruct and fan out now.
+        async_file = Path(self.cfg.output_file + "-async")
+        if async_file.exists():
+            LOG.info(
+                "Async file present after generate(); all docs were pre-filled. "
+                "Calling restore_async_order to complete fan-out."
+            )
+            self.restore_async_order()
+
+
+GENERATION_TASK_CLASS = DocumentTranslationTask
+
+
+@hydra.main(version_base=None, config_name="base_generation_config")
+def generate(cfg: GenerationTaskConfig):
+    cfg = GenerationTaskConfig(_init_nested=True, **cfg)
+    LOG.info("Config used: %s", cfg)
+    task = DocumentTranslationTask(cfg)
+    task.generate()
+
+
+HELP_MESSAGE = get_help_message(
+    GenerationTaskConfig,
+    server_params=server_params(),
+    sandbox_params=sandbox_params(),
+)
+
+if __name__ == "__main__":
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print(HELP_MESSAGE)
+    else:
+        setup_logging()
+        generate()

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -140,6 +140,9 @@ class GenerationTaskConfig:
 
     async_position_key: str = "_async_position"  # key to use for preserving position in async loop in data dict
 
+    # optional list of target_language codes to run for language tasks; if empty/None, all languages are run
+    target_languages: list = field(default_factory=list)
+
     # can add this flag to just print the first prompt instead of running generation
     # useful to double check that your data can be loaded and prompt has what you expect
     dry_run: bool = False

--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -507,6 +507,11 @@ def eval(
 
                     judge_step_fn = locate(judge_step_fn)
 
+                # Merge any extra judge kwargs from the CLI into judge_pipeline_args.
+                # _create_llm_judge_tasks handles this for the LLM path so it is only needed here.
+                if judge_pipeline_kwargs:
+                    judge_pipeline_args.update(parse_kwargs(judge_pipeline_kwargs))
+
                 # Pass judge_model through so judge implementations can access it if needed (e.g. comet)
                 if judge_model:
                     judge_pipeline_args.setdefault("judge_model", judge_model)

--- a/nemo_skills/pipeline/judges/segale_judge_step.py
+++ b/nemo_skills/pipeline/judges/segale_judge_step.py
@@ -1,0 +1,317 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SEGALE judge step for document-level translation evaluation.
+
+Runs segale_judge.py as a dependent SLURM job after generation, scoring each
+document with COMET, COMETKiwi, MetricX-24, and MetricX-24-QE. The scores are
+written back into the output.jsonl for consumption by TranslationMetrics.
+
+Expected keys in JUDGE_PIPELINE_ARGS (beyond input_file/output_dir injected
+by the pipeline):
+    segmenter   (str, default "ersatz")  — sentence segmenter for model output
+    judge_gpus  (int, default 1)         — GPUs for COMET/MetricX inference
+"""
+
+import json
+import logging
+import os
+
+from nemo_skills.pipeline.utils import add_task
+from nemo_skills.utils import get_logger_name
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+
+def _resolve_host_path(path: str, cluster_config: dict) -> str:
+    """Translate a container-internal path to a host path using cluster mounts.
+
+    Mounts are listed as "host_path:container_path" strings in cluster_config.
+    If no mount matches, returns the original path unchanged.
+    """
+    for mount in cluster_config.get("mounts", []):
+        try:
+            host, container = mount.split(":", 1)
+        except ValueError:
+            continue
+        if path == container or path.startswith(container + "/"):
+            return host + path[len(container) :]
+    return path
+
+
+def _get_target_languages(input_file: str, cluster_config: dict) -> list[str]:
+    """Return sorted unique target_language values found in the input file.
+
+    Translates container-internal paths to host paths so the launcher (which
+    runs on the login node) can read the file without being inside the container.
+
+    Tries the async file (``input_file + "-async"``) first: it is written one
+    record per document during generation and therefore reflects ALL languages
+    even when a prior restore_async_order run was interrupted mid-way through
+    writing output.jsonl.  Falls back to input_file when the async file does
+    not exist (clean completed run: restore_async_order already deleted it and
+    output.jsonl is complete).
+    """
+
+    def _read_langs(path):
+        try:
+            with open(path, "rt", encoding="utf-8") as f:
+                return sorted({json.loads(line).get("target_language", "") for line in f if line.strip()} - {""})
+        except FileNotFoundError:
+            return []
+
+    async_host_path = _resolve_host_path(input_file + "-async", cluster_config)
+    langs = _read_langs(async_host_path)
+    if langs:
+        LOG.info("Read %d target languages from async file %s", len(langs), async_host_path)
+        return langs
+
+    host_path = _resolve_host_path(input_file, cluster_config)
+    return _read_langs(host_path)
+
+
+def create_judge_tasks(
+    exp,
+    expname,
+    benchmark,
+    judge_pipeline_args,
+    rerun_done,
+    log_dir,
+    output_dir,
+    cluster_config,
+    judge_server_gpus,
+    judge_server_nodes,
+    partition,
+    run_after,
+    reuse_code_exp,
+    reuse_code,
+    dependent_tasks,
+    all_tasks,
+    _task_dependencies,
+    installation_command,
+    skip_hf_home_check,
+    sbatch_kwargs,
+    **kwargs,
+):
+    """Create SLURM tasks that run segale_judge.py on the generation output.
+
+    Supports both single-seed (``input_file`` in judge_pipeline_args) and
+    multi-seed (``input_dir`` + ``num_random_seeds``) runs.  Each seed gets its
+    own independent embed→align→score→merge pipeline writing to a seed-specific
+    intermediate directory and output file (``output-rsN.jsonl``).
+    """
+    output_dir_path = judge_pipeline_args["output_dir"]
+    segmenter = judge_pipeline_args.get("segmenter", "ersatz")
+    judge_debug = judge_pipeline_args.get("judge_debug", False)
+    num_gpus = judge_server_gpus or judge_pipeline_args.get("judge_gpus", 1)
+    embed_batch_size = judge_pipeline_args.get("embed_batch_size", 8192)
+    save_spans = judge_pipeline_args.get("save_spans", False)
+
+    # Build per-seed (input_file, output_file, task_suffix) triples.
+    if "input_file" in judge_pipeline_args:
+        seed_runs = [
+            (judge_pipeline_args["input_file"], f"{output_dir_path}/output.jsonl", ""),
+        ]
+    else:
+        input_dir = judge_pipeline_args["input_dir"]
+        num_seeds = int(judge_pipeline_args["num_random_seeds"])
+        seed_runs = [
+            (
+                f"{input_dir}/output-rs{s}.jsonl",
+                f"{output_dir_path}/output-rs{s}.jsonl",
+                f"-rs{s}",
+            )
+            for s in range(num_seeds)
+        ]
+
+    # Resolve target languages.  When the input file already exists (re-run),
+    # cross-check configured languages against it to catch typos early.
+    # On first run the file does not exist yet, so we skip the check and trust
+    # the configured list; unsupported languages would fail in the embed phase.
+    first_input_file = seed_runs[0][0]
+    configured_languages = judge_pipeline_args.get("target_languages")
+    detected_languages = _get_target_languages(first_input_file, cluster_config)
+    if configured_languages:
+        if detected_languages:
+            unsupported = set(configured_languages) - set(detected_languages)
+            if unsupported:
+                raise ValueError(
+                    f"target_languages in JUDGE_PIPELINE_ARGS contains languages not found in {first_input_file}: "
+                    f"{sorted(unsupported)}. Available: {sorted(detected_languages)}"
+                )
+        target_languages = configured_languages
+    else:
+        target_languages = detected_languages
+
+    is_slurm = cluster_config["executor"] == "slurm"
+    all_judge_tasks = []
+
+    for seed_input_file, seed_output_file, task_suffix in seed_runs:
+        # Each seed gets its own judge subdirectory to avoid intermediate collisions.
+        judge_dir = f"{output_dir_path}/judge{task_suffix}"
+        per_lang_base = f"{judge_dir}/per_lang"
+        inter_dir = f"{judge_dir}/segale_intermediate"
+
+        # Skip this seed if all per-language outputs AND the merged output exist.
+        if not rerun_done:
+            merged_done = _resolve_host_path(f"{seed_output_file}.done", cluster_config)
+            all_per_lang_done = (
+                all(
+                    os.path.exists(_resolve_host_path(f"{per_lang_base}/{lang}/output.jsonl.done", cluster_config))
+                    for lang in target_languages
+                )
+                if target_languages
+                else False
+            )
+            if all_per_lang_done and os.path.exists(merged_done):
+                LOG.info("Skipping SEGALE judge for %s%s — all outputs complete", benchmark, task_suffix)
+                continue
+
+        LOG.info(
+            "Detected %d target languages in %s — creating 3-phase judge tasks (embed→align→score→merge)%s.",
+            len(target_languages),
+            seed_input_file,
+            task_suffix,
+        )
+
+        # ---- embed task (GPU): segment all docs + LASER2 embeddings ----
+        embed_done_host = _resolve_host_path(f"{inter_dir}/embed/embed.done", cluster_config)
+        embed_task = None
+        if not rerun_done and os.path.exists(embed_done_host):
+            LOG.info("Skipping embed for %s%s — embed.done exists", benchmark, task_suffix)
+        else:
+            embed_script_args = (
+                f"--input-file {seed_input_file} "
+                f"--output-dir {judge_dir} "
+                f"--segmenter {segmenter} "
+                f"--embed-batch-size {embed_batch_size} "
+                f"--mode embed"
+            )
+            if judge_debug:
+                embed_script_args += " --judge-debug"
+            embed_task = add_task(
+                exp,
+                cmd=f"WANDB_DISABLED=true python -m nemo_skills.evaluation.evaluator.segale_judge {embed_script_args}",
+                task_name=f"{expname}-{benchmark}-segale-embed{task_suffix}",
+                log_dir=f"{log_dir}/judge-embed{task_suffix}",
+                container=cluster_config["containers"]["segale"],
+                cluster_config=cluster_config,
+                num_gpus=num_gpus,
+                num_nodes=judge_server_nodes or 1,
+                partition=partition,
+                run_after=run_after,
+                reuse_code_exp=reuse_code_exp,
+                reuse_code=reuse_code,
+                task_dependencies=(dependent_tasks if is_slurm else all_tasks + _task_dependencies),
+                installation_command=installation_command,
+                skip_hf_home_check=skip_hf_home_check,
+                sbatch_kwargs=sbatch_kwargs,
+            )
+
+        # ---- align task (CPU, num_gpus=0): vecalign in parallel across all langs ----
+        all_align_done = all(
+            os.path.exists(_resolve_host_path(f"{inter_dir}/align/{lang}/align.done", cluster_config))
+            for lang in target_languages
+        )
+        align_task = None
+        if not rerun_done and all_align_done:
+            LOG.info("Skipping align for %s%s — all align.done exist", benchmark, task_suffix)
+        else:
+            align_script_args = f"--output-dir {judge_dir} --segmenter {segmenter} --mode align"
+            if judge_debug:
+                align_script_args += " --judge-debug"
+            embed_deps = [embed_task] if embed_task else []
+            align_task = add_task(
+                exp,
+                cmd=f'CUDA_VISIBLE_DEVICES="" WANDB_DISABLED=true python -m nemo_skills.evaluation.evaluator.segale_judge {align_script_args}',
+                task_name=f"{expname}-{benchmark}-segale-align{task_suffix}",
+                log_dir=f"{log_dir}/judge-align{task_suffix}",
+                container=cluster_config["containers"]["segale"],
+                cluster_config=cluster_config,
+                num_gpus=0,
+                num_nodes=1,
+                partition=partition,
+                run_after=run_after,
+                reuse_code_exp=reuse_code_exp,
+                reuse_code=reuse_code,
+                task_dependencies=(embed_deps if is_slurm else all_tasks + _task_dependencies + embed_deps),
+                installation_command=installation_command,
+                skip_hf_home_check=skip_hf_home_check,
+                sbatch_kwargs=sbatch_kwargs,
+            )
+
+        # ---- score task (GPU): batch COMET-QE + MetricX-QE across all langs ----
+        all_score_done = all(
+            os.path.exists(_resolve_host_path(f"{per_lang_base}/{lang}/output.jsonl.done", cluster_config))
+            for lang in target_languages
+        )
+        score_task = None
+        if not rerun_done and all_score_done:
+            LOG.info("Skipping score for %s%s — all output.jsonl.done exist", benchmark, task_suffix)
+        else:
+            score_script_args = f"--input-file {seed_input_file} --output-dir {judge_dir} --mode score"
+            if judge_debug:
+                score_script_args += " --judge-debug"
+            if save_spans:
+                score_script_args += " --save-spans"
+            align_deps = [align_task] if align_task else []
+            score_task = add_task(
+                exp,
+                cmd=f"WANDB_DISABLED=true python -m nemo_skills.evaluation.evaluator.segale_judge {score_script_args}",
+                task_name=f"{expname}-{benchmark}-segale-score{task_suffix}",
+                log_dir=f"{log_dir}/judge-score{task_suffix}",
+                container=cluster_config["containers"]["segale"],
+                cluster_config=cluster_config,
+                num_gpus=num_gpus,
+                num_nodes=judge_server_nodes or 1,
+                partition=partition,
+                run_after=run_after,
+                reuse_code_exp=reuse_code_exp,
+                reuse_code=reuse_code,
+                task_dependencies=(align_deps if is_slurm else all_tasks + _task_dependencies + align_deps),
+                installation_command=installation_command,
+                skip_hf_home_check=skip_hf_home_check,
+                sbatch_kwargs=sbatch_kwargs,
+            )
+
+        # ---- merge task: reassemble per-language outputs into seed output file ----
+        merge_args = (
+            f"--merge-input {seed_input_file} "
+            f"--merge-langs-dir {per_lang_base} "
+            f"--output-dir {output_dir_path} "
+            f"--output-file {seed_output_file}"
+        )
+        score_deps = [score_task] if score_task else []
+        merge_task = add_task(
+            exp,
+            cmd=f"WANDB_DISABLED=true python -m nemo_skills.evaluation.evaluator.segale_judge {merge_args}",
+            task_name=f"{expname}-{benchmark}-segale-merge{task_suffix}",
+            log_dir=f"{log_dir}/judge-merge{task_suffix}",
+            container=cluster_config["containers"]["segale"],
+            cluster_config=cluster_config,
+            num_gpus=1,
+            num_nodes=1,
+            partition=partition,
+            run_after=run_after,
+            reuse_code_exp=reuse_code_exp,
+            reuse_code=reuse_code,
+            task_dependencies=(score_deps if is_slurm else all_tasks + _task_dependencies + score_deps),
+            installation_command=installation_command,
+            skip_hf_home_check=skip_hf_home_check,
+            sbatch_kwargs=sbatch_kwargs,
+        )
+
+        all_judge_tasks.extend(t for t in [embed_task, align_task, score_task, merge_task] if t is not None)
+
+    return all_judge_tasks

--- a/nemo_skills/prompt/config/multilingual/document-translation.yaml
+++ b/nemo_skills/prompt/config/multilingual/document-translation.yaml
@@ -1,0 +1,3 @@
+# Prompt for document-level translation. Used with wmt24pp-doc and SEGALE evaluation.
+
+user: "Translate the following document into {target_lang_name}. Preserve the paragraph structure of the source text; you may merge or split sentences as needed, but keep the translation approximately aligned with the source. Output only the translation with no commentary or explanation.\n\nSource ({source_lang_name}):\n{text}\n\nTranslation ({target_lang_name}):\n"

--- a/tests/test_document_translation_task.py
+++ b/tests/test_document_translation_task.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for DocumentTranslationTask.
+
+Tests preprocess_data and restore_async_order without a live model by:
+  - bypassing GenerationTask.__init__ via __new__
+  - writing a synthetic async file to simulate what the async loop produces
+  - verifying the final output.jsonl has generation on seg_id=0 and "" on others
+"""
+
+import json
+
+from nemo_skills.inference.document_translation import DocumentTranslationTask
+
+SENTENCES = [
+    # doc_1: 3 sentences, seg_ids 0-2
+    {
+        "doc_id": "doc_1",
+        "seg_id": 0,
+        "text": "First sentence.",
+        "translation": "Erster Satz.",
+        "source_language": "en",
+        "target_language": "de_DE",
+    },
+    {
+        "doc_id": "doc_1",
+        "seg_id": 1,
+        "text": "Second sentence.",
+        "translation": "Zweiter Satz.",
+        "source_language": "en",
+        "target_language": "de_DE",
+    },
+    {
+        "doc_id": "doc_1",
+        "seg_id": 2,
+        "text": "Third sentence.",
+        "translation": "Dritter Satz.",
+        "source_language": "en",
+        "target_language": "de_DE",
+    },
+    # doc_2: 2 sentences, seg_ids 0-1
+    {
+        "doc_id": "doc_2",
+        "seg_id": 0,
+        "text": "Hello world.",
+        "translation": "Hallo Welt.",
+        "source_language": "en",
+        "target_language": "de_DE",
+    },
+    {
+        "doc_id": "doc_2",
+        "seg_id": 1,
+        "text": "Goodbye world.",
+        "translation": "Auf Wiedersehen Welt.",
+        "source_language": "en",
+        "target_language": "de_DE",
+    },
+]
+
+
+def make_task(tmp_path):
+    """Instantiate DocumentTranslationTask without triggering GenerationTask.__init__."""
+
+    class FakeCfg:
+        output_file = str(tmp_path / "output.jsonl")
+        input_file = str(tmp_path / "input.jsonl")
+        async_position_key = "_async_position"
+        generation_key = "generation"
+        enable_litellm_cache = False
+        target_languages = []
+        skip_filled = False
+
+    task = DocumentTranslationTask.__new__(DocumentTranslationTask)
+    task.cfg = FakeCfg()
+    return task
+
+
+def test_preprocess_data_groups_by_doc_id(tmp_path):
+    task = make_task(tmp_path)
+    doc_records = task.preprocess_data(list(SENTENCES))
+
+    assert len(doc_records) == 2, "Should produce one record per document"
+    assert task._doc_order == [("doc_1", "de_DE"), ("doc_2", "de_DE")]
+
+    # doc_1: three sentences joined with a space
+    assert doc_records[0]["doc_id"] == "doc_1"
+    assert doc_records[0]["text"] == "First sentence. Second sentence. Third sentence."
+
+    # doc_2: two sentences joined with a space
+    assert doc_records[1]["doc_id"] == "doc_2"
+    assert doc_records[1]["text"] == "Hello world. Goodbye world."
+
+
+def test_preprocess_data_sorts_by_seg_id(tmp_path):
+    """Records arriving out of seg_id order should be sorted before concatenation."""
+    task = make_task(tmp_path)
+    shuffled = [SENTENCES[2], SENTENCES[0], SENTENCES[1], SENTENCES[4], SENTENCES[3]]
+    doc_records = task.preprocess_data(shuffled)
+
+    assert doc_records[0]["text"] == "First sentence. Second sentence. Third sentence."
+    assert doc_records[1]["text"] == "Hello world. Goodbye world."
+
+
+def test_preprocess_data_uses_first_sentence_fields(tmp_path):
+    """Non-text fields on the doc record should come from seg_id=0."""
+    task = make_task(tmp_path)
+    doc_records = task.preprocess_data(list(SENTENCES))
+
+    # translation field should be from seg_id=0, not concatenated
+    assert doc_records[0]["translation"] == "Erster Satz."
+    assert doc_records[0]["seg_id"] == 0
+
+
+def test_restore_async_order_fans_out(tmp_path):
+    """Full round-trip: preprocess → write fake async file → restore → verify output."""
+    task = make_task(tmp_path)
+    task.preprocess_data(list(SENTENCES))
+
+    # Write the input file that restore_async_order reads to recover per-sentence records.
+    with open(task.cfg.input_file, "w") as f:
+        for s in SENTENCES:
+            f.write(json.dumps(s) + "\n")
+
+    # Simulate what the async loop would write: two doc-level outputs, out of order.
+    doc1_generation = "Erster Satz. Zweiter Satz. Dritter Satz."
+    doc2_generation = "Hallo Welt. Auf Wiedersehen Welt."
+
+    async_records = [
+        # doc_2 finishes first (position 1)
+        {
+            "generation": doc2_generation,
+            "doc_id": "doc_2",
+            "target_language": "de_DE",
+            "text": "Hello world. Goodbye world.",
+            "_async_position": 1,
+        },
+        # doc_1 finishes second (position 0)
+        {
+            "generation": doc1_generation,
+            "doc_id": "doc_1",
+            "target_language": "de_DE",
+            "text": "First sentence. Second sentence. Third sentence.",
+            "_async_position": 0,
+        },
+    ]
+
+    async_path = task.cfg.output_file + "-async"
+    with open(async_path, "w") as f:
+        for rec in async_records:
+            f.write(json.dumps(rec) + "\n")
+
+    task.restore_async_order()
+
+    assert not __import__("pathlib").Path(async_path).exists(), "async file should be deleted"
+
+    with open(task.cfg.output_file) as f:
+        output = [json.loads(line) for line in f]
+
+    assert len(output) == 5, "Should have one record per original sentence"
+
+    # doc_1 records: generation on seg_id=0, "" on others
+    assert output[0]["doc_id"] == "doc_1"
+    assert output[0]["seg_id"] == 0
+    assert output[0]["generation"] == doc1_generation
+    assert output[0]["text"] == "First sentence."  # original sentence text, not concatenated
+
+    assert output[1]["seg_id"] == 1
+    assert output[1]["generation"] == ""
+    assert output[1]["text"] == "Second sentence."
+
+    assert output[2]["seg_id"] == 2
+    assert output[2]["generation"] == ""
+
+    # doc_2 records
+    assert output[3]["doc_id"] == "doc_2"
+    assert output[3]["seg_id"] == 0
+    assert output[3]["generation"] == doc2_generation
+
+    assert output[4]["seg_id"] == 1
+    assert output[4]["generation"] == ""
+
+
+def test_restore_async_order_preserves_per_sentence_fields(tmp_path):
+    """Each output record should have the original per-sentence translation field."""
+    task = make_task(tmp_path)
+    task.preprocess_data(list(SENTENCES))
+
+    # Write the input file that restore_async_order reads to recover per-sentence records.
+    with open(task.cfg.input_file, "w") as f:
+        for s in SENTENCES:
+            f.write(json.dumps(s) + "\n")
+
+    async_records = [
+        {
+            "generation": "Erster Satz. Zweiter Satz. Dritter Satz.",
+            "doc_id": "doc_1",
+            "target_language": "de_DE",
+            "_async_position": 0,
+        },
+        {
+            "generation": "Hallo Welt. Auf Wiedersehen Welt.",
+            "doc_id": "doc_2",
+            "target_language": "de_DE",
+            "_async_position": 1,
+        },
+    ]
+    with open(task.cfg.output_file + "-async", "w") as f:
+        for rec in async_records:
+            f.write(json.dumps(rec) + "\n")
+
+    task.restore_async_order()
+
+    with open(task.cfg.output_file) as f:
+        output = [json.loads(line) for line in f]
+
+    # Each sentence record should have its own reference translation, not the first sentence's
+    assert output[0]["translation"] == "Erster Satz."
+    assert output[1]["translation"] == "Zweiter Satz."
+    assert output[2]["translation"] == "Dritter Satz."
+    assert output[3]["translation"] == "Hallo Welt."
+    assert output[4]["translation"] == "Auf Wiedersehen Welt."

--- a/tests/test_segale_judge.py
+++ b/tests/test_segale_judge.py
@@ -1,0 +1,349 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the SEGALE judge script (segale_judge.py).
+
+All SEGALE model calls are mocked so no GPU or model downloads are needed.
+
+Tests cover:
+  - Score phase correctly aggregates aligned spans to doc-level QE scores
+  - Merge phase correctly writes scores back to original record order
+  - .done marker is created after a successful merge
+  - Merge returns early (preserving the embed checkpoint) when no scores exist
+"""
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# ---------------------------------------------------------------------------
+# Fixture data: 5 sentences across 2 documents
+#
+# Mirrors the real document-level MT output format:
+#   - seg_id=1 carries the full document translation in `generation`
+#   - all other segments have generation="" (the model was given the full
+#     document as one prompt and produced one generation, stored on the first
+#     record; subsequent records preserve the source/reference structure)
+# ---------------------------------------------------------------------------
+DOC1_GENERATION = "The cat sat on the mat. She observed it carefully. Then she left it in peace."
+DOC2_GENERATION = "It was a bright and sunny day. Children were playing in the park."
+
+RECORDS = [
+    # doc1 — 3 source/reference sentences
+    {
+        "source_language": "de_Latn",
+        "target_language": "en_Latn",
+        "text": "Die Katze saß auf der Matte. Sie beobachtete es aufmerksam. Dann ließ sie es in Ruhe.",
+        "source_sentences": [
+            "Die Katze saß auf der Matte.",
+            "Sie beobachtete es aufmerksam.",
+            "Dann ließ sie es in Ruhe.",
+        ],
+        "reference_sentences": [
+            "The cat sat on the mat.",
+            "She watched it carefully.",
+            "Then she left it alone.",
+        ],
+        "generation": DOC1_GENERATION,
+        "doc_id": "doc1",
+        "seg_id": 1,
+    },
+    # doc2 — 2 source/reference sentences
+    {
+        "source_language": "de_Latn",
+        "target_language": "en_Latn",
+        "text": "Es war ein heller Tag. Kinder spielten im Park.",
+        "source_sentences": [
+            "Es war ein heller Tag.",
+            "Kinder spielten im Park.",
+        ],
+        "reference_sentences": [
+            "It was a bright day.",
+            "Children played in the park.",
+        ],
+        "generation": DOC2_GENERATION,
+        "doc_id": "doc2",
+        "seg_id": 1,
+    },
+]
+
+# Pre-baked aligned spans that the score phase will process.
+# 3 spans for doc1, 2 spans for doc2 (1:1 alignment for simplicity).
+MOCK_ALIGNED_SPANS = [
+    {
+        "doc_id": "doc1",
+        "sys_id": "nemo_skills",
+        "src": RECORDS[0]["source_sentences"][0],
+        "ref": RECORDS[0]["reference_sentences"][0],
+        "tgt": "The cat sat on the mat.",
+        "seg_id": 1,
+    },
+    {
+        "doc_id": "doc1",
+        "sys_id": "nemo_skills",
+        "src": RECORDS[0]["source_sentences"][1],
+        "ref": RECORDS[0]["reference_sentences"][1],
+        "tgt": "She observed it carefully.",
+        "seg_id": 2,
+    },
+    {
+        "doc_id": "doc1",
+        "sys_id": "nemo_skills",
+        "src": RECORDS[0]["source_sentences"][2],
+        "ref": RECORDS[0]["reference_sentences"][2],
+        "tgt": "Then she left it in peace.",
+        "seg_id": 3,
+    },
+    {
+        "doc_id": "doc2",
+        "sys_id": "nemo_skills",
+        "src": RECORDS[1]["source_sentences"][0],
+        "ref": RECORDS[1]["reference_sentences"][0],
+        "tgt": "It was a bright and sunny day.",
+        "seg_id": 1,
+    },
+    {
+        "doc_id": "doc2",
+        "sys_id": "nemo_skills",
+        "src": RECORDS[1]["source_sentences"][1],
+        "ref": RECORDS[1]["reference_sentences"][1],
+        "tgt": "Children were playing in the park.",
+        "seg_id": 2,
+    },
+]
+
+# QE scores the mock returns (one per aligned span).
+MOCK_COMET_QE_SCORES = [0.83, 0.86, 0.80, 0.87, 0.84]
+MOCK_METRICX_QE_SCORES = [1.5, 1.4, 1.6, 1.1, 1.2]
+
+# Expected doc-level averages.  doc1: spans 0-2 — doc2: spans 3-4
+DOC1_COMET_QE = sum(MOCK_COMET_QE_SCORES[:3]) / 3
+DOC1_METRICX_QE = sum(MOCK_METRICX_QE_SCORES[:3]) / 3
+DOC2_COMET_QE = sum(MOCK_COMET_QE_SCORES[3:]) / 2
+DOC2_METRICX_QE = sum(MOCK_METRICX_QE_SCORES[3:]) / 2
+
+
+# ---------------------------------------------------------------------------
+# Stubs for heavy optional dependencies
+# ---------------------------------------------------------------------------
+
+
+def _make_segale_align_stub():
+    stub = types.ModuleType("segale_align")
+    stub.VERBOSE = 0
+    stub.SPACY = "ersatz"
+    stub.STOP_JUMP = 0.15
+    stub.COST_MIN = 0.30
+    stub.COST_MAX = 0.30
+    stub.init_config = MagicMock()
+    stub.load_alternative_model = MagicMock(return_value=(None, MagicMock()))
+    stub.merge_system_entries = MagicMock(return_value=[])
+    stub.merge_ref_entries = MagicMock(return_value=[])
+    stub.combine_system_ref = MagicMock(return_value=[])
+    stub.prepare_doc_windows = MagicMock(return_value=None)
+    return stub
+
+
+def _make_laser_stub():
+    stub = types.ModuleType("laser_encoders")
+    stub.LaserEncoderPipeline = MagicMock(return_value=MagicMock())
+    return stub
+
+
+def _make_segale_eval_stub():
+    """Stub for segale_eval; only QE scorers are used by the current pipeline."""
+    stub = types.ModuleType("segale_eval")
+    stub.run_comet_qe_evaluation = MagicMock(return_value=MOCK_COMET_QE_SCORES)
+    stub.run_metricx_qe_evaluation = MagicMock(return_value=MOCK_METRICX_QE_SCORES)
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# Module loader
+# ---------------------------------------------------------------------------
+
+
+def _import_judge_with_stubs():
+    """Import segale_judge with SEGALE library stubs injected into sys.modules."""
+    sys.modules.pop("segale_judge", None)
+    sys.modules["segale_align"] = _make_segale_align_stub()
+    sys.modules["laser_encoders"] = _make_laser_stub()
+    sys.modules["segale_eval"] = _make_segale_eval_stub()
+
+    evaluator_dir = str(Path(__file__).parent.parent / "nemo_skills" / "evaluation" / "evaluator")
+    if evaluator_dir not in sys.path:
+        sys.path.insert(0, evaluator_dir)
+
+    import segale_judge
+
+    return segale_judge
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path, records):
+    with open(path, "wt", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+
+def _read_jsonl(path):
+    with open(path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunScorePhase:
+    """_run_score_phase aggregates aligned spans to doc-level QE scores and writes per-lang output."""
+
+    def setup_method(self):
+        self.judge = _import_judge_with_stubs()
+
+    def _setup(self, tmp_path):
+        """Write input records and aligned spans; return (input_file, output_dir)."""
+        input_file = tmp_path / "input.jsonl"
+        _write_jsonl(input_file, RECORDS)
+
+        align_dir = tmp_path / "segale_intermediate" / "align" / "en_Latn"
+        align_dir.mkdir(parents=True)
+        _write_jsonl(align_dir / "aligned_spans.jsonl", MOCK_ALIGNED_SPANS)
+        (align_dir / "align.done").touch()
+
+        return input_file, tmp_path
+
+    def _read_per_lang(self, output_dir):
+        return _read_jsonl(output_dir / "per_lang" / "en_Latn" / "output.jsonl")
+
+    def test_comet_qe_average_doc1(self, tmp_path):
+        input_file, output_dir = self._setup(tmp_path)
+        self.judge._run_score_phase(input_file=input_file, output_dir=output_dir)
+
+        doc1 = next(r for r in self._read_per_lang(output_dir) if r.get("doc_id") == "doc1")
+        assert abs(doc1["segale_comet_qe"] - DOC1_COMET_QE) < 1e-9
+
+    def test_comet_qe_average_doc2(self, tmp_path):
+        input_file, output_dir = self._setup(tmp_path)
+        self.judge._run_score_phase(input_file=input_file, output_dir=output_dir)
+
+        doc2 = next(r for r in self._read_per_lang(output_dir) if r.get("doc_id") == "doc2")
+        assert abs(doc2["segale_comet_qe"] - DOC2_COMET_QE) < 1e-9
+
+    def test_all_metrics_present(self, tmp_path):
+        input_file, output_dir = self._setup(tmp_path)
+        self.judge._run_score_phase(input_file=input_file, output_dir=output_dir)
+
+        for record in self._read_per_lang(output_dir):
+            for field in ("segale_comet_qe", "segale_metricx_qe", "segale_lang_fidelity", "segale_total_seg"):
+                assert field in record, f"{field} missing from scored record (doc_id={record.get('doc_id')})"
+
+    def test_total_seg_count(self, tmp_path):
+        """segale_total_seg counts all spans (including misaligned), not just valid ones."""
+        input_file, output_dir = self._setup(tmp_path)
+        self.judge._run_score_phase(input_file=input_file, output_dir=output_dir)
+
+        out = self._read_per_lang(output_dir)
+        doc1 = next(r for r in out if r.get("doc_id") == "doc1")
+        doc2 = next(r for r in out if r.get("doc_id") == "doc2")
+        assert doc1["segale_total_seg"] == 3  # 3 spans total for doc1
+        assert doc2["segale_total_seg"] == 2  # 2 spans total for doc2
+
+    def test_done_marker_created(self, tmp_path):
+        input_file, output_dir = self._setup(tmp_path)
+        self.judge._run_score_phase(input_file=input_file, output_dir=output_dir)
+
+        assert (output_dir / "per_lang" / "en_Latn" / "output.jsonl.done").exists()
+
+
+class TestMergePerLanguageOutputs:
+    """merge_per_language_outputs combines per-lang scores into the final output file."""
+
+    def setup_method(self):
+        self.judge = _import_judge_with_stubs()
+
+    def _scored_records(self):
+        """Return RECORDS with doc-level scores pre-applied (as _run_score_phase would write)."""
+        return [
+            {
+                **RECORDS[0],
+                "segale_comet_qe": DOC1_COMET_QE,
+                "segale_metricx_qe": DOC1_METRICX_QE,
+                "segale_lang_fidelity": 1.0,
+                "segale_total_seg": 3,
+                "segale_misaligned_seg": 0,  # all mock spans have positive scores
+            },
+            {
+                **RECORDS[1],
+                "segale_comet_qe": DOC2_COMET_QE,
+                "segale_metricx_qe": DOC2_METRICX_QE,
+                "segale_lang_fidelity": 1.0,
+                "segale_total_seg": 2,
+                "segale_misaligned_seg": 0,  # all mock spans have positive scores
+            },
+        ]
+
+    def test_scores_merged_into_output(self, tmp_path):
+        input_file = tmp_path / "input.jsonl"
+        langs_dir = tmp_path / "per_lang"
+        output_file = tmp_path / "output.jsonl"
+
+        _write_jsonl(input_file, RECORDS)
+        lang_dir = langs_dir / "en_Latn"
+        lang_dir.mkdir(parents=True)
+        _write_jsonl(lang_dir / "output.jsonl", self._scored_records())
+
+        self.judge.merge_per_language_outputs(input_file, langs_dir, output_file)
+
+        out = _read_jsonl(output_file)
+        doc1 = next(r for r in out if r.get("doc_id") == "doc1")
+        doc2 = next(r for r in out if r.get("doc_id") == "doc2")
+        assert abs(doc1["segale_comet_qe"] - DOC1_COMET_QE) < 1e-9
+        assert abs(doc2["segale_comet_qe"] - DOC2_COMET_QE) < 1e-9
+
+    def test_done_marker_created(self, tmp_path):
+        input_file = tmp_path / "input.jsonl"
+        langs_dir = tmp_path / "per_lang"
+        output_file = tmp_path / "output.jsonl"
+
+        _write_jsonl(input_file, RECORDS)
+        lang_dir = langs_dir / "en_Latn"
+        lang_dir.mkdir(parents=True)
+        _write_jsonl(lang_dir / "output.jsonl", self._scored_records())
+
+        self.judge.merge_per_language_outputs(input_file, langs_dir, output_file)
+
+        assert Path(str(output_file) + ".done").exists()
+
+    def test_empty_score_map_returns_early(self, tmp_path):
+        """When no per-lang scores exist, merge returns early to preserve the embed checkpoint."""
+        input_file = tmp_path / "input.jsonl"
+        langs_dir = tmp_path / "per_lang"
+        output_file = tmp_path / "output.jsonl"
+
+        _write_jsonl(input_file, RECORDS)
+        langs_dir.mkdir(parents=True)
+        # No per-lang output.jsonl files — simulates upstream timeout/failure
+
+        self.judge.merge_per_language_outputs(input_file, langs_dir, output_file)
+
+        assert not output_file.exists(), "output.jsonl must not be written when score_map is empty"
+        assert not Path(str(output_file) + ".done").exists(), ".done must not be written when score_map is empty"

--- a/tests/test_segale_metrics.py
+++ b/tests/test_segale_metrics.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+TDD test for SEGALE metric integration in TranslationMetrics.
+
+tests than 'ns summarize_results' works as expected once the sentences
+have been properly segmented and scored on a sentence level.
+"""
+
+import json
+
+from nemo_skills.pipeline.summarize_results import summarize_results
+
+# Pre-computed SEGALE scores that the judge script would write into output.jsonl.
+# Two language pairs: de_Latn->en_Latn and zho_Hans->en_Latn.
+#
+# Format mirrors SEGALE's native input: one record per sentence.
+#   source      — one source sentence
+#   translation — one reference sentence
+#   generation  — one sentence of the model's MT output
+#   doc_id      — groups sentences into documents
+#   seg_id      — sentence index within the document
+#   sys_id      — system/model identifier
+#   segale_*    — document-level score written by the judge script to every
+#                 sentence record in the document (same value per doc).
+#                 Aggregation weighting across doc sizes is a TODO.
+PREDICTIONS = [
+    # --- de_Latn -> en_Latn, doc 1 (3 sentences) ---
+    {
+        "source_language": "de_Latn",
+        "target_language": "en_Latn",
+        "source": "Die Katze saß auf der Matte.",
+        "translation": "The cat sat on the mat.",
+        "generation": "The cat sat on the mat.",
+        "doc_id": "de_doc1",
+        "seg_id": 0,
+        "sys_id": "test_model",
+        "segale_comet": 0.88,
+        "segale_comet_qe": 0.83,
+        "segale_metricx": 1.2,
+        "segale_metricx_qe": 1.5,
+    },
+    {
+        "source_language": "de_Latn",
+        "target_language": "en_Latn",
+        "source": "Sie beobachtete es aufmerksam von der anderen Seite des Zimmers.",
+        "translation": "She watched it carefully from across the room.",
+        "generation": "She watched it carefully from across the room.",
+        "doc_id": "de_doc1",
+        "seg_id": 1,
+        "sys_id": "test_model",
+        "segale_comet": 0.88,
+        "segale_comet_qe": 0.83,
+        "segale_metricx": 1.2,
+        "segale_metricx_qe": 1.5,
+    },
+    {
+        "source_language": "de_Latn",
+        "target_language": "en_Latn",
+        "source": "Nach einer Weile beschloss sie, es in Ruhe zu lassen.",
+        "translation": "After some time, she decided to leave it in peace.",
+        "generation": "After a while, she decided to leave it alone.",
+        "doc_id": "de_doc1",
+        "seg_id": 2,
+        "sys_id": "test_model",
+        "segale_comet": 0.88,
+        "segale_comet_qe": 0.83,
+        "segale_metricx": 1.2,
+        "segale_metricx_qe": 1.5,
+    },
+    # --- de_Latn -> en_Latn, doc 2 (2 sentences) ---
+    {
+        "source_language": "de_Latn",
+        "target_language": "en_Latn",
+        "source": "Es war ein heller und sonniger Tag.",
+        "translation": "It was a bright sunny day.",
+        "generation": "It was a bright and sunny day.",
+        "doc_id": "de_doc2",
+        "seg_id": 0,
+        "sys_id": "test_model",
+        "segale_comet": 0.90,
+        "segale_comet_qe": 0.87,
+        "segale_metricx": 0.9,
+        "segale_metricx_qe": 1.1,
+    },
+    {
+        "source_language": "de_Latn",
+        "target_language": "en_Latn",
+        "source": "Kinder spielten im Park, während ihre Eltern auf den Bänken saßen.",
+        "translation": "Children played in the park while their parents rested on the benches.",
+        "generation": "Children played in the park while their parents sat on the benches.",
+        "doc_id": "de_doc2",
+        "seg_id": 1,
+        "sys_id": "test_model",
+        "segale_comet": 0.90,
+        "segale_comet_qe": 0.87,
+        "segale_metricx": 0.9,
+        "segale_metricx_qe": 1.1,
+    },
+    # --- zho_Hans -> en_Latn, doc 1 (3 sentences) ---
+    {
+        "source_language": "zho_Hans",
+        "target_language": "en_Latn",
+        "source": "去年经济大幅增长。",
+        "translation": "The economy saw significant growth last year.",
+        "generation": "The economy grew significantly last year.",
+        "doc_id": "zh_doc1",
+        "seg_id": 0,
+        "sys_id": "test_model",
+        "segale_comet": 0.82,
+        "segale_comet_qe": 0.78,
+        "segale_metricx": 2.3,
+        "segale_metricx_qe": 2.7,
+    },
+    {
+        "source_language": "zho_Hans",
+        "target_language": "en_Latn",
+        "source": "第三季度出口达到创纪录的高位。",
+        "translation": "Exports hit a record high in the third quarter.",
+        "generation": "Exports reached a record high in the third quarter.",
+        "doc_id": "zh_doc1",
+        "seg_id": 1,
+        "sys_id": "test_model",
+        "segale_comet": 0.82,
+        "segale_comet_qe": 0.78,
+        "segale_metricx": 2.3,
+        "segale_metricx_qe": 2.7,
+    },
+    {
+        "source_language": "zho_Hans",
+        "target_language": "en_Latn",
+        "source": "分析师预计这一趋势将延续到明年。",
+        "translation": "Analysts expect this trend to continue into next year.",
+        "generation": "Analysts expect the trend to continue into next year.",
+        "doc_id": "zh_doc1",
+        "seg_id": 2,
+        "sys_id": "test_model",
+        "segale_comet": 0.82,
+        "segale_comet_qe": 0.78,
+        "segale_metricx": 2.3,
+        "segale_metricx_qe": 2.7,
+    },
+    # --- zho_Hans -> en_Latn, doc 2 (2 sentences) ---
+    {
+        "source_language": "zho_Hans",
+        "target_language": "en_Latn",
+        "source": "科学家在雨林中发现了一个新物种。",
+        "translation": "Scientists discovered a new species in the rainforest.",
+        "generation": "Scientists have discovered a new species in the rainforest.",
+        "doc_id": "zh_doc2",
+        "seg_id": 0,
+        "sys_id": "test_model",
+        "segale_comet": 0.86,
+        "segale_comet_qe": 0.83,
+        "segale_metricx": 1.4,
+        "segale_metricx_qe": 1.6,
+    },
+    {
+        "source_language": "zho_Hans",
+        "target_language": "en_Latn",
+        "source": "介绍这些发现的会议将于三月举行。",
+        "translation": "The conference presenting these findings is scheduled for March.",
+        "generation": "The conference to present the findings will be held in March.",
+        "doc_id": "zh_doc2",
+        "seg_id": 1,
+        "sys_id": "test_model",
+        "segale_comet": 0.86,
+        "segale_comet_qe": 0.83,
+        "segale_metricx": 1.4,
+        "segale_metricx_qe": 1.6,
+    },
+]
+
+SEGALE_FIELDS = ["segale_comet", "segale_comet_qe", "segale_metricx", "segale_metricx_qe"]
+
+
+def test_segale_fields_in_summarize_results(tmp_path):
+    """SEGALE scores pre-written by the judge in output.jsonl should appear in metrics.json."""
+    # Write predictions into the expected directory structure:
+    # <results_dir>/<benchmark>/output.jsonl
+    benchmark_dir = tmp_path / "wmt24"
+    benchmark_dir.mkdir()
+    output_file = benchmark_dir / "output.jsonl"
+    with open(output_file, "w") as f:
+        for record in PREDICTIONS:
+            f.write(json.dumps(record) + "\n")
+
+    summarize_results(results_dir=str(tmp_path), metric_type="translation")
+
+    with open(tmp_path / "metrics.json") as f:
+        metrics = json.load(f)
+
+    # The top-level key is the benchmark directory name.
+    assert "wmt24" in metrics, f"'wmt24' not in metrics.json keys: {list(metrics.keys())}"
+    wmt24 = metrics["wmt24"]
+
+    # All per-pair and aggregated keys from above should carry SEGALE scores.
+    expected_keys = [
+        "de_Latn->en_Latn",
+        "zho_Hans->en_Latn",
+        "xx->xx",
+        "de_Latn->xx",
+        "zho_Hans->xx",
+        "xx->en_Latn",
+    ]
+    for lang_pair in expected_keys:
+        assert lang_pair in wmt24, f"'{lang_pair}' missing from metrics.json"
+        for field in SEGALE_FIELDS:
+            assert field in wmt24[lang_pair], (
+                f"'{field}' missing from metrics.json['{lang_pair}']. "
+                "translation_metrics.py does not yet read SEGALE scores."
+            )
+
+    # Each document should contribute equally regardless of sentence count.
+    # de_Latn->en_Latn: doc1=0.88 (3 sentences), doc2=0.90 (2 sentences).
+    # Correct average = (0.88 + 0.90) / 2 = 0.89.
+    # Wrong average (weighted by sentence count) = (0.88*3 + 0.90*2) / 5 = 0.888.
+    assert abs(wmt24["de_Latn->en_Latn"]["segale_comet"] - 0.89) < 1e-9, (
+        f"segale_comet for de_Latn->en_Latn is {wmt24['de_Latn->en_Latn']['segale_comet']}, "
+        "expected 0.89. Each document should contribute equally, not weighted by sentence count."
+    )
+
+
+def test_segale_graceful_degradation_no_doc_id(tmp_path):
+    """When doc_id is absent (sentence-level data), SEGALE fields should not appear.
+
+    This tests the graceful degradation path: sentence-level benchmarks like
+    FLORES-200 fall back to BLEU/COMET only without raising an error.
+    """
+    benchmark_dir = tmp_path / "flores200"
+    benchmark_dir.mkdir()
+    output_file = benchmark_dir / "output.jsonl"
+
+    # Same records but without doc_id and without segale_* fields.
+    sentence_level_records = [
+        {k: v for k, v in r.items() if k not in ("doc_id",) + tuple(SEGALE_FIELDS)} for r in PREDICTIONS
+    ]
+    with open(output_file, "w") as f:
+        for record in sentence_level_records:
+            f.write(json.dumps(record) + "\n")
+
+    summarize_results(results_dir=str(tmp_path), metric_type="translation")
+
+    with open(tmp_path / "metrics.json") as f:
+        metrics = json.load(f)
+
+    flores200 = metrics["flores200"]
+    # BLEU should still be present.
+    assert "bleu" in flores200["de_Latn->en_Latn"]
+    # SEGALE fields must NOT appear when doc_id / segale scores are absent.
+    for field in SEGALE_FIELDS:
+        assert field not in flores200["de_Latn->en_Latn"], (
+            f"'{field}' should not appear in sentence-level benchmark results"
+        )


### PR DESCRIPTION
- Add wmt24pp.doc (per-document) and wmt24pp.long (per-language) as sub-benchmarks of wmt24pp using the benchmark group pattern
- Add SEGALE judge (segale_judge.py) with QE-only pipeline: segment-align-evaluate using ersatz, LASER2/vecalign, COMET-QE, and MetricX-QE
- Add DocumentTranslationTask for document-level generation
- Add span-level BLEU scoring and language fidelity detection
- Add Dockerfile.segale for the SEGALE evaluation container
- Fix judge_pipeline_kwargs not being passed to custom judge steps in eval.py
- Update translation_metrics.py to handle QE-only fields
- Add/update tests for segale_judge and document_translation_task
- Add documentation and results in docs/evaluation/multilingual.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document-level SEGALE-based translation evaluation, span-aware scoring, and long-input benchmark variant
  * Document-level generation task with async resume/restore and per-run target-language filtering
  * Multi-stage judge orchestration (embed → align → score → merge) and a SEGALE-capable evaluation container
  * SEGALE metric collection integrated into summary/metrics outputs

* **Documentation**
  * Guides/examples and command templates for document-level and long-input WMT24 PP benchmarks

* **Tests**
  * Unit tests for document translation task, SEGALE judge, and SEGALE metric integration

* **Chores**
  * Dataset writers now emit sent/doc/long outputs; defaults select sentence sub-benchmark only
<!-- end of auto-generated comment: release notes by coderabbit.ai -->