### PR TITLE
Fix parent process error leakage in sandbox execution results

### DIFF
--- a/nemo_skills/code_execution/local_sandbox/local_sandbox_server.py
+++ b/nemo_skills/code_execution/local_sandbox/local_sandbox_server.py
@@ -212,6 +212,20 @@ class ShellManager:
         proc.terminate()
         proc.join(timeout=2.0)
 
+    def _finish_restart(self, shell_id):
+        """Start a fresh shell and mark it as needing session restore.
+
+        IMPORTANT: Must be called OUTSIDE except handlers. start_shell() uses
+        multiprocessing.Process.start() → os.fork(). A child forked inside an
+        except block inherits sys.exc_info() from the parent, causing Python's
+        implicit exception chaining to attach the parent's exception context to
+        every subsequent exception in the child process.
+        """
+        self.start_shell(shell_id)
+        with self.manager_lock:
+            if shell_id in self.shells:
+                self.shells[shell_id]["restart_pending"] = True
+
     def _cleanup_shell_resources(self, proc, conn):
         # Best-effort teardown for the current shell process and pipe.
         try:
@@ -270,6 +284,7 @@ class ShellManager:
 
         exec_id = time.time_ns()
         with lock:
+            _need_restart = False
             # send execution request
             try:
                 conn.send({"cmd": "exec", "id": exec_id, "code": code, "traceback_verbosity": traceback_verbosity})
@@ -278,25 +293,26 @@ class ShellManager:
                 # clean up the shell process and connection - best-effort
                 self._cleanup_shell_resources(proc, conn)
 
-                # remove and restart a fresh shell for this id
+                # remove the old shell entry
                 with self.manager_lock:
                     self.shells.pop(shell_id, None)
-                self.start_shell(shell_id)
 
