### PR TITLE
Fix arena-hard (v1) judge KeyError by dropping category tag at prep time

### DIFF
--- a/nemo_skills/dataset/arena-hard/prepare.py
+++ b/nemo_skills/dataset/arena-hard/prepare.py
@@ -50,4 +50,9 @@ if __name__ == "__main__":
             data = json.loads(line)
             data["question"] = data.pop("prompt")
             data["baseline_answer"] = baseline_answers[data["uid"]]
+            # The upstream lmarena/arena-hard-auto source stores a dataset-version
+            # string ("arena-hard-v0.1") in the category field. v1 has no real
+            # sub-categories, so drop it to let ArenaJudgeTask.fill_prompt fall
+            # through to the default prompt via its `if not category` branch.
+            data.pop("category", None)
             fout.write(json.dumps(data) + "\n")

--- a/nemo_skills/inference/eval/arena_judge.py
+++ b/nemo_skills/inference/eval/arena_judge.py
@@ -84,7 +84,7 @@ class ArenaJudgeTask(GenerationTask):
         if self.cfg.prompt_format == "openai":
             return None
 
-        # Load the default prompt (used for most categories including hard_prompt, arena-hard-v0.1, etc.)
+        # Load the default prompt (used for any category not explicitly mapped below, including hard_prompt)
         default_prompt = get_prompt(
             prompt_config=self.cfg.prompt_config,
             tokenizer=self.tokenizer,


### PR DESCRIPTION
Closes #1367

## Summary
Drop the `category` field from arena-hard (v1) `test.jsonl` at prep time. This removes the `"arena-hard-v0.1"` dataset-version string that `lmarena/arena-hard-auto` ships in the category field, letting `ArenaJudgeTask.fill_prompt` reach its already-intended default-prompt fallback (`if not category: prompt = self.prompt`).

## Why a data-side fix?
Downstream consumers were already written assuming v1 has no category:

- `arena_metrics.py` L57: `# Track category for per-category scoring (defaults to None for v1 compatibility)`
- `arena_metrics.py` L109: per-category breakdown only fires when `len(unique_categories) > 1`, so v1's `{None}` is already skipped
- `arena_judge.py` L121: `if not category: prompt = self.prompt` is already in place

The mismatch is that `lmarena/arena-hard-auto` writes `"arena-hard-v0.1"` (a version tag, not a real category) into the category field, which `fill_prompt`'s else branch fails on via strict dict lookup. Dropping the noisy field at prep time aligns the data with the existing "no category" assumption rather than patching each consumer.

Regression introduced in #1205 when multi-category prompt dispatch was added. v2 behavior unchanged (its `hard_prompt` / `creative_writing` values are real categories and remain populated).

## Changes
- `nemo_skills/dataset/arena-hard/prepare.py`: pop `category` when writing `test.jsonl`.
- `nemo_skills/inference/eval/arena_judge.py`: drop the inaccurate `including arena-hard-v0.1` from the default-prompt comment.

## Test plan
- [x] `ns eval --benchmarks arena-hard --model <small model> ...` runs the judge to completion and writes `eval-results/arena-hard/output.jsonl` / `metrics.json`.
- [x] arena-hard-v2 unaffected — v2 `test.jsonl` still ships real category values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure prompt selection no longer relies on a preserved `category` field in processed dataset records, restoring correct fallback behavior for unmapped prompt categories.
* **Documentation**
  * Clarified default prompt description so fallback behavior for unmapped categories is accurately documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->