### PR TITLE
SWE-bench: fix OpenHands /workspace mount check

### DIFF
--- a/nemo_skills/inference/eval/swebench.py
+++ b/nemo_skills/inference/eval/swebench.py
@@ -818,7 +818,7 @@ class SweBenchGenerationTask(GenerationTask):
         openhands_cmd = (
             # make sure /workspace isn't mounted as a safety precaution
             # (mounting it in the nemo-skills cluster config is ok, just not inside of apptainer specifically)
-            "if mountpoint -q /workspace; then "
+            "if awk '{print $2}' /proc/mounts | grep -qE '^/workspace(/|$)'; then "
             "    echo 'Exiting because /workspace is mounted.' && "
             "    echo 'Please make sure /workspace is not mounted inside of Apptainer before running OpenHands.' && "
             "    echo 'This is because OpenHands DELETES EVERYTHING in the /workspace folder if it exists.' && "

--- a/nemo_skills/inference/eval/swebench.py
+++ b/nemo_skills/inference/eval/swebench.py
@@ -818,7 +818,7 @@ class SweBenchGenerationTask(GenerationTask):
         openhands_cmd = (
             # make sure /workspace isn't mounted as a safety precaution
             # (mounting it in the nemo-skills cluster config is ok, just not inside of apptainer specifically)
-            "if [ -d /workspace ]; then "
+            "if mountpoint -q /workspace; then "
             "    echo 'Exiting because /workspace is mounted.' && "
             "    echo 'Please make sure /workspace is not mounted inside of Apptainer before running OpenHands.' && "
             "    echo 'This is because OpenHands DELETES EVERYTHING in the /workspace folder if it exists.' && "


### PR DESCRIPTION
OpenHands inference will no longer automatically fail if the `/workspace` folder exists in the container, only if `/workspace` or a subfolder of it is mounted externally. This is useful for working with some custom datasets e.g. SWE-rebench-V2.

(By default OpenHands will still delete the contents of `/workspace` and create its own folder inside. To prevent that, a custom branch of OpenHands is required.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workspace mounting detection and validation in container operations. The system now performs more rigorous verification to confirm workspace volumes are properly mounted before executing operations, preventing potential runtime errors in misconfigured environments and ensuring more reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->