### PR TITLE
Fix sbatch_kwargs mutation causing --exclusive on GPU jobs

### DIFF
--- a/nemo_skills/pipeline/utils/exp.py
+++ b/nemo_skills/pipeline/utils/exp.py
@@ -289,8 +289,7 @@ def get_executor(
         if partition == cluster_config.get("cpu_partition"):
             # by default we use exclusive if no gpus are needed and use non-exclusive if gpus are required
             # as cpu jobs almost always need more resources than automatically allocated by slurm
-            if sbatch_kwargs is None:
-                sbatch_kwargs = {}
+            sbatch_kwargs = dict(sbatch_kwargs) if sbatch_kwargs else {}
             sbatch_kwargs["exclusive"] = True
 
     timeout = get_slurm_timeout_str(cluster_config, partition, with_save_delay=False)


### PR DESCRIPTION
## Summary

`get_executor()` in `exp.py` mutates the shared `sbatch_kwargs` dict in-place when adding `exclusive=True` for CPU jobs. If a CPU task runs before a GPU task in the same experiment, the GPU task inherits `--exclusive`, which is incorrect.

## Fix

Create a copy of the dictionary before modifying:

```python
# Before (mutates shared dict)
if sbatch_kwargs is None:
    sbatch_kwargs = {}
sbatch_kwargs["exclusive"] = True

# After (safe copy)
sbatch_kwargs = dict(sbatch_kwargs) if sbatch_kwargs else {}
sbatch_kwargs["exclusive"] = True
```

## Test plan

- [x] Verified with `burst_eval_vllm.py` submitting mixed CPU+GPU jobs
- [x] GPU jobs no longer receive `--exclusive`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed SLURM executor to safely handle configuration parameters without modifying the original user-provided dictionary.
* Improved handling of missing or empty configuration values for more robust job submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->