### PR TITLE
Add MT-Bench and Komt-Bench (Korean MT-Bench) benchmarks

### DIFF
--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -24,6 +24,7 @@ language-data
 litellm[caching]==1.83.0
 math-verify[antlr4_9_3]
 mcp
+mediapipe
 numpy
 openai
 openpyxl>=3.1.0

--- a/dockerfiles/Dockerfile.nemo-skills
+++ b/dockerfiles/Dockerfile.nemo-skills
@@ -1,7 +1,8 @@
 # using ubuntu instead of debian for easier apptainer installation on arm64
 FROM ubuntu:22.04
 
-# Install Python and other dependencies
+# Install Python and other dependencies (libgl1/gles2/egl1 are mediapipe runtime
+# requirements used by the MT-Bench / KoMT-Bench language detector).
 RUN apt-get update && \
     apt-get install -y \
     python3.10 \
@@ -10,7 +11,10 @@ RUN apt-get update && \
     wget \
     git \
     git-lfs \
-    ffmpeg && \
+    ffmpeg \
+    libgl1-mesa-glx \
+    libgles2-mesa \
+    libegl1-mesa && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 

--- a/dockerfiles/Dockerfile.nemo-skills
+++ b/dockerfiles/Dockerfile.nemo-skills
@@ -1,8 +1,7 @@
 # using ubuntu instead of debian for easier apptainer installation on arm64
 FROM ubuntu:22.04
 
-# Install Python and other dependencies (libgl1/gles2/egl1 are mediapipe runtime
-# requirements used by the MT-Bench / KoMT-Bench language detector).
+# Install Python and other dependencies
 RUN apt-get update && \
     apt-get install -y \
     python3.10 \

--- a/nemo_skills/dataset/komt-bench/__init__.py
+++ b/nemo_skills/dataset/komt-bench/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "mt_bench"
+GENERATION_MODULE = "nemo_skills.inference.eval.mt_bench"
+GENERATION_ARGS = "++prompt_format=openai"
+
+JUDGE_PIPELINE_ARGS = {
+    "generation_module": "nemo_skills.inference.eval.mt_bench_judge",
+    "model": "gpt-4o-2024-08-06",
+    "server_type": "openai",
+    "server_address": "https://api.openai.com/v1",
+}
+
+JUDGE_ARGS = (
+    "++prompt_config_turn1=judge/komt-bench/turn1 "
+    "++prompt_config_turn1_with_ref=judge/komt-bench/turn1_with_ref "
+    "++prompt_config_turn2=judge/komt-bench/turn2 "
+    "++prompt_config_turn2_with_ref=judge/komt-bench/turn2_with_ref "
+    "++num_judges=8"
+)

