### PR TITLE
Harden DirectPythonTool against malformed calls and transient failures

### DIFF
--- a/nemo_skills/mcp/servers/python_tool.py
+++ b/nemo_skills/mcp/servers/python_tool.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Annotated, Any, Dict, List
 
+import httpx
 from httpx import RemoteProtocolError
 from mcp.server.fastmcp import FastMCP
 from omegaconf import OmegaConf
@@ -215,21 +216,41 @@ class DirectPythonTool(Tool):
         timeout = extra_args.get("timeout", self._config.get("exec_timeout_s", 10))
         session_id = self.requests_to_sessions[request_id] if request_id is not None else None
 
-        try:
-            output_dict, session_id = await self._sandbox.execute_code(
-                arguments["code"],
-                language="ipython",
-                timeout=timeout,
-                session_id=session_id,
-            )
-        except RemoteProtocolError:
-            output_dict = {"process_status": "fail", "stdout": "", "stderr": "Error connecting to sandbox"}
-            session_id = None
+        # Validate required `code` argument. The MCP path gets this via Pydantic at the FastMCP
+        # boundary; since we bypass FastMCP we need to validate ourselves so a malformed tool call
+        # surfaces as a handleable error instead of crashing the tool.
+        code = arguments.get("code")
+        if not isinstance(code, str):
+            output_dict = {
+                "process_status": "fail",
+                "stdout": "",
+                "stderr": "Error: missing required argument 'code'",
+            }
+        else:
+            try:
+                output_dict, session_id = await self._sandbox.execute_code(
+                    code,
+                    language="ipython",
+                    timeout=timeout,
+                    session_id=session_id,
+                )
+            except (httpx.HTTPError, RemoteProtocolError):
+                # Transport/protocol errors talking to the sandbox — log details, return generic.
+                logger.exception("Sandbox communication error during stateful_python_code_exec")
+                output_dict = {"process_status": "fail", "stdout": "", "stderr": "Error connecting to sandbox"}
+                session_id = None
+            except Exception:
+                # Catch-all so a poorly-formed call or transient issue never crashes the RL run.
+                # Log full details server-side but keep the model-facing stderr generic to avoid
+                # leaking framework internals into what is supposed to be sandbox output.
+                logger.exception("Unexpected error during stateful_python_code_exec")
+                output_dict = {"process_status": "fail", "stdout": "", "stderr": "Error executing code"}
+                session_id = None
 
         if request_id is not None:
             self.requests_to_sessions[request_id] = session_id
 
-        output = f"{output_dict['stdout']}{output_dict['stderr']}"
+        output = f"{output_dict.get('stdout', '')}{output_dict.get('stderr', '')}"
         if output.endswith("\n"):
             output = output[:-1]
         return output
@@ -240,8 +261,14 @@ class DirectPythonTool(Tool):
                 str(session_id) for session_id in self.requests_to_sessions.values() if session_id is not None
             }
             for session_id in session_ids:
-                await self._sandbox.delete_session(session_id)
-            await self._sandbox.close()
+                try:
+                    await self._sandbox.delete_session(session_id)
+                except Exception:
+                    logger.exception("Failed to delete sandbox session %s during shutdown", session_id)
+            try:
+                await self._sandbox.close()
+            except Exception:
+                logger.exception("Failed to close sandbox HTTP session during shutdown")
         self.requests_to_sessions.clear()
 
     async def cleanup_request(self, request_id: str) -> None:
@@ -249,7 +276,10 @@ class DirectPythonTool(Tool):
         if session_id is None:
             return
         if self._sandbox is not None:
-            await self._sandbox.delete_session(str(session_id))
+            try:
+                await self._sandbox.delete_session(str(session_id))
+            except Exception:
+                logger.exception("Failed to delete sandbox session %s during cleanup_request", session_id)
         self.requests_to_sessions.pop(request_id, None)
 
 

--- a/tests/slurm-tests/nano_30b_tool_calling/run_test.py
+++ b/tests/slurm-tests/nano_30b_tool_calling/run_test.py
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""SLURM test for PythonTool (MCP tool calling) with nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.
+"""SLURM test for DirectPythonTool with nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.
 
 Sub-tests:
   - Non-streaming: full eval (aime24:16, aime25:16) with metric ranges, timeouts, tool usage
   - Streaming: quick smoke test (aime24:1) to verify streaming token counting works
 
-Validates the MCP-based tool calling pipeline on a real cluster:
-  - PythonTool spawns python_tool server (stdio or HTTP depending on branch)
-  - Model generates tool calls, PythonTool executes them in sandbox
+Validates the DirectPythonTool path on a real cluster:
+  - DirectPythonTool calls sandbox.execute_code() directly (no MCP subprocess/JSON-RPC)
+  - Model generates tool calls, DirectPythonTool executes them in sandbox
   - Results are evaluated for correctness and tool usage
 
 This test exercises a different code path than gpt_oss_python_aime25
 (which uses code_execution=true / CodeExecutionWrapper). Here we use
-tool_modules / ToolCallingWrapper / PythonTool.
+tool_modules / ToolCallingWrapper / DirectPythonTool.
 """
 
 import argparse
@@ -40,7 +40,7 @@ COMMON_PARAMS = (
     "++inference.tokens_to_generate=65536 "
     "++inference.temperature=1 "
     "++inference.top_p=0.95 "
-    "++tool_modules=[nemo_skills.mcp.servers.python_tool::PythonTool] "
+    "++tool_modules=[nemo_skills.mcp.servers.python_tool::DirectPythonTool] "
     "++max_tool_calls=100 "
 )
 

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -883,3 +883,122 @@ async def test_mcp_vs_direct_error_parity():
 
     await direct.shutdown()
     await mcp_tool.shutdown()
