### PR TITLE
SWE-bench: fix data_dir crash

### DIFF
--- a/nemo_skills/inference/eval/swebench.py
+++ b/nemo_skills/inference/eval/swebench.py
@@ -509,6 +509,7 @@ class SweBenchGenerationTask(GenerationTask):
         apptainer_cmd = (
             f"apptainer exec --writable-tmpfs --cleanenv --no-mount home,tmp,bind-paths "
             f"--mount type=bind,src=/nemo_run/code,dst=/nemo_run/code "
+            f"--mount type=bind,src={Path(self.cfg.input_file).parent},dst=/input_mount,ro "
             f"--mount type=bind,src=/root,dst=/root_mount,ro "
             f"--mount type=bind,src={self.output_dir},dst=/trajectories_mount "
             f"{extra_apptainer_args} "
@@ -838,7 +839,7 @@ class SweBenchGenerationTask(GenerationTask):
             "source /root/OpenHands/.venv/bin/activate && "
             # copy dataset
             f"mkdir {data_dir} && "
-            f"cp {self.cfg.input_file} {data_dir}/dataset.jsonl && "
+            f"cp /input_mount/{Path(self.cfg.input_file).name} {data_dir}/dataset.jsonl && "
             # set up config files
             f"echo {shlex.quote(config_str)} >config.toml && "
             f"echo \"selected_ids = ['{data_point['instance_id']}']\" >evaluation/benchmarks/{benchmark_name}/config.toml && "

--- a/nemo_skills/inference/eval/swebench.py
+++ b/nemo_skills/inference/eval/swebench.py
@@ -970,7 +970,7 @@ class SweBenchGenerationTask(GenerationTask):
                     "cd /root/SWE-bench && "
                     # run the evaluation with streaming output
                     f"/root/SWE-bench/venv/bin/python -m swebench.harness.run_local_evaluation "
-                    f"    --raw_sample_path {self.cfg.input_file} "
+                    f"    --raw_sample_path /input_mount/{Path(self.cfg.input_file).name} "
                     f"    --patch_path {pred_mounted_path} "
                     f"    --output_dir eval-outputs "
                     f"    --scripts_dir /root/SWE-bench/run_scripts && "
@@ -988,7 +988,7 @@ class SweBenchGenerationTask(GenerationTask):
                     f"    --instance_ids {data_point['instance_id']} "
                     f"    --run_id eval-outputs "
                     f"    --timeout {self.cfg.swebench_tests_timeout} "
-                    f"    --dataset_name {self.cfg.input_file} && "
+                    f"    --dataset_name /input_mount/{Path(self.cfg.input_file).name} && "
                     f"cp -r logs/run_evaluation/eval-outputs /trajectories_mount/"
                 )
 


### PR DESCRIPTION
Fixes an issue where using the `data_dir` parameter crashed SWE-bench evaluation and inference with OpenHands.

This was caused by the dataset file path from the Nemo-Skills container being used inside the Apptainer containers, which only worked if the file was inside `/nemo_run/code`. The folder with the dataset file is now mounted separately and the paths are fixed accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset access in containerized evaluations by optimizing how mounted data directories are referenced, ensuring reliable execution of SWE-bench assessments and OpenHands dataset operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->