--- a/nemo_skills/dataset/komt-bench/prepare.py
+++ b/nemo_skills/dataset/komt-bench/prepare.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import urllib.request
+from pathlib import Path
+
+URL_QUESTIONS = (
+    "https://raw.githubusercontent.com/LG-AI-EXAONE/KoMT-Bench/main/"
+    "FastChat/fastchat/llm_judge/data/mt_bench/question_ko.jsonl"
+)
+URL_REF_ANSWERS = (
+    "https://raw.githubusercontent.com/LG-AI-EXAONE/KoMT-Bench/main/"
+    "FastChat/fastchat/llm_judge/data/mt_bench/reference_answer_ko/gpt-4.jsonl"
+)
+
+# qids 138/140 expect JSON/CSV output; exempted by upstream detector.py.
+LANG_PENALTY_EXEMPT_QIDS = {138, 140}
+
+
+if __name__ == "__main__":
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    questions_file = data_dir / "question_ko.jsonl"
+    ref_file = data_dir / "gpt-4-ref-ko.jsonl"
+    output_file = data_dir / "test.jsonl"
+
+    urllib.request.urlretrieve(URL_QUESTIONS, str(questions_file))
+    urllib.request.urlretrieve(URL_REF_ANSWERS, str(ref_file))
+
+    ref_by_qid = {}
+    with open(ref_file, "rt", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            data = json.loads(line)
+            ref_by_qid[data["question_id"]] = data["choices"][0]["turns"]
+
+    with open(questions_file, "rt", encoding="utf-8") as fin, open(output_file, "wt", encoding="utf-8") as fout:
+        for line in fin:
+            if not line.strip():
+                continue
+            q = json.loads(line)
+            qid = q["question_id"]
+            turns = q["turns"]
+            if len(turns) != 2:
+                raise ValueError(f"KoMT-Bench question {qid} expected 2 turns, got {len(turns)}")
+            ref_turns = ref_by_qid.get(qid, [None, None])
+            entry = {
+                "question_id": qid,
+                "category": q["category"],
+                "question_1": turns[0],
+                "question_2": turns[1],
+                "ref_answer_1": ref_turns[0],
+                "ref_answer_2": ref_turns[1],
+            }
+            if qid not in LANG_PENALTY_EXEMPT_QIDS:
+                entry["target_language"] = "ko"
+            fout.write(json.dumps(entry, ensure_ascii=False) + "\n")

--- a/nemo_skills/dataset/mt-bench/__init__.py
+++ b/nemo_skills/dataset/mt-bench/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "mt_bench"
+GENERATION_MODULE = "nemo_skills.inference.eval.mt_bench"
+GENERATION_ARGS = "++prompt_format=openai"
+
+JUDGE_PIPELINE_ARGS = {
+    "generation_module": "nemo_skills.inference.eval.mt_bench_judge",
+    "model": "gpt-4o-2024-08-06",
+    "server_type": "openai",
+    "server_address": "https://api.openai.com/v1",
+}
+
+JUDGE_ARGS = "++num_judges=8"

--- a/nemo_skills/dataset/mt-bench/prepare.py
+++ b/nemo_skills/dataset/mt-bench/prepare.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import urllib.request
+from pathlib import Path
+
+URL_QUESTIONS = (
+    "https://raw.githubusercontent.com/lm-sys/FastChat/main/fastchat/llm_judge/data/mt_bench/question.jsonl"
+)
+URL_REF_ANSWERS = "https://raw.githubusercontent.com/lm-sys/FastChat/main/fastchat/llm_judge/data/mt_bench/reference_answer/gpt-4.jsonl"
+
+
+if __name__ == "__main__":
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+
+    questions_file = data_dir / "question.jsonl"
+    ref_file = data_dir / "reference_answer.jsonl"
+    output_file = data_dir / "test.jsonl"
+
+    urllib.request.urlretrieve(URL_QUESTIONS, str(questions_file))
+    urllib.request.urlretrieve(URL_REF_ANSWERS, str(ref_file))
+
+    # Build reference answer lookup {question_id: {turn1: str, turn2: str}}
+    ref_answers = {}
+    with open(ref_file, "rt", encoding="utf-8") as f:
+        for line in f:
+            data = json.loads(line)
+            qid = data["question_id"]
+            turns = data["choices"][0]["turns"]
+            ref_answers[qid] = {"turn1": turns[0], "turn2": turns[1] if len(turns) > 1 else None}
+
+    with open(questions_file, "rt", encoding="utf-8") as fin, open(output_file, "wt", encoding="utf-8") as fout:
+        for line in fin:
+            data = json.loads(line)
+            qid = data["question_id"]
+            turns = data["turns"]
+            if len(turns) != 2:
+                raise ValueError(f"MT-Bench question {qid} expected 2 turns, got {len(turns)}")
+            # Reference answers are populated upstream only for math/reasoning/coding;
+            # other categories legitimately have none.
+            ref = ref_answers.get(qid, {})
+            entry = {
+                "question_id": qid,
+                "category": data["category"],
+                "question_1": turns[0],
+                "question_2": turns[1],
+                "ref_answer_1": ref.get("turn1"),
+                "ref_answer_2": ref.get("turn2"),
+            }
+            fout.write(json.dumps(entry, ensure_ascii=False) + "\n")

--- a/nemo_skills/evaluation/metrics/map_metrics.py
+++ b/nemo_skills/evaluation/metrics/map_metrics.py
@@ -42,6 +42,7 @@ from nemo_skills.evaluation.metrics.math_metrics import MathMetrics
 from nemo_skills.evaluation.metrics.mcq_multilingual_metrics import MCQMultilingualMetrics
 from nemo_skills.evaluation.metrics.mmau_pro_metrics import MMAUProMetrics
 from nemo_skills.evaluation.metrics.mrcr_metrics import MRCRMetrics
+from nemo_skills.evaluation.metrics.mt_bench_metrics import MTBenchMetrics
 from nemo_skills.evaluation.metrics.omni_metrics import OmniMetrics
 from nemo_skills.evaluation.metrics.physics_metrics import PhysicsMetrics
 from nemo_skills.evaluation.metrics.ruler2_metrics import Ruler2Metrics
@@ -101,6 +102,7 @@ METRICS_MAP = {
     "hotpotqa": HotpotQAMetrics,
     "hotpotqa_closedbook": functools.partial(HotpotQAMetrics, closed_book=True),
     "weighted-math": WeightedMathMetrics,
+    "mt_bench": MTBenchMetrics,
 }
 
 

--- a/nemo_skills/evaluation/metrics/mt_bench_metrics.py
+++ b/nemo_skills/evaluation/metrics/mt_bench_metrics.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import os
+import re
+import urllib.request
+from collections import defaultdict
+from functools import lru_cache
+from pathlib import Path
+
+from iso639.exceptions import InvalidLanguageValue
+from iso639.iso639 import Lang
+
+from nemo_skills.evaluation.metrics.base import BaseMetrics, as_float, default_formatting
+
+# MediaPipe language detector. The ~315KB ``language_detector.tflite`` model is
+# fetched on first use to ``~/.cache/nemo_skills/`` (override via NEMO_SKILLS_CACHE).
+_LANG_MODEL_URL = (
+    "https://storage.googleapis.com/mediapipe-models/language_detector/"
+    "language_detector/float32/latest/language_detector.tflite"
+)
+
+
+def _lang_model_path() -> Path:
+    cache_root = os.environ.get("NEMO_SKILLS_CACHE")
+    base = Path(cache_root).resolve() if cache_root else Path.home() / ".cache" / "nemo_skills"
+    return base / "language_detector.tflite"
+
+
+@lru_cache(maxsize=1)
+def _lang_detector():
+    from mediapipe.tasks import python
+    from mediapipe.tasks.python import text
+
+    model_path = _lang_model_path()
+    if not model_path.exists():
+        model_path.parent.mkdir(parents=True, exist_ok=True)
+        # Download to a temp path then atomic-rename so parallel processes
+        # don't read a half-written file.
+        tmp_path = model_path.with_suffix(model_path.suffix + ".tmp")
+        urllib.request.urlretrieve(_LANG_MODEL_URL, tmp_path)
+        os.replace(tmp_path, model_path)
+    return text.LanguageDetector.create_from_options(
+        text.LanguageDetectorOptions(
+            base_options=python.BaseOptions(model_asset_path=str(model_path)),
+            max_results=1,
+        )
+    )
+
+
+def _detect_top_language(answer_text: str) -> str:
+    """Return the top-1 ISO 639-1 code for ``answer_text``; ``"unknown"`` if undetectable."""
+    if not answer_text or not answer_text.strip():
+        return "unknown"
+    result = _lang_detector().detect(answer_text)
+    if not result.detections:
+        return "unknown"
+    return result.detections[0].language_code
+
+
+class MTBenchMetrics(BaseMetrics):
+    """MT-Bench scoring with optional per-entry target-language penalty.
+
+    Multilingual variants (e.g. KoMT-Bench) set ``target_language`` (an ISO 639-1
+    2-letter code) on each dataset entry. When set and the response is not in
+    that language, raw judge scores are sqrt-penalized to discourage
+    code-switching. Plain MT-Bench leaves ``target_language`` unset and reports
+    raw scores only.
+    """
+
+    def __init__(self, compute_no_answer: bool = True):
+        super().__init__(compute_no_answer=compute_no_answer)
+
+    def _parse_rating(self, judgement):
+        """Extract [[rating]] from judge output. Returns float 1-10 or None."""
+        if not judgement:
+            return None
+        pattern = re.compile(r"\[\[(\d+\.?\d*)\]\]")
+        matches = pattern.findall(judgement)
+        if not matches:
+            return None
+        try:
+            score = float(matches[-1])
+            if 1.0 <= score <= 10.0:
+                return score
+        except ValueError:
+            pass
+        return None
+
+    @staticmethod
+    def _validate_target_language(lang):
+        try:
+            Lang(pt1=lang)
+        except InvalidLanguageValue as exc:
+            raise ValueError(f"target_language must be a valid ISO 639-1 2-letter code, got: {lang!r}") from exc
+
+    def _score_one(self, pred):
+        """Parse turn1/turn2 ratings for a single prediction (multi-judge aware),
+        then apply target-language penalty if requested."""
+        # all_judgements_turn* is only emitted by mt_bench_judge.py when num_judges>1.
+        # Absence is the standard single-judge path, so .get() here is intentional.
+        all_j1 = pred.get("all_judgements_turn1")
+        all_j2 = pred.get("all_judgements_turn2")
+        if all_j1 and all_j2:
+            scores_t1 = [s for s in (self._parse_rating(j) for j in all_j1) if s is not None]
+            scores_t2 = [s for s in (self._parse_rating(j) for j in all_j2) if s is not None]
+            score_t1 = sum(scores_t1) / len(scores_t1) if scores_t1 else None
+            score_t2 = sum(scores_t2) / len(scores_t2) if scores_t2 else None
+        else:
+            score_t1 = self._parse_rating(pred["judgement_turn1"])
+            score_t2 = self._parse_rating(pred["judgement_turn2"])
+
+        # Downstream pipeline fills missing string fields with "", so a truthy
+        # check covers both unset and empty-string as "no language penalty".
+        target_language = pred.get("target_language")
+        pen_t1, pen_t2 = score_t1, score_t2
+        if target_language:
+            self._validate_target_language(target_language)
+            answer_1 = pred["answer_1"]
+            answer_2 = pred["answer_2"]
+            if score_t1 is not None and _detect_top_language(answer_1) != target_language:
+                pen_t1 = math.sqrt(score_t1)
+            if score_t2 is not None and _detect_top_language(answer_2) != target_language:
+                pen_t2 = math.sqrt(score_t2)
+        return {
+            "category": pred["category"],
+            "score_turn1": score_t1,
+            "score_turn2": score_t2,
+            "penalized_turn1": pen_t1,
+            "penalized_turn2": pen_t2,
+            "has_target_language": bool(target_language),
+        }
+
+    def update(self, predictions):
+        """Each (row, sample) contributes its own scored entry, so the aggregated
+        average matches pass@1[avg-of-N] semantics for task:N runs."""
+        super().update(predictions)
+        for pred in predictions:
+            self.entries.append(self._score_one(pred))
+
+    def _build_overall(self, entries):
+        overall = {"num_entries": self.total}
+        self.update_common_metrics(overall)
+
+        pen_t1 = [e["penalized_turn1"] for e in entries if e["penalized_turn1"] is not None]
+        pen_t2 = [e["penalized_turn2"] for e in entries if e["penalized_turn2"] is not None]
+        all_pen = pen_t1 + pen_t2
+        if all_pen:
+            overall["average_score"] = sum(all_pen) / len(all_pen)
+        if pen_t1:
+            overall["turn1_average"] = sum(pen_t1) / len(pen_t1)
+        if pen_t2:
+            overall["turn2_average"] = sum(pen_t2) / len(pen_t2)
+
+        # Only emit raw_* when target_language was set on at least one entry — for
+        # plain MT-Bench raw_* would just duplicate the primary averages.
+        if any(e["has_target_language"] for e in entries):
+            raw_t1 = [e["score_turn1"] for e in entries if e["score_turn1"] is not None]
+            raw_t2 = [e["score_turn2"] for e in entries if e["score_turn2"] is not None]
+            all_raw = raw_t1 + raw_t2
+            if all_raw:
+                overall["raw_average_score"] = sum(all_raw) / len(all_raw)
+            if raw_t1:
+                overall["raw_turn1_average"] = sum(raw_t1) / len(raw_t1)
+            if raw_t2:
+                overall["raw_turn2_average"] = sum(raw_t2) / len(raw_t2)
+
+        cat_scores = defaultdict(lambda: {"turn1": [], "turn2": []})
+        for entry in entries:
+            cat = entry["category"]
+            if entry["penalized_turn1"] is not None:
+                cat_scores[cat]["turn1"].append(entry["penalized_turn1"])
+            if entry["penalized_turn2"] is not None:
+                cat_scores[cat]["turn2"].append(entry["penalized_turn2"])
+        for cat, scores in sorted(cat_scores.items()):
+            all_cat = scores["turn1"] + scores["turn2"]
+            if all_cat:
+                overall[f"category_{cat}"] = sum(all_cat) / len(all_cat)
+        return overall
+
+    def get_metrics(self):
+        # pass@1 already aggregates every (row, sample) entry under task:N>1,
+        # so it doubles as pass@1[avg-of-N]; we don't emit a redundant alias.
+        return {"pass@1": self._build_overall(self.entries)}
+
+    def evaluations_to_print(self):
+        return ["pass@1"]
+
+    def metrics_to_print(self):
+        # MT-Bench scores are 1-10, not percentages
+        metrics = self.get_metrics()
+        all_keys = set()
+        for eval_metrics in metrics.values():
+            all_keys.update(eval_metrics.keys())
+        return {
+            key: as_float
+            if isinstance(next((m[key] for m in metrics.values() if key in m), None), float)
+            else default_formatting
+            for key in all_keys
+        }
+
+    def reset(self):
+        super().reset()
+        self.entries = []

--- a/nemo_skills/inference/eval/mt_bench.py
+++ b/nemo_skills/inference/eval/mt_bench.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+from dataclasses import field
+
+import hydra
+
+from nemo_skills.code_execution.sandbox import sandbox_params
+from nemo_skills.inference.generate import GenerationTask, GenerationTaskConfig
+from nemo_skills.inference.model import server_params
+from nemo_skills.inference.model.base import EndpointType
+from nemo_skills.utils import get_help_message, get_logger_name, nested_dataclass, parse_reasoning, setup_logging
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+
+@nested_dataclass(kw_only=True)
+class MTBenchInferenceConfig:
+    endpoint_type: EndpointType = EndpointType.chat
+    temperature: float = 0.0
+    top_k: int | None = -1
+    top_p: float | None = None
+    min_p: float | None = 0.0
+    random_seed: int | None = None
+    tokens_to_generate: int | None = None
+    repetition_penalty: float | None = None
+    top_logprobs: int | None = None
+    timeout: int | None = 14400
+    reasoning_effort: str | None = None
+    extra_body: dict = field(default_factory=dict)
+
+
+@nested_dataclass(kw_only=True)
+class MTBenchGenerationConfig(GenerationTaskConfig):
+    """MT-Bench two-turn generation config."""
+
+    inference: MTBenchInferenceConfig = field(default_factory=MTBenchInferenceConfig)
+    server: dict = field(default_factory=dict)
+    prompt_format: str = "openai"
+
+
+cs = hydra.core.config_store.ConfigStore.instance()
+cs.store(name="base_mt_bench_generation_config", node=MTBenchGenerationConfig)
+
+
+class MTBenchGenerationTask(GenerationTask):
+    """Two-turn generation for MT-Bench: generate answer_1, then answer_2."""
+
+    def fill_prompt(self, data_point, data, prompt_format=None):
+        if "messages" in data_point:
+            return data_point["messages"]
+        return [{"role": "user", "content": data_point["question_1"]}]
+
+    async def process_single_datapoint(self, data_point, all_data):
+        """Process a single datapoint with two-turn generation.
+
+        The flow is:
+        1. Generate answer for question 1
+        2. Generate answer for question 2 conditioned on answer 1
+        """
+        # ===== Turn 1: Generate answer for question 1 =====
+        turn1_result = await super().process_single_datapoint(data_point, all_data)
+        LOG.debug("Turn 1 result: %s", turn1_result)
+
+        if self.cfg.parse_reasoning:
+            parse_reasoning(turn1_result, self.cfg.generation_key, self.cfg.end_reasoning_string)
+
+        answer_1 = turn1_result[self.cfg.generation_key]
+        LOG.debug("Answer 1: %s", answer_1)
+
+        # ===== Turn 2: Generate answer for question 2 =====
+        turn2_messages = [
+            {"role": "user", "content": data_point["question_1"]},
+            {"role": "assistant", "content": answer_1},
+            {"role": "user", "content": data_point["question_2"]},
+        ]
+        LOG.debug("Turn 2 messages: %s", turn2_messages)
+
+        turn2_data_point = {"messages": turn2_messages}
+        turn2_result = await super().process_single_datapoint(turn2_data_point, all_data)
+        LOG.debug("Turn 2 result: %s", turn2_result)
+
+        raw_turn2_generation = turn2_result[self.cfg.generation_key]
+        if self.cfg.parse_reasoning:
+            parse_reasoning(turn2_result, self.cfg.generation_key, self.cfg.end_reasoning_string)
+
+        answer_2 = turn2_result[self.cfg.generation_key]
+
+        return {
+            "answer_1": answer_1,
+            "answer_2": answer_2,
+            "generation": raw_turn2_generation,
+            "num_generated_tokens": (
+                turn1_result.get("num_generated_tokens", 0) + turn2_result.get("num_generated_tokens", 0)
+            ),
+        }
+
+
+GENERATION_TASK_CLASS = MTBenchGenerationTask
+
+
+@hydra.main(version_base=None, config_name="base_mt_bench_generation_config")
+def generate(cfg: MTBenchGenerationConfig):
+    cfg = MTBenchGenerationConfig(_init_nested=True, **cfg)
+    LOG.info("Config used: %s", cfg)
+    task = MTBenchGenerationTask(cfg)
+    task.generate()
+
+
+HELP_MESSAGE = get_help_message(
+    MTBenchGenerationConfig,
+    server_params=server_params(),
+    sandbox_params=sandbox_params(),
+)
+
+
+if __name__ == "__main__":
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print(HELP_MESSAGE)
+    else:
+        setup_logging()
+        generate()

--- a/nemo_skills/inference/eval/mt_bench_judge.py
+++ b/nemo_skills/inference/eval/mt_bench_judge.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+import sys
+from dataclasses import field
+
+import hydra
+
+from nemo_skills.inference.generate import GenerationTask, GenerationTaskConfig, InferenceConfig
+from nemo_skills.inference.model import server_params
+from nemo_skills.prompt.utils import get_prompt, load_config
+from nemo_skills.utils import get_help_message, get_logger_name, nested_dataclass, setup_logging
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+NEED_REF_CATS = {"math", "reasoning", "coding"}
+JUDGE_TIMEOUT = 180  # 3 minutes per individual judge API call
+
+
+@nested_dataclass(kw_only=True)
+class MTBenchJudgeConfig(GenerationTaskConfig):
+    """MT-Bench judge config with per-turn prompt templates."""
+
+    inference: InferenceConfig = field(default_factory=InferenceConfig)
+    server: dict = field(default_factory=dict)
+
+    prompt_format: str = "openai"
+    generation_key: str = "judgement"
+
+    prompt_config_turn1: str = "judge/mt-bench/turn1"
+    prompt_config_turn1_with_ref: str = "judge/mt-bench/turn1_with_ref"
+    prompt_config_turn2: str = "judge/mt-bench/turn2"
+    prompt_config_turn2_with_ref: str = "judge/mt-bench/turn2_with_ref"
+
+    num_judges: int = 1  # Number of judge calls per turn (averaged to reduce variance)
+
+
+cs = hydra.core.config_store.ConfigStore.instance()
+cs.store(name="base_mt_bench_judge_config", node=MTBenchJudgeConfig)
+
+
+class MTBenchJudgeTask(GenerationTask):
+    """Judge task for MT-Bench: score each turn on 1-10 scale."""
+
+    def __init__(self, cfg: MTBenchJudgeConfig):
+        super().__init__(cfg)
+        self.prompt_turn1 = get_prompt(prompt_config=load_config(self.cfg.prompt_config_turn1))
+        self.prompt_turn1_with_ref = get_prompt(prompt_config=load_config(self.cfg.prompt_config_turn1_with_ref))
+        self.prompt_turn2 = get_prompt(prompt_config=load_config(self.cfg.prompt_config_turn2))
+        self.prompt_turn2_with_ref = get_prompt(prompt_config=load_config(self.cfg.prompt_config_turn2_with_ref))
+
+    def fill_prompt(self, data_point, data, prompt_format=None):
+        if "messages" in data_point:
+            return data_point["messages"]
+        # Build judge prompt for preview (dry-run); answers may not exist yet.
+        category = data_point["category"]
+        prompt = self._select_prompt(category, turn=1)
+        judge_input = {
+            "question_1": data_point["question_1"],
+            "answer_1": data_point.get("answer_1", "(not yet generated)"),
+        }
+        if category in NEED_REF_CATS:
+            judge_input["ref_answer_1"] = data_point["ref_answer_1"]
+        return prompt.fill(input_dict=judge_input)
+
+    def log_example_prompt(self, data):
+        if data:
+            LOG.info("Example judge prompt:\n%s", self.fill_prompt(data[0], data))
+
+    def _select_prompt(self, category, turn):
+        has_ref = category in NEED_REF_CATS
+        if turn == 1:
+            return self.prompt_turn1_with_ref if has_ref else self.prompt_turn1
+        else:
+            return self.prompt_turn2_with_ref if has_ref else self.prompt_turn2
+
+    async def _judge_turn(self, data_point, all_data, turn):
+        category = data_point["category"]
+        prompt = self._select_prompt(category, turn)
+
+        if turn == 1:
+            judge_input = {
+                "question_1": data_point["question_1"],
+                "answer_1": data_point["answer_1"],
+            }
+            if category in NEED_REF_CATS:
+                judge_input["ref_answer_1"] = data_point["ref_answer_1"]
+        else:
+            judge_input = {
+                "question_1": data_point["question_1"],
+                "answer_1": data_point["answer_1"],
+                "question_2": data_point["question_2"],
+                "answer_2": data_point["answer_2"],
+            }
+            if category in NEED_REF_CATS:
+                judge_input["ref_answer_1"] = data_point["ref_answer_1"]
+                judge_input["ref_answer_2"] = data_point["ref_answer_2"]
+
+        messages = prompt.fill(input_dict=judge_input)
+        judge_data_point = {"messages": messages}
+        result = await super().process_single_datapoint(judge_data_point, all_data)
+        return result["generation"]
+
+    async def _safe_judge(self, data_point, all_data, turn):
+        """Call _judge_turn with a timeout to prevent indefinite hangs."""
+        try:
+            return await asyncio.wait_for(
+                self._judge_turn(data_point, all_data, turn),
+                timeout=JUDGE_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            LOG.warning(
+                "Judge call timed out (turn=%d, timeout=%ds, category=%s)",
+                turn,
+                JUDGE_TIMEOUT,
+                data_point["category"],
+            )
+            return ""
+
+    async def process_single_datapoint(self, data_point, all_data, prompt_format=None):
+        # Skip judging if generation failed (answer fields missing)
+        if "answer_1" not in data_point or "answer_2" not in data_point:
+            LOG.warning("Skipping judge for data point missing answer_1/answer_2 (generation likely failed)")
+            return {
+                "judgement_turn1": "",
+                "judgement_turn2": "",
+                "generation": "",
+                "error": "missing_answers",
+            }
+
+        num_judges = self.cfg.num_judges
+
+        if num_judges <= 1:
+            judgement_turn1, judgement_turn2 = await asyncio.gather(
+                self._safe_judge(data_point, all_data, turn=1),
+                self._safe_judge(data_point, all_data, turn=2),
+            )
+            return {
+                "judgement_turn1": judgement_turn1,
+                "judgement_turn2": judgement_turn2,
+                "generation": "",
+            }
+
+        # Multiple judges: call N times in parallel and store all judgements
+        tasks = []
+        for _ in range(num_judges):
+            tasks.append(self._safe_judge(data_point, all_data, turn=1))
+            tasks.append(self._safe_judge(data_point, all_data, turn=2))
+        results = await asyncio.gather(*tasks)
+
+        # results = [turn1_j0, turn2_j0, turn1_j1, turn2_j1, ...]
+        judgements_turn1 = [results[i] for i in range(0, len(results), 2)]
+        judgements_turn2 = [results[i] for i in range(1, len(results), 2)]
+
+        return {
+            "judgement_turn1": judgements_turn1[0],  # primary (for backward compat)
+            "judgement_turn2": judgements_turn2[0],
+            "all_judgements_turn1": judgements_turn1,
+            "all_judgements_turn2": judgements_turn2,
+            "num_judges": num_judges,
+            "generation": "",
+        }
+
+
+GENERATION_TASK_CLASS = MTBenchJudgeTask
+
+
+@hydra.main(version_base=None, config_name="base_mt_bench_judge_config")
+def generate(cfg: MTBenchJudgeConfig):
+    cfg = MTBenchJudgeConfig(_init_nested=True, **cfg)
+    LOG.info("Config used: %s", cfg)
+    task = MTBenchJudgeTask(cfg)
+    task.generate()
+
+
+HELP_MESSAGE = get_help_message(
+    MTBenchJudgeConfig,
+    server_params=server_params(),
+)
+
+
+if __name__ == "__main__":
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print(HELP_MESSAGE)
+    else:
+        setup_logging()
+        generate()

--- a/nemo_skills/prompt/config/judge/komt-bench/turn1.yaml
+++ b/nemo_skills/prompt/config/judge/komt-bench/turn1.yaml
@@ -1,0 +1,15 @@
+# Korean MT-Bench judge prompt: single-turn, no reference
+# Converted from openeval-lmalign/assets/tasks/komt_bench/judge_prompts_ko.jsonl (single-v1)
+
+system: "당신은 유용한 어시스턴트입니다."
+
+user: |-
+    [Instruction]
+     공정한 심사위원이 되어 사용자 질문에 대해 인공지능 어시스턴트가 제공한 아래 답변의 품질을 평가해 주세요. 평가할 때는 답변의 유용성, 관련성, 정확성, 깊이, 창의성 및 대답의 자세한 정도와 같은 요소를 고려해야 합니다. 간단한 설명을 제공하는 것으로 평가를 시작하세요. 가능한 한 객관적으로 평가합니다. 설명을 제공한 후에는 다음 형식을 엄격하게 준수하여 답변을 1점부터 10점까지 평가해야 합니다: "[[rating]]", for example: "점수: [[5]]".
+
+    [사용자 질문]
+    {question_1}
+
+    [어시스턴트 답변 시작]
+    {answer_1}
+    [어시스턴트 답변 끝]

--- a/nemo_skills/prompt/config/judge/komt-bench/turn1_with_ref.yaml
+++ b/nemo_skills/prompt/config/judge/komt-bench/turn1_with_ref.yaml
@@ -1,0 +1,19 @@
+# Korean MT-Bench judge prompt: single-turn, with reference answer
+# Converted from openeval-lmalign/assets/tasks/komt_bench/judge_prompts_ko.jsonl (single-math-v1)
+
+system: "당신은 유용한 어시스턴트입니다."
+
+user: |-
+    [Instruction]
+     공정한 심사위원이 되어 사용자 질문에 대해 인공지능 어시스턴트가 제공한 아래 답변의 품질을 평가해 주세요. 평가 시에는 정확성과 유용성을 고려해야 합니다. 참고 답변과 어시스턴트의 답변이 제공됩니다. 어시스턴트의 답변과 참조 답변을 비교하여 평가를 시작하세요. 실수가 있다면 찾고 수정합니다. 가능한 한 객관적으로 평가합니다. 설명을 제공한 후에는 다음 형식을 엄격하게 준수하여 답변을 1점부터 10점까지 평가해야 합니다: "[[rating]]", 예시: "점수: [[5]]".
+
+    [사용자 질문]
+    {question_1}
+
+    [참조용 답변 시작]
+    {ref_answer_1}
+    [참조용 답변 끝]
+
+    [어시스턴트 답변 시작]
+    {answer_1}
+    [어시스턴트 답변 끝]

--- a/nemo_skills/prompt/config/judge/komt-bench/turn2.yaml
+++ b/nemo_skills/prompt/config/judge/komt-bench/turn2.yaml
@@ -1,0 +1,22 @@
+# Korean MT-Bench judge prompt: multi-turn, no reference
+# Converted from openeval-lmalign/assets/tasks/komt_bench/judge_prompts_ko.jsonl (single-v1-multi-turn)
+
+system: |-
+    공정한 심사위원이 되어 사용자 질문에 대해 인공지능 어시스턴트가 제공한 아래 답변의 품질을 평가해 주세요. 평가할 때는 답변의 유용성, 관련성, 정확성, 깊이, 창의성 및 대답의 자세한 정도와 같은 요소를 고려해야 합니다. 사용자의 두번째 질문에 대한 어시스턴트의 답변에 초점을 맞춰 평가해야 합니다. 간단한 설명을 제공하는 것으로 평가를 시작하세요. 가능한 한 객관적으로 평가합니다. 설명을 제공한 후에는 다음 형식을 엄격하게 준수하여 답변을 1점부터 10점까지 평가해야 합니다: "[[rating]]", 예시: "점수: [[5]]".
+
+user: |-
+    <|어시스턴트 A와 사용자와의 대화 시작|>
+
+    ### 사용자:
+    {question_1}
+
+    ### 어시스턴트 A:
+    {answer_1}
+
+    ### 사용자:
+    {question_2}
+
+    ### 어시스턴트 A:
+    {answer_2}
+
+    <|어시스턴트 A와 사용자와의 대화 종료|>

--- a/nemo_skills/prompt/config/judge/komt-bench/turn2_with_ref.yaml
+++ b/nemo_skills/prompt/config/judge/komt-bench/turn2_with_ref.yaml
@@ -1,0 +1,39 @@
+# Korean MT-Bench judge prompt: multi-turn, with reference answers
+# Converted from openeval-lmalign/assets/tasks/komt_bench/judge_prompts_ko.jsonl (single-math-v1-multi-turn)
+
+system: |-
+    공정한 심사위원이 되어 사용자 질문에 대해 인공지능 어시스턴트가 제공한 답변의 품질을 평가해 주세요. 평가 시에는 정확성과 유용성을 고려해야 합니다. 참고 답변과 어시스턴트의 답변이 제공됩니다. 사용자의 두번째 질문에 대한 어시스턴트의 답변에 초점을 맞춰 평가해야 합니다. 어시스턴트의 답변과 참조 답변을 비교하여 평가를 시작하세요. 실수가 있다면 찾고 수정합니다. 가능한 한 객관적으로 평가합니다. 설명을 제공한 후에는 다음 형식을 엄격하게 준수하여 답변을 1점부터 10점까지 평가해야 합니다: "[[rating]]", 예시: "점수: [[5]]".
+
+user: |-
+    <|참조용 답변 시작|>
+
+    ### 사용자:
+    {question_1}
+
+    ### 참조용 답변:
+    {ref_answer_1}
+
+    ### 사용자:
+    {question_2}
+
+    ### 참조용 답변:
+    {ref_answer_2}
+
+    <|참조용 답변 끝|>
+
+
+    <|어시스턴트 A와 사용자와의 대화 시작|>
+
+    ### 사용자:
+    {question_1}
+
+    ### 어시스턴트 A:
+    {answer_1}
+
+    ### 사용자:
+    {question_2}
+
+    ### 어시스턴트 A:
+    {answer_2}
+
+    <|어시스턴트 A와 사용자와의 대화 끝|>

--- a/tests/test_mt_bench_metrics.py
+++ b/tests/test_mt_bench_metrics.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import pytest
+
+from nemo_skills.evaluation.metrics.mt_bench_metrics import MTBenchMetrics
+
+
+def _pred(turn1, turn2, *, category="writing", target_language=None, answer_1=None, answer_2=None):
+    pred = {
+        "category": category,
+        "judgement_turn1": f"[[{turn1}]]" if turn1 is not None else "",
+        "judgement_turn2": f"[[{turn2}]]" if turn2 is not None else "",
+    }
+    if target_language is not None:
+        pred["target_language"] = target_language
+    if answer_1 is not None:
+        pred["answer_1"] = answer_1
+    if answer_2 is not None:
+        pred["answer_2"] = answer_2
+    return pred
+
+
+# ---- Plain MT-Bench (no target_language) ----------------------------------
+
+
+def test_mt_bench_single_sample_per_row():
+    m = MTBenchMetrics()
+    m.update([_pred(8.0, 7.0, category="writing")])
+    m.update([_pred(6.0, 5.0, category="math")])
+
+    metrics = m.get_metrics()
+    assert list(metrics.keys()) == ["pass@1"]
+    overall = metrics["pass@1"]
+    assert overall["num_entries"] == 2
+    assert overall["average_score"] == (8.0 + 7.0 + 6.0 + 5.0) / 4
+    assert overall["turn1_average"] == 7.0
+    assert overall["turn2_average"] == 6.0
+    assert overall["category_writing"] == 7.5
+    assert overall["category_math"] == 5.5
+    # No target_language anywhere — raw_* should not be emitted.
+    assert "raw_average_score" not in overall
+    assert m.evaluations_to_print() == ["pass@1"]
+
+
+def test_mt_bench_task_n_flattens_samples():
+    m = MTBenchMetrics()
+    n = 3
+    m.update([_pred(s, s, category="writing") for s in (4.0, 6.0, 8.0)])
+
+    metrics = m.get_metrics()
+    assert m.total == 1
+    assert m.max_k == n
+    assert len(m.entries) == n
+    # Single-key output: pass@1 already aggregates over all N samples.
+    assert list(metrics.keys()) == ["pass@1"]
+    overall = metrics["pass@1"]
+    assert overall["turn1_average"] == 6.0
+    assert overall["turn2_average"] == 6.0
+    assert overall["average_score"] == 6.0
+    assert m.evaluations_to_print() == ["pass@1"]
+
+
+def test_mt_bench_multi_judge_averaging():
+    m = MTBenchMetrics()
+    pred = {
+        "category": "writing",
+        "all_judgements_turn1": ["[[8]]", "[[6]]", "[[10]]"],
+        "all_judgements_turn2": ["[[5]]", "[[7]]"],
+    }
+    m.update([pred])
+    overall = m.get_metrics()["pass@1"]
+    assert overall["turn1_average"] == 8.0
+    assert overall["turn2_average"] == 6.0
+
+
+def test_mt_bench_invalid_ratings_dropped():
+    m = MTBenchMetrics()
+    pred = {
+        "category": "writing",
+        "judgement_turn1": "no rating here",
+        "judgement_turn2": "[[15]]",  # out of 1-10 range
+    }
+    m.update([pred])
+    overall = m.get_metrics()["pass@1"]
+    assert "average_score" not in overall
+    assert overall["num_entries"] == 1
+
+
+# ---- target_language penalty (covers former KomtBench behavior) ----------
+
+KO_ANSWER = "안녕하세요 반갑습니다 정말 좋은 하루 보내세요"
+EN_ANSWER = "Hello, glad to meet you. Have a wonderful day."
+
+
+def test_mt_bench_target_language_match_no_penalty():
+    m = MTBenchMetrics()
+    m.update([_pred(8.0, 6.0, target_language="ko", answer_1=KO_ANSWER, answer_2=KO_ANSWER)])
+    overall = m.get_metrics()["pass@1"]
+    assert overall["turn1_average"] == 8.0
+    assert overall["turn2_average"] == 6.0
+    # Penalty path was active so raw_* should be emitted (and equal primary).
+    assert overall["raw_turn1_average"] == 8.0
+    assert overall["raw_turn2_average"] == 6.0
+
+
+def test_mt_bench_target_language_mismatch_applies_sqrt_penalty():
+    m = MTBenchMetrics()
+    m.update([_pred(9.0, 4.0, target_language="ko", answer_1=EN_ANSWER, answer_2=EN_ANSWER)])
+    overall = m.get_metrics()["pass@1"]
+    assert math.isclose(overall["turn1_average"], math.sqrt(9.0))
+    assert math.isclose(overall["turn2_average"], math.sqrt(4.0))
+    assert overall["raw_turn1_average"] == 9.0
+    assert overall["raw_turn2_average"] == 4.0
+
+
+def test_mt_bench_no_target_language_means_no_penalty():
+    """Plain MT-Bench: target_language unset → penalty never applies even for English."""
+    m = MTBenchMetrics()
+    m.update([_pred(9.0, 4.0, answer_1=EN_ANSWER, answer_2=EN_ANSWER)])
+    overall = m.get_metrics()["pass@1"]
+    assert overall["turn1_average"] == 9.0
+    assert overall["turn2_average"] == 4.0
+    assert "raw_turn1_average" not in overall
+
+
+def test_mt_bench_per_sample_penalty_under_task_n():
+    """Penalty is applied per (row, sample), so mixed-language samples mix penalized and raw."""
+    m = MTBenchMetrics()
+    m.update(
+        [
+            _pred(9.0, 9.0, target_language="ko", answer_1=KO_ANSWER, answer_2=KO_ANSWER),
+            _pred(9.0, 9.0, target_language="ko", answer_1=EN_ANSWER, answer_2=EN_ANSWER),
+        ]
+    )
+    overall = m.get_metrics()["pass@1"]
+    expected = (9.0 + math.sqrt(9.0)) / 2
+    assert math.isclose(overall["turn1_average"], expected)
+    assert math.isclose(overall["turn2_average"], expected)
+    assert overall["raw_turn1_average"] == 9.0
+    assert overall["raw_turn2_average"] == 9.0
+
+
+def test_mt_bench_invalid_target_language_raises():
+    m = MTBenchMetrics()
+    with pytest.raises(ValueError, match="ISO 639-1"):
+        m.update([_pred(8.0, 8.0, target_language="xx", answer_1=KO_ANSWER, answer_2=KO_ANSWER)])
+
+
+def test_mt_bench_missing_required_fields_fail_fast():
+    m = MTBenchMetrics()
+    # Required single-judge fields use direct indexing, so missing keys raise.
+    with pytest.raises(KeyError):
+        m.update([{"category": "writing"}])


### PR DESCRIPTION
Closes #1377

## Summary
Add MT-Bench (80 two-turn English questions) and Komt-Bench (80 two-turn Korean questions) with LLM-as-judge evaluation.

### Architecture
Both benchmarks share the same generation + judge modules:
- **`mt_bench.py`** — Two-turn generation: answer_1 for question_1, then answer_2 conditioned on full conversation
- **`mt_bench_judge.py`** — Per-turn 1-10 scoring with multi-judge averaging (default 8 calls), reference-aware prompts for math/reasoning/coding categories

### Metrics
- **`MTBenchMetrics`** — Parses `[[rating]]` from judge output; per-turn and per-category averages
- **`KomtBenchMetrics`** — Extends `MTBenchMetrics` with `sqrt(score)` penalty for non-Korean responses (code-output questions exempted)

### Data
| Benchmark | Source | Format |
|---|---|---|
| mt-bench | [FastChat repo](https://github.com/lm-sys/FastChat) questions + GPT-4 ref answers | `prepare.py` downloads |
| komt-bench | [LGAI-EXAONE/KoMT-Bench](https://huggingface.co/datasets/LGAI-EXAONE/KoMT-Bench) | `prepare.py` downloads |

MT-Bench reuses existing English judge prompts at `judge/mt-bench/`. Komt-Bench adds Korean judge prompts at `judge/komt-bench/` (4 turn/ref variants).

## Changes

### New files (12)
- `nemo_skills/dataset/{mt-bench,komt-bench}/` — `__init__.py` + `prepare.py` each
- `nemo_skills/inference/eval/mt_bench.py`, `mt_bench_judge.py`
- `nemo_skills/evaluation/metrics/mt_bench_metrics.py`, `komt_bench_metrics.py`
- `nemo_skills/prompt/config/judge/komt-bench/` — 4 YAMLs

### Modified files (1)
- `nemo_skills/evaluation/metrics/map_metrics.py` — register `mt_bench` + `komt_bench` (+4 lines)

## Test plan
- [ ] `ns eval --benchmarks mt-bench --model <model>` — verify two-turn generation + judge scoring + metrics
- [ ] `ns eval --benchmarks komt-bench --model <model>` — verify Korean prompts + language penalty
- [ ] Existing benchmarks unaffected (metrics map additions only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MT-Bench evaluation: two-turn generation, judging, and Hydra-configured CLI entrypoints.
  * KoMT-Bench (Korean MT-Bench) dataset support with dataset preparation utilities.
  * New Korean judge prompt templates for single- and multi-turn evaluation (with/without references).
  * Multi-judge execution with aggregated and per-turn outputs; language-aware scoring that applies a penalty when answers mismatch a target language.

* **Tests**
  * Comprehensive tests validating MT-Bench metrics, averaging, penalty logic, multi-judge behavior, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->