+
+
+# ==============================
+# Hardening tests: DirectPythonTool should not raise on malformed calls or
+# transient sandbox/shutdown failures — RL runs must survive them.
+# ==============================
+
+
+class _StubSandbox:
+    """Stand-in sandbox whose behavior is controlled by the test."""
+
+    def __init__(self, execute_code=None, delete_session=None, close=None):
+        self._execute_code = execute_code
+        self._delete_session = delete_session
+        self._close = close
+        self.delete_calls = []
+        self.close_calls = 0
+
+    async def execute_code(self, code, language="ipython", timeout=10, session_id=None, **kwargs):
+        if self._execute_code is None:
+            raise AssertionError("execute_code called but not stubbed")
+        return await self._execute_code(code, language=language, timeout=timeout, session_id=session_id)
+
+    async def delete_session(self, session_id):
+        self.delete_calls.append(session_id)
+        if self._delete_session is not None:
+            await self._delete_session(session_id)
+
+    async def close(self):
+        self.close_calls += 1
+        if self._close is not None:
+            await self._close()
+
+
+def _direct_tool_with_stub(stub):
+    """Build a DirectPythonTool wired to a stub sandbox without needing a live server."""
+    from nemo_skills.mcp.servers.python_tool import DirectPythonTool
+
+    tool = DirectPythonTool()
+    # configure() builds sanitize keys from hide_args; we replace the sandbox afterwards
+    # so we don't depend on a running local sandbox server.
+    tool._sanitize_keys = {"stateful_python_code_exec": {"session_id", "timeout"}}
+    tool._sandbox = stub
+    return tool
+
+
+@pytest.mark.asyncio
+async def test_direct_python_tool_missing_code_returns_error_not_raise():
+    """A tool call without 'code' must return a sandbox-shaped error, not crash the run."""
+    tool = _direct_tool_with_stub(_StubSandbox())  # execute_code must NOT be called
+
+    result = await tool.execute(
+        "stateful_python_code_exec",
+        {},  # no 'code' key — mirrors the KeyError seen in production
+        extra_args={"request_id": "missing-code"},
+    )
+    assert isinstance(result, str)
+    assert "code" in result  # error mentions the missing argument
+    # Must not leak framework internals (Python exception names / tracebacks).
+    assert "KeyError" not in result
+    assert "Traceback" not in result
+
+
+@pytest.mark.asyncio
+async def test_direct_python_tool_sandbox_exception_returns_generic_error():
+    """Unexpected sandbox exceptions must be contained and must not leak internals."""
+
+    async def exploding_execute(code, language, timeout, session_id):
+        raise RuntimeError("internal sandbox detail that must not reach the model")
+
+    tool = _direct_tool_with_stub(_StubSandbox(execute_code=exploding_execute))
+
+    result = await tool.execute(
+        "stateful_python_code_exec",
+        {"code": "print(1)"},
+        extra_args={"request_id": "boom"},
+    )
+    assert isinstance(result, str)
+    # Generic message only — no leaked exception detail, no stack.
+    assert "internal sandbox detail" not in result
+    assert "Traceback" not in result
+    assert "RuntimeError" not in result
+
+
+@pytest.mark.asyncio
+async def test_direct_python_tool_shutdown_tolerates_delete_failure():
+    """A failing delete_session for one session must not abort shutdown of the rest."""
+
+    async def flaky_delete(session_id):
+        if session_id == "sess-a":
+            raise RuntimeError("transient delete failure")
+
+    stub = _StubSandbox(delete_session=flaky_delete)
+    tool = _direct_tool_with_stub(stub)
+    tool.requests_to_sessions["req-a"] = "sess-a"
+    tool.requests_to_sessions["req-b"] = "sess-b"
+
+    # Must not raise despite sess-a's delete blowing up.
+    await tool.shutdown()
+
+    assert set(stub.delete_calls) == {"sess-a", "sess-b"}
+    assert stub.close_calls == 1  # close() still called after delete failures
+    assert tool.requests_to_sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_direct_python_tool_cleanup_request_tolerates_delete_failure():
+    """cleanup_request must not propagate delete_session errors into ToolManager."""
+
+    async def failing_delete(session_id):
+        raise RuntimeError("transient delete failure")
+
+    stub = _StubSandbox(delete_session=failing_delete)
+    tool = _direct_tool_with_stub(stub)
+    tool.requests_to_sessions["req-x"] = "sess-x"
+
+    # Must not raise; session must be removed from the mapping regardless.
+    await tool.cleanup_request("req-x")
+    assert "req-x" not in tool.requests_to_sessions


### PR DESCRIPTION
DirectPythonTool bypasses FastMCP's Pydantic validation and exception containment, so a tool call missing `code`, a flaky sandbox, or a failing session delete could raise out of the tool and disrupt RL runs.

- Validate `code` in execute() and return a sandbox-shaped error.
- Broaden the narrow RemoteProtocolError catch to (httpx.HTTPError, RemoteProtocolError) plus a final Exception catch-all. Full detail goes to logger.exception; model-facing stderr stays generic so framework internals never leak into what should be sandbox output.
- Use output_dict.get() for stdout/stderr so a malformed response can't crash the tool.
- Wrap each delete_session and close() in shutdown()/cleanup_request() so one failing session doesn't abort shutdown of the others and doesn't propagate through ToolManager.cleanup_request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validate missing/invalid code arguments and return clear error messages.
  * Prevent leaking sandbox exception details; return generic connection/execution errors.
  * Use defensive output assembly to avoid key errors and make shutdown/cleanup resilient to failures.

* **Tests**
  * Added hardening tests for the Python execution tool.
  * Updated SLURM test to exercise the DirectPythonTool execution path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->