### PR TITLE
fix: align HLE answer extraction with prompt format

### DIFF
--- a/nemo_skills/dataset/hle/__init__.py
+++ b/nemo_skills/dataset/hle/__init__.py
@@ -14,7 +14,13 @@
 
 # settings that define how evaluation should be done by default (all can be changed from cmdline)
 METRICS_TYPE = "hle"  # This uses the MathMetrics class, but with compute_no_answer=False
-GENERATION_ARGS = "++prompt_config=generic/hle ++eval_type=math"
+HLE_ANSWER_EXTRACT_REGEX = r"(?is)(?:^|\n)\s*\**Answer\**\s*:\s*(.+?)(?=\n\s*\**Confidence\**\s*:|\Z)"
+HLE_EVAL_EXTRACTION_ARGS = (
+    "++eval_config.extract_from_boxed=False "
+    "++eval_config.relaxed_extraction=True "
+    f"++eval_config.extract_regex='{HLE_ANSWER_EXTRACT_REGEX}' "
+)
+GENERATION_ARGS = f"++prompt_config=generic/hle ++eval_type=math {HLE_EVAL_EXTRACTION_ARGS}"
 EVAL_SPLIT = "text"
 
 # Some answers are not possible to compare symbolically, so have to use a judge model

--- a/nemo_skills/dataset/hle_verified/__init__.py
+++ b/nemo_skills/dataset/hle_verified/__init__.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 # settings that define how evaluation should be done by default (all can be changed from cmdline)
+from nemo_skills.dataset.hle import HLE_EVAL_EXTRACTION_ARGS
+
+
 METRICS_TYPE = "hle"
-GENERATION_ARGS = "++prompt_config=generic/hle ++eval_type=math"
+GENERATION_ARGS = f"++prompt_config=generic/hle ++eval_type=math {HLE_EVAL_EXTRACTION_ARGS}"
 EVAL_SPLIT = "text"  # text subset of gold + revised subset of HLE-Verified (https://arxiv.org/pdf/2602.13964v3)
 
 # Some answers are not possible to compare symbolically, so have to use a judge model

--- a/nemo_skills/evaluation/math_grader.py
+++ b/nemo_skills/evaluation/math_grader.py
@@ -117,7 +117,11 @@ def extract_answer(
 def search_regex(string: str, regex: str):
     match = re.findall(regex, string)
     if match:
-        return match[-1]
+        retval = match[-1]
+        if isinstance(retval, tuple):
+            retval = next((group for group in retval if group), "")
+        retval = retval.strip()
+        return retval or None
     return None
 
 

--- a/tests/test_hle_answer_extraction.py
+++ b/tests/test_hle_answer_extraction.py
@@ -1,0 +1,55 @@
+from nemo_skills.dataset.hle import HLE_ANSWER_EXTRACT_REGEX
+from nemo_skills.evaluation.math_grader import extract_answer, math_equal
+
+
+def extract_hle_answer(generation: str) -> str | None:
+    return extract_answer(
+        generation,
+        extract_from_boxed=False,
+        extract_regex=HLE_ANSWER_EXTRACT_REGEX,
+        relaxed=True,
+    )
+
+
+def test_hle_extracts_plain_answer_line():
+    generation = """Explanation: Arrhenius's theorem rules out this view.
+Answer: D
+Confidence: 100%"""
+
+    assert extract_hle_answer(generation) == "D"
+
+
+def test_hle_extracts_markdown_answer_line():
+    generation = """
+Based on my historical analysis, I can now provide the answer.
+
+**The Answer is C. 1223, Rigord**
+
+Here's the breakdown...
+
+Answer: **C. 1223, Rigord**
+
+Confidence: **90%**
+"""
+
+    extracted = extract_hle_answer(generation)
+
+    assert extracted == "**C. 1223, Rigord**"
+    assert math_equal("C", extracted)
+
+
+def test_hle_falls_back_to_boxed_answer():
+    generation = r"""Explanation: Using Chebotarev, the density is \boxed{\frac{2}{7}}."""
+
+    assert extract_hle_answer(generation) == r"\frac{2}{7}"
+
+
+def test_hle_extracts_exact_match_answer():
+    generation = """Explanation: Putting the letters together gives the final string.
+Answer: yeyo
+Confidence: 100%"""
+
+    extracted = extract_hle_answer(generation)
+
+    assert extracted == "yeyo"
+    assert math_equal("yeyo", extracted)


### PR DESCRIPTION
## Summary
- align HLE answer extraction with the `Explanation:` / `Answer:` / `Confidence:` format used by `generic/hle`
- apply the same extraction override to `hle_verified`
- add focused regression tests for plain answer lines, markdown-styled answers, boxed fallback, and exact-match outputs

## Why
HLE prompts do not require `\\boxed{...}`, but the default math extraction path is box-first. In practice this can leave `predicted_answer` unset even when the answer is clearly present on the `Answer:` line. This patch keeps HLE extraction aligned with the benchmark prompt while preserving boxed fallback for models that still emit boxed answers.

This does not change the main HLE judge path, which already reads the full raw generation. It fixes extracted-answer artifacts and symbolic bookkeeping for HLE-style outputs.

## Test plan
- `python -m pytest tests/test_hle_answer_extraction.py -q`
- attempted `python -m pytest -m \"not live\" -q --tb=short`, but local collection was blocked by a missing optional dependency (`soundfile`) in `tests/test_magpie_tts_backend.py`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved answer extraction accuracy with enhanced regex patterns and better handling of multiple answer format variations, including markdown and boxed notations.

* **Tests**
  * Added comprehensive test coverage for answer extraction across various answer format scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->