-                # Mark the new shell as having a restart pending so the caller can restore session state
-                with self.manager_lock:
-                    if shell_id in self.shells:
-                        self.shells[shell_id]["restart_pending"] = True
-
-                return {
+                _need_restart = True
+                _exc_msg = str(exc)
+                _restart_result = {
                     "status": "error",
-                    "msg": f"send failed: {exc}",
+                    "msg": f"send failed: {_exc_msg}",
                     "shell_was_created": shell_was_created,
                     "shell_was_restarted": True,
                     "shell_was_recently_restarted": shell_was_recently_restarted,
                 }
 
+            if _need_restart:
+                self._finish_restart(shell_id)
+                return _restart_result
+
             # wait for the result up to `timeout`
+            _need_restart = False
             if conn.poll(timeout):
                 try:
                     result = conn.recv()
@@ -310,23 +326,22 @@ class ShellManager:
                     # clean up the shell process and connection - best-effort
                     self._cleanup_shell_resources(proc, conn)
 
-                    # remove and restart a fresh shell for this id
+                    # remove the old shell entry
                     with self.manager_lock:
                         self.shells.pop(shell_id, None)
-                    self.start_shell(shell_id)
 
-                    # Mark the new shell as having a restart pending
-                    with self.manager_lock:
-                        if shell_id in self.shells:
-                            self.shells[shell_id]["restart_pending"] = True
-
-                    return {
+                    _need_restart = True
+                    _restart_result = {
                         "status": "error",
                         "msg": "connection closed",
                         "shell_was_created": shell_was_created,
                         "shell_was_restarted": True,
                         "shell_was_recently_restarted": shell_was_recently_restarted,
                     }
+
+            if _need_restart:
+                self._finish_restart(shell_id)
+                return _restart_result
 
             # no reply yet -> try gentle interrupt (SIGINT)
             try:
@@ -340,6 +355,7 @@ class ShellManager:
                 pass
 
             # wait short grace period for the shell to handle the interrupt
+            _need_restart = False
             if conn.poll(grace):
                 try:
                     result = conn.recv()
@@ -352,23 +368,22 @@ class ShellManager:
                     # clean up the shell process and connection - best-effort
                     self._cleanup_shell_resources(proc, conn)
 
-                    # remove and restart a fresh shell for this id
+                    # remove the old shell entry
                     with self.manager_lock:
                         self.shells.pop(shell_id, None)
-                    self.start_shell(shell_id)
 
-                    # Mark the new shell as having a restart pending
-                    with self.manager_lock:
-                        if shell_id in self.shells:
-                            self.shells[shell_id]["restart_pending"] = True
-
-                    return {
+                    _need_restart = True
+                    _restart_result = {
                         "status": "interrupted",
                         "msg": "connection closed after interrupt",
                         "shell_was_created": shell_was_created,
                         "shell_was_restarted": True,
                         "shell_was_recently_restarted": shell_was_recently_restarted,
                     }
+
+            if _need_restart:
+                self._finish_restart(shell_id)
+                return _restart_result
 
             # still stuck -> terminate the shell and restart it (drop memory)
             # clean up the shell process and connection - best-effort
@@ -377,12 +392,7 @@ class ShellManager:
             # remove and restart a fresh shell for this id
             with self.manager_lock:
                 self.shells.pop(shell_id, None)
-            self.start_shell(shell_id)
-
-            # Mark the new shell as having a restart pending
-            with self.manager_lock:
-                if shell_id in self.shells:
-                    self.shells[shell_id]["restart_pending"] = True
+            self._finish_restart(shell_id)
 
             return {
                 "status": "timeout_killed",

--- a/tests/test_sandbox_fork_exc_leak.py
+++ b/tests/test_sandbox_fork_exc_leak.py
@@ -13,183 +13,131 @@
 # limitations under the License.
 
 """
-Tests that shell_worker processes forked during shell restart do not inherit
-the parent's exception state via sys.exc_info().
+Functional test for the fork-inside-except traceback leak bug.
 
-Bug: ShellManager.run_cell() calls start_shell() inside except handlers.
-os.fork() copies the parent's sys.exc_info(), so the new shell_worker
-inherits the EOFError. Any subsequent user code error then gets implicit
-exception chaining (__context__ = EOFError), and IPython formats the full
-chain — leaking internal sandbox frames into the tool output.
+When ShellManager.run_cell() restarts a dead shell inside an except handler,
+os.fork() copies the parent's sys.exc_info() into the child process. Any
+subsequent error in the child gets implicit exception chaining, leaking
+internal sandbox tracebacks (EOFError from conn.recv()) into tool output.
 
-Fix: Move start_shell() calls outside except handlers (flag pattern) so
-sys.exc_info() is cleared before forking.
+This test kills a shell worker, lets run_cell() handle the restart, then
+runs error-producing code and asserts no leaked exception chain.
 """
 
-import multiprocessing
+import io
 import os
 import signal
 import sys
-
-import pytest
-
-# ---------------------------------------------------------------------------
-# Unit tests: core mechanism (no IPython / Flask required)
-# ---------------------------------------------------------------------------
+import traceback
+import types
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
 
 
-def _child_check_exc_info(conn):
-    """Child process that reports its inherited sys.exc_info()."""
-    exc = sys.exc_info()
-    conn.send({"exc_type": type(exc[1]).__name__ if exc[1] else None})
+def _test_shell_worker(conn):
+    """Minimal shell_worker for testing — uses exec() instead of IPython.
 
-    # Raise a new exception and check __context__
+    Avoids traitlets class-identity issues after fork in IPython 9.x.
+    The bug under test is in ShellManager.run_cell() (whether it forks
+    inside an except handler), not in shell_worker itself.
+    """
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    namespace = {}
     try:
-        raise NameError("test")
-    except NameError as e:
-        conn.send(
-            {
-                "context_type": type(e.__context__).__name__ if e.__context__ else None,
-            }
-        )
-    conn.close()
-
-
-class TestForkExcInfoInheritance:
-    """Verify that os.fork() inside an except handler leaks exc_info to child."""
-
-    def test_fork_inside_except_inherits_exc_info(self):
-        """Child forked inside except handler DOES inherit the exception."""
-        try:
-            raise EOFError("simulated conn.recv failure")
-        except EOFError:
-            parent_conn, child_conn = multiprocessing.Pipe()
-            proc = multiprocessing.Process(target=_child_check_exc_info, args=(child_conn,))
-            proc.start()
-            exc_msg = parent_conn.recv()
-            ctx_msg = parent_conn.recv()
-            proc.join(timeout=5)
-            parent_conn.close()
-
-        # This test documents the bug mechanism — it should always pass
-        assert exc_msg["exc_type"] == "EOFError"
-        assert ctx_msg["context_type"] == "EOFError"
-
-    def test_fork_outside_except_clean_exc_info(self):
-        """Child forked outside except handler has clean exc_info."""
-        need_restart = False
-        try:
-            raise EOFError("simulated conn.recv failure")
-        except EOFError:
-            need_restart = True
-
-        # Fork AFTER except block exits — sys.exc_info() is cleared
-        assert need_restart
-        parent_conn, child_conn = multiprocessing.Pipe()
-        proc = multiprocessing.Process(target=_child_check_exc_info, args=(child_conn,))
-        proc.start()
-        exc_msg = parent_conn.recv()
-        ctx_msg = parent_conn.recv()
-        proc.join(timeout=5)
-        parent_conn.close()
-
-        assert exc_msg["exc_type"] is None
-        assert ctx_msg["context_type"] is None
-
-
-# ---------------------------------------------------------------------------
-# Integration test: ShellManager with real IPython shell_worker
-# ---------------------------------------------------------------------------
-
-
-class TestShellManagerNoTracbackLeak:
-    """After shell restart, user code errors must not contain leaked traceback."""
-
-    @pytest.fixture()
-    def shell_manager(self):
-        from nemo_skills.code_execution.local_sandbox.local_sandbox_server import ShellManager
-
-        mgr = ShellManager()
-        yield mgr
-        # Cleanup all shells
-        for sid in list(mgr.shells.keys()):
+        while True:
             try:
-                mgr.stop_shell(sid)
-            except Exception:
-                pass
+                msg = conn.recv()
+            except EOFError:
+                break
+            if not isinstance(msg, dict):
+                continue
+            cmd = msg.get("cmd")
+            if cmd == "exec":
+                code = msg.get("code", "")
+                exec_id = msg.get("id")
+                stdout_buf = io.StringIO()
+                stderr_buf = io.StringIO()
+                has_error = False
+                try:
+                    with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
+                        exec(code, namespace)
+                except Exception:
+                    has_error = True
+                    stdout_buf.write(traceback.format_exc())
+                conn.send(
+                    {
+                        "status": "ok",
+                        "id": exec_id,
+                        "result_repr": "None",
+                        "stdout": stdout_buf.getvalue(),
+                        "stderr": stderr_buf.getvalue(),
+                        "has_error": has_error,
+                    }
+                )
+            elif cmd == "shutdown":
+                break
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
 
-    def test_restart_after_kill_no_eof_leak(self, shell_manager):
-        """Kill shell_worker, trigger restart via EOFError, then verify clean output."""
-        sid = "test-eof-leak"
 
-        # 1. Start shell, run harmless code
-        r1 = shell_manager.run_cell(sid, "x = 42", timeout=5.0)
-        assert r1["status"] == "ok"
-        assert not r1.get("has_error")
+def _get_server_module():
+    """Import the sandbox server module, mocking unavailable deps."""
+    mocks = {}
+    for dep in ("psutil", "flask"):
+        if dep not in sys.modules:
+            mocks[dep] = types.ModuleType(dep)
+            if dep == "flask":
+                mocks[dep].Flask = mock.MagicMock()
+                mocks[dep].request = mock.MagicMock()
 
-        # 2. Kill the shell_worker process to force EOFError on next recv
-        entry = shell_manager.shells[sid]
-        proc = entry["proc"]
+    with mock.patch.dict(sys.modules, mocks):
+        import nemo_skills.code_execution.local_sandbox.local_sandbox_server as mod
+
+    # Replace shell_worker with test-friendly version that doesn't need IPython
+    mod.shell_worker = _test_shell_worker
+    return mod
+
+
+def test_error_after_shell_restart_has_no_exception_chain():
+    """After shell death + restart, errors must not chain with parent EOFError.
+
+    Scenario: start shell → kill it → run_cell (triggers restart) →
+    run error code → output should have only NameError, not EOFError.
+    """
+    mod = _get_server_module()
+    mgr = mod.ShellManager()
+
+    try:
+        # 1. Create shell and confirm it works
+        r1 = mgr.run_cell("test", "x = 42", timeout=5.0)
+        assert r1["status"] == "ok", f"Initial run_cell failed: {r1}"
+
+        # 2. Kill the shell worker process (simulates OOM/crash)
+        with mgr.manager_lock:
+            proc = mgr.shells["test"]["proc"]
         os.kill(proc.pid, signal.SIGKILL)
-        proc.join(timeout=3.0)
+        proc.join(timeout=3)
 
-        # 3. Next run_cell → conn.recv raises EOFError → shell restarts
-        r2 = shell_manager.run_cell(sid, "y = 1", timeout=5.0)
-        # Should report error or restart (the exact status depends on timing:
-        # conn.send might fail first, or conn.recv raises EOFError)
-        assert r2.get("shell_was_restarted") or r2["status"] in ("error", "ok")
+        # 3. run_cell on dead shell → triggers except handler → restart
+        mgr.run_cell("test", "y = 1", timeout=5.0)
 
-        # 4. Run code that raises NameError in the restarted shell
-        r3 = shell_manager.run_cell(sid, "z = undefined_var + 1", timeout=5.0)
-        assert r3["status"] == "ok"
-        assert r3.get("has_error")
+        # 4. Run error-producing code in the restarted shell
+        result = mgr.run_cell("test", "z = undefined_var + 1", timeout=5.0)
+        assert result["status"] == "ok", f"Unexpected status: {result}"
+        assert result.get("has_error"), f"Expected an error: {result}"
 
-        output = r3.get("stdout", "") + r3.get("stderr", "")
+        output = result.get("stdout", "") + result.get("stderr", "")
+        assert "NameError" in output, f"Expected NameError:\n{output}"
 
-        # THE CRITICAL ASSERTIONS:
-        assert "EOFError" not in output, f"Leaked EOFError traceback into tool output:\n{output}"
+        # THE BUG: if start_shell() ran inside an except handler, the forked
+        # child inherited sys.exc_info() and every error gets chained with
+        # "During handling of the above exception, another exception occurred"
+        assert "EOFError" not in output, f"Parent EOFError leaked into child output:\n{output}"
         assert "During handling of the above exception" not in output, (
-            f"Exception chain from parent process leaked into output:\n{output}"
+            f"Exception chain leaked into child output:\n{output}"
         )
-        assert "conn.recv" not in output, f"Parent-process conn.recv() frame leaked into output:\n{output}"
-
-        # Should contain ONLY the user's NameError
-        assert "NameError" in output
-
-    def test_restart_after_timeout_no_eof_leak(self, shell_manager):
-        """Timeout → SIGINT → shell dies → restart, then verify clean output."""
-        sid = "test-timeout-leak"
-
-        # 1. Run code that will block, with a short timeout
-        #    Use a tight loop that ignores SIGINT to force the kill path
-        blocking_code = "import signal, time\nsignal.signal(signal.SIGINT, signal.SIG_IGN)\ntime.sleep(120)\n"
-        r1 = shell_manager.run_cell(sid, blocking_code, timeout=1.0, grace=1.0)
-        # Should be timeout_killed since it ignores SIGINT
-        assert r1["status"] in ("timeout_killed", "interrupted", "error")
-
-        # 2. Run code that raises an error in the restarted shell
-        r2 = shell_manager.run_cell(sid, "z = undefined_var + 1", timeout=5.0)
-        assert r2["status"] == "ok"
-        assert r2.get("has_error")
-
-        output = r2.get("stdout", "") + r2.get("stderr", "")
-
-        assert "EOFError" not in output, f"Leaked EOFError traceback into tool output:\n{output}"
-        assert "During handling of the above exception" not in output, (
-            f"Exception chain from parent process leaked into output:\n{output}"
-        )
-        assert "NameError" in output
-
-    def test_normal_error_no_chain(self, shell_manager):
-        """Without any restart, errors should never have exception chaining."""
-        sid = "test-no-chain"
-
-        # Just run code that errors — no restart involved
-        r = shell_manager.run_cell(sid, "z = undefined_var + 1", timeout=5.0)
-        assert r["status"] == "ok"
-        assert r.get("has_error")
-
-        output = r.get("stdout", "") + r.get("stderr", "")
-        assert "NameError" in output
-        assert "During handling of the above exception" not in output
-        assert "EOFError" not in output
+    finally:
+        mgr.stop_shell("test")

--- a/tests/test_sandbox_fork_exc_leak.py
+++ b/tests/test_sandbox_fork_exc_leak.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests that shell_worker processes forked during shell restart do not inherit
+the parent's exception state via sys.exc_info().
+
+Bug: ShellManager.run_cell() calls start_shell() inside except handlers.
+os.fork() copies the parent's sys.exc_info(), so the new shell_worker
+inherits the EOFError. Any subsequent user code error then gets implicit
+exception chaining (__context__ = EOFError), and IPython formats the full
+chain — leaking internal sandbox frames into the tool output.
+
+Fix: Move start_shell() calls outside except handlers (flag pattern) so
+sys.exc_info() is cleared before forking.
+"""
+
+import multiprocessing
+import os
+import signal
+import sys
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Unit tests: core mechanism (no IPython / Flask required)
+# ---------------------------------------------------------------------------
+
+
+def _child_check_exc_info(conn):
+    """Child process that reports its inherited sys.exc_info()."""
+    exc = sys.exc_info()
+    conn.send({"exc_type": type(exc[1]).__name__ if exc[1] else None})
+
+    # Raise a new exception and check __context__
+    try:
+        raise NameError("test")
+    except NameError as e:
+        conn.send(
+            {
+                "context_type": type(e.__context__).__name__ if e.__context__ else None,
+            }
+        )
+    conn.close()
+
+
+class TestForkExcInfoInheritance:
+    """Verify that os.fork() inside an except handler leaks exc_info to child."""
+
+    def test_fork_inside_except_inherits_exc_info(self):
+        """Child forked inside except handler DOES inherit the exception."""
+        try:
+            raise EOFError("simulated conn.recv failure")
+        except EOFError:
+            parent_conn, child_conn = multiprocessing.Pipe()
+            proc = multiprocessing.Process(target=_child_check_exc_info, args=(child_conn,))
+            proc.start()
+            exc_msg = parent_conn.recv()
+            ctx_msg = parent_conn.recv()
+            proc.join(timeout=5)
+            parent_conn.close()
+
+        # This test documents the bug mechanism — it should always pass
+        assert exc_msg["exc_type"] == "EOFError"
+        assert ctx_msg["context_type"] == "EOFError"
+
+    def test_fork_outside_except_clean_exc_info(self):
+        """Child forked outside except handler has clean exc_info."""
+        need_restart = False
+        try:
+            raise EOFError("simulated conn.recv failure")
+        except EOFError:
+            need_restart = True
+
+        # Fork AFTER except block exits — sys.exc_info() is cleared
+        assert need_restart
+        parent_conn, child_conn = multiprocessing.Pipe()
+        proc = multiprocessing.Process(target=_child_check_exc_info, args=(child_conn,))
+        proc.start()
+        exc_msg = parent_conn.recv()
+        ctx_msg = parent_conn.recv()
+        proc.join(timeout=5)
+        parent_conn.close()
+
+        assert exc_msg["exc_type"] is None
+        assert ctx_msg["context_type"] is None
+
+
+# ---------------------------------------------------------------------------
+# Integration test: ShellManager with real IPython shell_worker
+# ---------------------------------------------------------------------------
+
+
+class TestShellManagerNoTracbackLeak:
+    """After shell restart, user code errors must not contain leaked traceback."""
+
+    @pytest.fixture()
+    def shell_manager(self):
+        from nemo_skills.code_execution.local_sandbox.local_sandbox_server import ShellManager
+
+        mgr = ShellManager()
+        yield mgr
+        # Cleanup all shells
+        for sid in list(mgr.shells.keys()):
+            try:
+                mgr.stop_shell(sid)
+            except Exception:
+                pass
+
+    def test_restart_after_kill_no_eof_leak(self, shell_manager):
+        """Kill shell_worker, trigger restart via EOFError, then verify clean output."""
+        sid = "test-eof-leak"
+
+        # 1. Start shell, run harmless code
+        r1 = shell_manager.run_cell(sid, "x = 42", timeout=5.0)
+        assert r1["status"] == "ok"
+        assert not r1.get("has_error")
+
+        # 2. Kill the shell_worker process to force EOFError on next recv
+        entry = shell_manager.shells[sid]
+        proc = entry["proc"]
+        os.kill(proc.pid, signal.SIGKILL)
+        proc.join(timeout=3.0)
+
+        # 3. Next run_cell → conn.recv raises EOFError → shell restarts
+        r2 = shell_manager.run_cell(sid, "y = 1", timeout=5.0)
+        # Should report error or restart (the exact status depends on timing:
+        # conn.send might fail first, or conn.recv raises EOFError)
+        assert r2.get("shell_was_restarted") or r2["status"] in ("error", "ok")
+
+        # 4. Run code that raises NameError in the restarted shell
+        r3 = shell_manager.run_cell(sid, "z = undefined_var + 1", timeout=5.0)
+        assert r3["status"] == "ok"
+        assert r3.get("has_error")
+
+        output = r3.get("stdout", "") + r3.get("stderr", "")
+
+        # THE CRITICAL ASSERTIONS:
+        assert "EOFError" not in output, f"Leaked EOFError traceback into tool output:\n{output}"
+        assert "During handling of the above exception" not in output, (
+            f"Exception chain from parent process leaked into output:\n{output}"
+        )
+        assert "conn.recv" not in output, f"Parent-process conn.recv() frame leaked into output:\n{output}"
+
+        # Should contain ONLY the user's NameError
+        assert "NameError" in output
+
+    def test_restart_after_timeout_no_eof_leak(self, shell_manager):
+        """Timeout → SIGINT → shell dies → restart, then verify clean output."""
+        sid = "test-timeout-leak"
+
+        # 1. Run code that will block, with a short timeout
+        #    Use a tight loop that ignores SIGINT to force the kill path
+        blocking_code = "import signal, time\nsignal.signal(signal.SIGINT, signal.SIG_IGN)\ntime.sleep(120)\n"
+        r1 = shell_manager.run_cell(sid, blocking_code, timeout=1.0, grace=1.0)
+        # Should be timeout_killed since it ignores SIGINT
+        assert r1["status"] in ("timeout_killed", "interrupted", "error")
+
+        # 2. Run code that raises an error in the restarted shell
+        r2 = shell_manager.run_cell(sid, "z = undefined_var + 1", timeout=5.0)
+        assert r2["status"] == "ok"
+        assert r2.get("has_error")
+
+        output = r2.get("stdout", "") + r2.get("stderr", "")
+
+        assert "EOFError" not in output, f"Leaked EOFError traceback into tool output:\n{output}"
+        assert "During handling of the above exception" not in output, (
+            f"Exception chain from parent process leaked into output:\n{output}"
+        )
+        assert "NameError" in output
+
+    def test_normal_error_no_chain(self, shell_manager):
+        """Without any restart, errors should never have exception chaining."""
+        sid = "test-no-chain"
+
+        # Just run code that errors — no restart involved
+        r = shell_manager.run_cell(sid, "z = undefined_var + 1", timeout=5.0)
+        assert r["status"] == "ok"
+        assert r.get("has_error")
+
+        output = r.get("stdout", "") + r.get("stderr", "")
+        assert "NameError" in output
+        assert "During handling of the above exception" not in output
+        assert "EOFError" not in output


### PR DESCRIPTION
During RL training rollouts, samples had raw internal sandbox tracebacks leaked into the model's tool call results. The model sees output like:

```
Traceback (most recent call last):
  File /app/./main.py:307 in run_cell
    result = conn.recv()
  File /usr/local/lib/python3.10/multiprocessing/connection.py:250 in recv
    buf = self._recv_bytes()
  File /usr/local/lib/python3.10/multiprocessing/connection.py:414 in _recv_bytes
    buf = self._recv(4)
  File /usr/local/lib/python3.10/multiprocessing/connection.py:383 in _recv
    raise EOFError
EOFError

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
    print("Can place rooks?", test_pawn_set(pawn_set, n))
    return can_place_rooks(pawn_set, n)
    pawns_in_row = sorted([c for (rr,cc) in pawn_set if rr == r])
NameError: free variable 'c' referenced before assignment in enclosing scope
```

The first traceback (`/app/./main.py:307 in run_cell`) is from the sandbox server's parent process, completely irrelevant to
the user's code. It should never be visible. The second traceback is the actual user code error.

## Root Cause

`os.fork()` inside a Python `except` handler causes the child process to inherit the parent's `sys.exc_info()` state.

Key code from the reproduction:

```python
# BUGGY: fork inside except handler
try:
    conn.recv()
except EOFError:
    proc = multiprocessing.Process(target=shell_worker, ...)
    proc.start()  # child inherits sys.exc_info() = EOFError

# FIXED: fork outside except handler
need_restart = False
try:
    conn.recv()
except EOFError:
    need_restart = True  # just set a flag

# sys.exc_info() cleared after except block exits
if need_restart:
    proc = multiprocessing.Process(target=shell_worker, ...)
    proc.start()  # child has clean sys.exc_info() = None
```

## The Fix

Add a `_finish_restart()` helper and restructure `run_cell()` so that `start_shell()`
(which forks) is always called after the except block exits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell restart handling in the local code-execution sandbox to prevent exception-context leaking and ensure error reports after a restart are clean.

* **Tests**
  * Added end-to-end tests that simulate worker crashes and verify restarted shells do not include parent-process exception chaining in user error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->