### PR TITLE
update slurm test for nano v3

### DIFF
--- a/tests/slurm-tests/nano_30b_eval/check_results.py
+++ b/tests/slurm-tests/nano_30b_eval/check_results.py
@@ -33,7 +33,7 @@ NO_TOOLS_METRICS = {
 }
 
 WITH_TOOLS_METRICS = {
-    "aime25": ("pass@1[avg-of-4]", "symbolic_correct", (96.0, 100.0)),
+    "aime25": ("pass@1[avg-of-4]", "symbolic_correct", (88.0, 100.0)),
     "gpqa": ("pass@1[avg-of-4]", "symbolic_correct", (72.0, 78.0)),
     "hle": ("pass@1", "judge_correct", (13.0, 19.0)),
 }
@@ -64,13 +64,17 @@ def load_metrics_block(metrics_path: Path, benchmark: str):
     return data[benchmark]
 
 
+def normalize_percent(value: float) -> float:
+    return value * 100.0 if 0.0 <= value <= 1.0 else value
+
+
 def check_metric_group(eval_dir: Path, metric_config: dict[str, tuple[str, str, tuple[float, float]]]):
     for benchmark, (agg_key, field, (lo, hi)) in metric_config.items():
         metrics_path = eval_dir / "eval-results" / benchmark / "metrics.json"
         metrics = load_metrics_block(metrics_path, benchmark)
         soft_assert(agg_key in metrics, f"Missing aggregation key {agg_key} in {metrics_path}")
         soft_assert(field in metrics[agg_key], f"Missing field {field} in {metrics_path}")
-        value = float(metrics[agg_key][field])
+        value = normalize_percent(float(metrics[agg_key][field]))
         print(f"{eval_dir.name}/{benchmark}/{agg_key}/{field}: {value}")
         soft_assert(lo <= value <= hi, f"{benchmark}: {field}={value} out of range [{lo}, {hi}]")
 
@@ -145,24 +149,13 @@ def check_timeouts(eval_dir: Path):
         )
 
 
-def check_livecodebench_split(eval_dir: Path):
-    bench_dir = eval_dir / "eval-results" / "livecodebench"
-    output_path = next(iter(sorted(bench_dir.glob("output-rs*.jsonl"))), None)
-    soft_assert(output_path is not None, f"No livecodebench output files found in {bench_dir}")
-    with output_path.open("rt", encoding="utf-8") as fin:
-        first_row = json.loads(next(line for line in fin if line.strip()))
-
-    split = first_row.get("subset_for_metrics")
-    soft_assert(split == "test_v6_2408_2505", f"Expected livecodebench split test_v6_2408_2505, got {split}")
-
-
 def check_formal_math(eval_dir: Path):
     for label, (benchmark, agg_key, field, (lo, hi)) in FORMAL_MATH_METRICS.items():
         metrics_path = eval_dir / "eval-results" / benchmark / "metrics.json"
         metrics = load_metrics_block(metrics_path, benchmark)
         soft_assert(agg_key in metrics, f"Missing aggregation key {agg_key} in {metrics_path}")
         soft_assert(field in metrics[agg_key], f"Missing field {field} in {metrics_path}")
-        value = float(metrics[agg_key][field])
+        value = normalize_percent(float(metrics[agg_key][field]))
         print(f"formal_math/{label}/{agg_key}/{field}: {value}")
         soft_assert(lo <= value <= hi, f"{label}: {field}={value} out of range [{lo}, {hi}]")
 
@@ -176,7 +169,6 @@ def main():
 
     print("=== no_tools ===")
     check_metric_group(eval_root / "no_tools", NO_TOOLS_METRICS)
-    check_livecodebench_split(eval_root / "no_tools")
 
     print("\n=== with_tools ===")
     check_metric_group(eval_root / "with_tools", WITH_TOOLS_METRICS)

--- a/tests/slurm-tests/nano_30b_eval/check_results.py
+++ b/tests/slurm-tests/nano_30b_eval/check_results.py
@@ -24,7 +24,7 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))  # for utils.py
 from utils import assert_all, get_nested_value, load_json, soft_assert  # noqa: E402
 
 NO_TOOLS_METRICS = {
-    "aime25": ("pass@1[avg-of-4]", "symbolic_correct", (84.0, 94.0)),
+    "aime25": ("pass@1[avg-of-4]", "symbolic_correct", (88.0, 94.0)),
     "gpqa": ("pass@1[avg-of-4]", "symbolic_correct", (69.0, 76.0)),
     "mmlu-pro": ("pass@1", "symbolic_correct", (74.0, 82.0)),
     "ifbench": ("pass@1[avg-of-5]", "average_score", (66.0, 77.0)),
@@ -40,7 +40,7 @@ NO_TOOLS_METRICS = {
 }
 
 WITH_TOOLS_METRICS = {
-    "aime25": ("pass@1[avg-of-4]", "symbolic_correct", (88.0, 100.0)),
+    "aime25": ("pass@1[avg-of-4]", "symbolic_correct", (95.0, 100.0)),
     "gpqa": ("pass@1[avg-of-4]", "symbolic_correct", (72.0, 78.0)),
     "hle": ("pass@1", "judge_correct", (13.0, 19.0)),
 }
@@ -95,13 +95,21 @@ def check_metric_group(
     for benchmark, (agg_key, field, (lo, hi)) in metric_config.items():
         metrics_path, metrics, benchmark_label = resolve_metrics_entry(eval_dir, benchmark)
         soft_assert(agg_key in metrics, f"Missing aggregation key {agg_key} in {metrics_path}")
+        if agg_key not in metrics:
+            continue
+        agg_metrics = metrics[agg_key]
         if isinstance(field, tuple):
-            value = get_nested_value(metrics[agg_key], field)
+            value = get_nested_value(agg_metrics, field)
             field_label = "/".join(field)
         else:
-            value = metrics[agg_key].get(field)
+            soft_assert(field in agg_metrics, f"Missing field {field} in {metrics_path}")
+            if field not in agg_metrics:
+                continue
+            value = agg_metrics[field]
             field_label = field
         soft_assert(value is not None, f"Missing field {field_label} in {metrics_path}")
+        if value is None:
+            continue
         value = normalize_percent(float(value))
         print(f"{eval_dir.name}/{benchmark_label}/{agg_key}/{field_label}: {value}")
         soft_assert(lo <= value <= hi, f"{benchmark}: {field_label}={value} out of range [{lo}, {hi}]")
@@ -128,9 +136,23 @@ def check_tool_usage(eval_dir: Path):
         bench_dir = eval_dir / "eval-results" / benchmark
         for _, row in iter_output_rows(bench_dir):
             total_samples += 1
-            if row.get("num_tool_calls", 0) > 0:
+            soft_assert("num_tool_calls" in row, f"Missing num_tool_calls in {benchmark} output row")
+            soft_assert("conversation" in row, f"Missing conversation in {benchmark} output row")
+            if "num_tool_calls" not in row or "conversation" not in row:
+                continue
+            if row["num_tool_calls"] > 0:
                 samples_with_tools += 1
-            if any(msg.get("role") == "tool" for msg in row.get("conversation", [])):
+            has_tool_message = False
+            for msg in row["conversation"]:
+                soft_assert(isinstance(msg, dict), f"Conversation entry is not a dict in {benchmark} output row")
+                if not isinstance(msg, dict):
+                    continue
+                soft_assert("role" in msg, f"Missing role in {benchmark} conversation entry")
+                if "role" not in msg:
+                    continue
+                if msg["role"] == "tool":
+                    has_tool_message = True
+            if has_tool_message:
                 samples_with_tool_messages += 1
 
     soft_assert(total_samples > 0, "No samples found in with_tools outputs")
@@ -160,11 +182,25 @@ def check_timeouts(eval_dir: Path):
                     if not line.strip():
                         continue
                     row = json.loads(line)
-                    for msg in row.get("conversation", []):
-                        if msg.get("role") == "tool":
-                            content = str(msg.get("content", ""))
-                            if timeout_pattern.search(content):
-                                file_timeouts += 1
+                    soft_assert("conversation" in row, f"Missing conversation in {benchmark}/{output_path.name}")
+                    if "conversation" not in row:
+                        continue
+                    for msg in row["conversation"]:
+                        soft_assert(
+                            isinstance(msg, dict),
+                            f"Conversation entry is not a dict in {benchmark}/{output_path.name}",
+                        )
+                        if not isinstance(msg, dict):
+                            continue
+                        soft_assert("role" in msg, f"Missing role in {benchmark}/{output_path.name}")
+                        if "role" not in msg or msg["role"] != "tool":
+                            continue
+                        soft_assert("content" in msg, f"Missing content in {benchmark}/{output_path.name}")
+                        if "content" not in msg:
+                            continue
+                        content = str(msg["content"])
+                        if timeout_pattern.search(content):
+                            file_timeouts += 1
             bench_timeouts += file_timeouts
             if file_timeouts > 0:
                 print(f"{benchmark}/{output_path.name}: num_code_timeouts={file_timeouts}")

--- a/tests/slurm-tests/nano_30b_eval/check_results.py
+++ b/tests/slurm-tests/nano_30b_eval/check_results.py
@@ -35,7 +35,7 @@ NO_TOOLS_METRICS = {
     "scicode": ("pass@1[avg-of-4]", "subtask_accuracy", (28.0, 38.0)),
     "hle": ("pass@1", "judge_correct", (8.0, 14.0)),
     "aalcr": ("pass@1[avg-of-3]", "judge_correct", (30.0, 42.0)),
-    # "mmlu-prox": ("pass@1", "symbolic_correct", (54.0, 65.0)),
+    "mmlu-prox": ("pass@1", "symbolic_correct", (54.0, 65.0)),
     "wmt24pp": ("en->xx", "bleu", (82.0, 90.0)),
 }
 

--- a/tests/slurm-tests/nano_30b_eval/check_results.py
+++ b/tests/slurm-tests/nano_30b_eval/check_results.py
@@ -21,13 +21,17 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))  # for utils.py
-from utils import assert_all, load_json, soft_assert  # noqa: E402
+from utils import assert_all, get_nested_value, load_json, soft_assert  # noqa: E402
 
 NO_TOOLS_METRICS = {
     "aime25": ("pass@1[avg-of-4]", "symbolic_correct", (84.0, 94.0)),
     "gpqa": ("pass@1[avg-of-4]", "symbolic_correct", (69.0, 76.0)),
     "mmlu-pro": ("pass@1", "symbolic_correct", (74.0, 82.0)),
+    "ifbench": ("pass@1[avg-of-5]", "average_score", (66.0, 77.0)),
     "livecodebench": ("pass@1[avg-of-4]", "accuracy", (62.0, 72.0)),
+    "arena-hard-v2": ("pass@1", "score", (61.0, 74.0)),
+    "arena-hard-v2-hard_prompt": ("pass@1", ("category_hard_prompt", "score"), (66.0, 78.0)),
+    "arena-hard-v2-creative_writing": ("pass@1", ("category_creative_writing", "score"), (55.0, 72.0)),
     "scicode": ("pass@1[avg-of-4]", "subtask_accuracy", (28.0, 38.0)),
     "hle": ("pass@1", "judge_correct", (8.0, 14.0)),
     "aalcr": ("pass@1[avg-of-3]", "judge_correct", (30.0, 42.0)),
@@ -71,15 +75,32 @@ def normalize_percent(value: float) -> float:
     return value * 100.0 if 0.0 <= value <= 1.0 else value
 
 
-def check_metric_group(eval_dir: Path, metric_config: dict[str, tuple[str, str, tuple[float, float]]]):
+def resolve_metrics_entry(eval_dir: Path, benchmark_key: str):
+    if benchmark_key.startswith("arena-hard-v2-"):
+        metrics_path = eval_dir / "eval-results" / "arena-hard-v2" / "metrics.json"
+        metrics = load_metrics_block(metrics_path, "arena-hard-v2")
+        return metrics_path, metrics, "arena-hard-v2"
+    metrics_path = eval_dir / "eval-results" / benchmark_key / "metrics.json"
+    metrics = load_metrics_block(metrics_path, benchmark_key)
+    return metrics_path, metrics, benchmark_key
+
+
+def check_metric_group(
+    eval_dir: Path, metric_config: dict[str, tuple[str, str | tuple[str, ...], tuple[float, float]]]
+):
     for benchmark, (agg_key, field, (lo, hi)) in metric_config.items():
-        metrics_path = eval_dir / "eval-results" / benchmark / "metrics.json"
-        metrics = load_metrics_block(metrics_path, benchmark)
+        metrics_path, metrics, benchmark_label = resolve_metrics_entry(eval_dir, benchmark)
         soft_assert(agg_key in metrics, f"Missing aggregation key {agg_key} in {metrics_path}")
-        soft_assert(field in metrics[agg_key], f"Missing field {field} in {metrics_path}")
-        value = normalize_percent(float(metrics[agg_key][field]))
-        print(f"{eval_dir.name}/{benchmark}/{agg_key}/{field}: {value}")
-        soft_assert(lo <= value <= hi, f"{benchmark}: {field}={value} out of range [{lo}, {hi}]")
+        if isinstance(field, tuple):
+            value = get_nested_value(metrics[agg_key], field)
+            field_label = "/".join(field)
+        else:
+            value = metrics[agg_key].get(field)
+            field_label = field
+        soft_assert(value is not None, f"Missing field {field_label} in {metrics_path}")
+        value = normalize_percent(float(value))
+        print(f"{eval_dir.name}/{benchmark_label}/{agg_key}/{field_label}: {value}")
+        soft_assert(lo <= value <= hi, f"{benchmark}: {field_label}={value} out of range [{lo}, {hi}]")
 
 
 def iter_output_rows(bench_dir: Path):

--- a/tests/slurm-tests/nano_30b_eval/check_results.py
+++ b/tests/slurm-tests/nano_30b_eval/check_results.py
@@ -30,6 +30,9 @@ NO_TOOLS_METRICS = {
     "livecodebench": ("pass@1[avg-of-4]", "accuracy", (62.0, 72.0)),
     "scicode": ("pass@1[avg-of-4]", "subtask_accuracy", (28.0, 38.0)),
     "hle": ("pass@1", "judge_correct", (8.0, 14.0)),
+    "aalcr": ("pass@1[avg-of-3]", "judge_correct", (30.0, 42.0)),
+    "mmlu-prox": ("pass@1", "symbolic_correct", (54.0, 65.0)),
+    "wmt24pp": ("en->xx", "bleu", (82.0, 90.0)),
 }
 
 WITH_TOOLS_METRICS = {

--- a/tests/slurm-tests/nano_30b_eval/check_results.py
+++ b/tests/slurm-tests/nano_30b_eval/check_results.py
@@ -50,6 +50,10 @@ FORMAL_MATH_METRICS = {
     "minif2f_pass32": ("minif2f", "pass@32", "lean4_correct", (72.0, 88.0)),
 }
 
+AGENTIC_METRICS = {
+    "swe-bench": ("pass@1", "issues_resolved", (34.0, 44.0)),
+}
+
 TOOL_BENCHMARKS = ["aime25", "gpqa", "hle"]
 MIN_TOOL_CALL_FRACTION = 0.05
 MAX_TIMEOUTS = {
@@ -184,6 +188,10 @@ def check_formal_math(eval_dir: Path):
         soft_assert(lo <= value <= hi, f"{label}: {field}={value} out of range [{lo}, {hi}]")
 
 
+def check_agentic(eval_dir: Path):
+    check_metric_group(eval_dir, AGENTIC_METRICS)
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--workspace", required=True, help="Workspace directory containing results")
@@ -201,6 +209,9 @@ def main():
 
     print("\n=== formal_math ===")
     check_formal_math(eval_root / "formal_math")
+
+    print("\n=== agentic ===")
+    check_agentic(eval_root / "agentic")
 
     assert_all()
 

--- a/tests/slurm-tests/nano_30b_eval/check_results.py
+++ b/tests/slurm-tests/nano_30b_eval/check_results.py
@@ -35,7 +35,7 @@ NO_TOOLS_METRICS = {
     "scicode": ("pass@1[avg-of-4]", "subtask_accuracy", (28.0, 38.0)),
     "hle": ("pass@1", "judge_correct", (8.0, 14.0)),
     "aalcr": ("pass@1[avg-of-3]", "judge_correct", (30.0, 42.0)),
-    "mmlu-prox": ("pass@1", "symbolic_correct", (54.0, 65.0)),
+    # "mmlu-prox": ("pass@1", "symbolic_correct", (54.0, 65.0)),
     "wmt24pp": ("en->xx", "bleu", (82.0, 90.0)),
 }
 

--- a/tests/slurm-tests/nano_30b_eval/check_results.py
+++ b/tests/slurm-tests/nano_30b_eval/check_results.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check results for nano_30b_eval SLURM benchmark suite."""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))  # for utils.py
+from utils import assert_all, load_json, soft_assert  # noqa: E402
+
+NO_TOOLS_METRICS = {
+    "aime25": ("pass@1[avg-of-4]", "symbolic_correct", (84.0, 94.0)),
+    "gpqa": ("pass@1[avg-of-4]", "symbolic_correct", (69.0, 76.0)),
+    "mmlu-pro": ("pass@1", "symbolic_correct", (74.0, 82.0)),
+    "livecodebench": ("pass@1[avg-of-4]", "accuracy", (62.0, 72.0)),
+    "scicode": ("pass@1[avg-of-4]", "subtask_accuracy", (28.0, 38.0)),
+    "hle": ("pass@1", "judge_correct", (8.0, 14.0)),
+}
+
+WITH_TOOLS_METRICS = {
+    "aime25": ("pass@1[avg-of-4]", "symbolic_correct", (96.0, 100.0)),
+    "gpqa": ("pass@1[avg-of-4]", "symbolic_correct", (72.0, 78.0)),
+    "hle": ("pass@1", "judge_correct", (13.0, 19.0)),
+}
+
+FORMAL_MATH_METRICS = {
+    "minif2f_pass1": ("minif2f", "pass@1[avg-of-32]", "lean4_correct", (42.0, 58.0)),
+    "minif2f_pass32": ("minif2f", "pass@32", "lean4_correct", (72.0, 88.0)),
+}
+
+TOOL_BENCHMARKS = ["aime25", "gpqa", "hle"]
+MIN_TOOL_CALL_FRACTION = 0.05
+MAX_TIMEOUTS = {
+    "aime25": 200,
+    "gpqa": 1000,
+    "hle": 4000,
+}
+TIMEOUT_INDICATORS = [
+    "execution timed out",
+    "timed out",
+    "process_status.*timeout",
+    "TimeoutError",
+]
+
+
+def load_metrics_block(metrics_path: Path, benchmark: str):
+    data = load_json(metrics_path)
+    soft_assert(benchmark in data, f"Missing benchmark {benchmark} in {metrics_path}")
+    return data[benchmark]
+
+
+def check_metric_group(eval_dir: Path, metric_config: dict[str, tuple[str, str, tuple[float, float]]]):
+    for benchmark, (agg_key, field, (lo, hi)) in metric_config.items():
+        metrics_path = eval_dir / "eval-results" / benchmark / "metrics.json"
+        metrics = load_metrics_block(metrics_path, benchmark)
+        soft_assert(agg_key in metrics, f"Missing aggregation key {agg_key} in {metrics_path}")
+        soft_assert(field in metrics[agg_key], f"Missing field {field} in {metrics_path}")
+        value = float(metrics[agg_key][field])
+        print(f"{eval_dir.name}/{benchmark}/{agg_key}/{field}: {value}")
+        soft_assert(lo <= value <= hi, f"{benchmark}: {field}={value} out of range [{lo}, {hi}]")
+
+
+def iter_output_rows(bench_dir: Path):
+    output_files = sorted(bench_dir.glob("output-rs*.jsonl"))
+    soft_assert(len(output_files) > 0, f"No output files found in {bench_dir}")
+
+    for output_path in output_files:
+        with output_path.open("rt", encoding="utf-8") as fin:
+            for line in fin:
+                if not line.strip():
+                    continue
+                yield output_path, json.loads(line)
+
+
+def check_tool_usage(eval_dir: Path):
+    total_samples = 0
+    samples_with_tools = 0
+    samples_with_tool_messages = 0
+
+    for benchmark in TOOL_BENCHMARKS:
+        bench_dir = eval_dir / "eval-results" / benchmark
+        for _, row in iter_output_rows(bench_dir):
+            total_samples += 1
+            if row.get("num_tool_calls", 0) > 0:
+                samples_with_tools += 1
+            if any(msg.get("role") == "tool" for msg in row.get("conversation", [])):
+                samples_with_tool_messages += 1
+
+    soft_assert(total_samples > 0, "No samples found in with_tools outputs")
+    tool_fraction = samples_with_tools / total_samples
+    print(
+        f"with_tools/tool_usage: {samples_with_tools}/{total_samples} "
+        f"samples used tools ({tool_fraction:.1%}), {samples_with_tool_messages} had tool messages"
+    )
+    soft_assert(
+        tool_fraction >= MIN_TOOL_CALL_FRACTION,
+        f"Too few samples used tools: {tool_fraction:.1%} < {MIN_TOOL_CALL_FRACTION:.0%}",
+    )
+    soft_assert(samples_with_tool_messages > 0, "No samples contained tool messages")
+
+
+def check_timeouts(eval_dir: Path):
+    timeout_pattern = re.compile("|".join(TIMEOUT_INDICATORS), re.IGNORECASE)
+
+    for benchmark in TOOL_BENCHMARKS:
+        bench_dir = eval_dir / "eval-results" / benchmark
+        bench_timeouts = 0
+
+        for output_path in sorted(bench_dir.glob("output-rs*.jsonl")):
+            file_timeouts = 0
+            with output_path.open("rt", encoding="utf-8") as fin:
+                for line in fin:
+                    if not line.strip():
+                        continue
+                    row = json.loads(line)
+                    for msg in row.get("conversation", []):
+                        if msg.get("role") == "tool":
+                            content = str(msg.get("content", ""))
+                            if timeout_pattern.search(content):
+                                file_timeouts += 1
+            bench_timeouts += file_timeouts
+            if file_timeouts > 0:
+                print(f"{benchmark}/{output_path.name}: num_code_timeouts={file_timeouts}")
+
+        allowed = MAX_TIMEOUTS[benchmark]
+        print(f"{benchmark} total code_timeouts: {bench_timeouts} (allowed: {allowed})")
+        soft_assert(
+            bench_timeouts <= allowed,
+            f"{benchmark}: code execution timeouts regressed: observed {bench_timeouts}, allowed <= {allowed}",
+        )
+
+
+def check_livecodebench_split(eval_dir: Path):
+    bench_dir = eval_dir / "eval-results" / "livecodebench"
+    output_path = next(iter(sorted(bench_dir.glob("output-rs*.jsonl"))), None)
+    soft_assert(output_path is not None, f"No livecodebench output files found in {bench_dir}")
+    with output_path.open("rt", encoding="utf-8") as fin:
+        first_row = json.loads(next(line for line in fin if line.strip()))
+
+    split = first_row.get("subset_for_metrics")
+    soft_assert(split == "test_v6_2408_2505", f"Expected livecodebench split test_v6_2408_2505, got {split}")
+
+
+def check_formal_math(eval_dir: Path):
+    for label, (benchmark, agg_key, field, (lo, hi)) in FORMAL_MATH_METRICS.items():
+        metrics_path = eval_dir / "eval-results" / benchmark / "metrics.json"
+        metrics = load_metrics_block(metrics_path, benchmark)
+        soft_assert(agg_key in metrics, f"Missing aggregation key {agg_key} in {metrics_path}")
+        soft_assert(field in metrics[agg_key], f"Missing field {field} in {metrics_path}")
+        value = float(metrics[agg_key][field])
+        print(f"formal_math/{label}/{agg_key}/{field}: {value}")
+        soft_assert(lo <= value <= hi, f"{label}: {field}={value} out of range [{lo}, {hi}]")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workspace", required=True, help="Workspace directory containing results")
+    args = ap.parse_args()
+
+    eval_root = Path(args.workspace)
+
+    print("=== no_tools ===")
+    check_metric_group(eval_root / "no_tools", NO_TOOLS_METRICS)
+    check_livecodebench_split(eval_root / "no_tools")
+
+    print("\n=== with_tools ===")
+    check_metric_group(eval_root / "with_tools", WITH_TOOLS_METRICS)
+    check_tool_usage(eval_root / "with_tools")
+    check_timeouts(eval_root / "with_tools")
+
+    print("\n=== formal_math ===")
+    check_formal_math(eval_root / "formal_math")
+
+    assert_all()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/slurm-tests/nano_30b_eval/run_test.py
+++ b/tests/slurm-tests/nano_30b_eval/run_test.py
@@ -29,14 +29,14 @@ DEFAULT_SERVER_CONTAINER = (
 )
 
 NO_TOOLS_PARAMS = (
-    "++inference.tokens_to_generate=65536 "
+    "++inference.tokens_to_generate=120000 "
     "++inference.temperature=1.0 "
     "++inference.top_p=1.0 "
     "++chat_template_kwargs.enable_thinking=true "
 )
 
 WITH_TOOLS_COMMON_PARAMS = (
-    "++inference.tokens_to_generate=65536 "
+    "++inference.tokens_to_generate=120000 "
     "++inference.temperature=1.0 "
     "++inference.top_p=0.95 "
     "++chat_template_kwargs.enable_thinking=true "

--- a/tests/slurm-tests/nano_30b_eval/run_test.py
+++ b/tests/slurm-tests/nano_30b_eval/run_test.py
@@ -40,7 +40,6 @@ WITH_TOOLS_COMMON_PARAMS = (
     "++inference.temperature=1.0 "
     "++inference.top_p=0.95 "
     "++chat_template_kwargs.enable_thinking=true "
-    "++parse_reasoning=True "
     "++tool_modules=[nemo_skills.mcp.servers.python_tool::DirectPythonTool] "
     "++max_tool_calls=100 "
 )
@@ -196,7 +195,7 @@ def eval_no_tools(
 
     expname = f"{expname_prefix}-no-tools-scicode"
     eval(
-        ctx=wrap_arguments(NO_TOOLS_PARAMS),
+        ctx=wrap_arguments(NO_TOOLS_PARAMS + "++prompt_config=eval/scicode/background ++eval_type=scicode "),
         cluster=cluster,
         model=get_local_model_path(workspace),
         server_type="vllm",
@@ -232,6 +231,71 @@ def eval_no_tools(
         judge_server_gpus=server_gpus,
         judge_server_container=server_container,
         extra_judge_args="++inference.tokens_to_generate=4096 ++server.enable_soft_fail=True",
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    expname = f"{expname_prefix}-no-tools-aalcr"
+    eval(
+        ctx=wrap_arguments(NO_TOOLS_PARAMS),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="aalcr:3",
+        num_jobs=1,
+        partition=partition,
+        judge_model=get_local_judge_model_path(workspace),
+        judge_server_type="vllm",
+        judge_server_gpus=server_gpus,
+        judge_server_container=server_container,
+        extra_judge_args=("++prompt_config=judge/aalcr ++generation_key=judgement ++add_generation_stats=False "),
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    expname = f"{expname_prefix}-no-tools-mmlu-prox"
+    eval(
+        ctx=wrap_arguments(NO_TOOLS_PARAMS + "++prompt_config=generic/default ++eval_type=multichoice "),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="mmlu-prox:1",
+        num_jobs=1,
+        partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    expname = f"{expname_prefix}-no-tools-wmt24pp"
+    eval(
+        ctx=wrap_arguments(NO_TOOLS_PARAMS + "++prompt_config=multilingual/segment-translation "),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="wmt24pp:1",
+        num_jobs=1,
+        partition=partition,
         run_after=run_after,
         expname=expname,
         wandb_project=wandb_project,
@@ -384,7 +448,7 @@ def main():
 
     args = parser.parse_args()
 
-    prepare_data(ctx=wrap_arguments("mmlu-pro gpqa hle scicode aime25 minif2f"))
+    prepare_data(ctx=wrap_arguments("mmlu-pro gpqa hle scicode aime25 minif2f aalcr mmlu-prox wmt24pp"))
     prepare_data(ctx=wrap_arguments("livecodebench --release_version v6 --start_date 2024-08 --end_date 2025-05"))
 
     setup_expname = setup(workspace=args.workspace, cluster=args.cluster, expname_prefix=args.expname_prefix)

--- a/tests/slurm-tests/nano_30b_eval/run_test.py
+++ b/tests/slurm-tests/nano_30b_eval/run_test.py
@@ -1,0 +1,434 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SLURM benchmark suite for NVIDIA-Nemotron-3-Nano-30B-A3B-BF16."""
+
+import argparse
+
+from nemo_skills.pipeline.cli import eval, prepare_data, run_cmd, wrap_arguments
+
+MODEL = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+MODEL_DIRNAME = MODEL.split("/")[-1]
+JUDGE_MODEL = "openai/gpt-oss-120b"
+JUDGE_MODEL_DIRNAME = JUDGE_MODEL.split("/")[-1]
+REASONING_PARSER_FILENAME = "nano_v3_reasoning_parser.py"
+DEFAULT_SERVER_CONTAINER = (
+    "/lustre/fsw/portfolios/llmservice/users/igitman/super-models/"
+    "vllm-openai-nightly-097eb544e9a22810c9b7a59e586b61627b308362.sqsh"
+)
+
+NO_TOOLS_PARAMS = (
+    "++inference.tokens_to_generate=65536 ++inference.temperature=1.0 ++inference.top_p=1.0 ++parse_reasoning=True "
+)
+
+WITH_TOOLS_COMMON_PARAMS = (
+    "++inference.tokens_to_generate=65536 "
+    "++inference.temperature=1.0 "
+    "++inference.top_p=0.95 "
+    "++tool_modules=[nemo_skills.mcp.servers.python_tool::DirectPythonTool] "
+    "++max_tool_calls=100 "
+)
+
+FORMAL_MATH_PARAMS = (
+    "++inference.tokens_to_generate=38912 "
+    "++inference.temperature=1.0 "
+    "++inference.top_p=0.95 "
+    "++eval_config.timeout=400 "
+)
+
+
+def build_server_args(parser_path: str, enable_tools: bool) -> str:
+    parts = [
+        "--trust-remote-code",
+        "--dtype auto",
+        "--mamba-ssm-cache-dtype float32",
+        f"--reasoning-parser-plugin {parser_path}",
+        "--reasoning-parser nano_v3",
+    ]
+    if enable_tools:
+        parts = [
+            "--enable-auto-tool-choice",
+            "--tool-call-parser qwen3_coder",
+        ] + parts
+    return " ".join(parts)
+
+
+def get_local_judge_model_path(workspace: str) -> str:
+    return f"{workspace}/{JUDGE_MODEL_DIRNAME}"
+
+
+def get_local_model_path(workspace: str) -> str:
+    return f"{workspace}/{MODEL_DIRNAME}"
+
+
+def setup(workspace, cluster, expname_prefix):
+    parser_dir = f"{workspace}/nano_v3_parser"
+    cmd = (
+        f"mkdir -p {parser_dir} && "
+        f"hf download {MODEL} --local-dir {get_local_model_path(workspace)} && "
+        f"hf download nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 {REASONING_PARSER_FILENAME} "
+        f"--local-dir {parser_dir} && "
+        f"hf download {JUDGE_MODEL} --local-dir {get_local_judge_model_path(workspace)}"
+    )
+    run_cmd(
+        ctx=wrap_arguments(cmd),
+        cluster=cluster,
+        expname=f"{expname_prefix}-download-assets",
+        log_dir=f"{workspace}/download-assets",
+    )
+    return f"{expname_prefix}-download-assets"
+
+
+def eval_no_tools(
+    workspace,
+    cluster,
+    expname_prefix,
+    wandb_project,
+    partition,
+    num_jobs,
+    server_gpus,
+    server_container,
+    run_after,
+):
+    output_dir = f"{workspace}/no_tools"
+    server_args = build_server_args(
+        parser_path=f"{workspace}/nano_v3_parser/{REASONING_PARSER_FILENAME}",
+        enable_tools=False,
+    )
+    expnames = []
+
+    expname = f"{expname_prefix}-no-tools-aime25"
+    eval(
+        ctx=wrap_arguments(NO_TOOLS_PARAMS),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="aime25:4",
+        num_jobs=num_jobs,
+        partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    expname = f"{expname_prefix}-no-tools-gpqa"
+    eval(
+        ctx=wrap_arguments(NO_TOOLS_PARAMS + "++prompt_config=eval/aai/mcq-4choices-boxed "),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="gpqa:4",
+        num_jobs=num_jobs,
+        partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    expname = f"{expname_prefix}-no-tools-mmlu-pro"
+    eval(
+        ctx=wrap_arguments(NO_TOOLS_PARAMS + "++prompt_config=eval/aai/mcq-10choices-boxed "),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="mmlu-pro:1",
+        num_jobs=num_jobs,
+        partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    expname = f"{expname_prefix}-no-tools-livecodebench"
+    eval(
+        ctx=wrap_arguments(NO_TOOLS_PARAMS),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="livecodebench:4",
+        split="test_v6_2408_2505",
+        num_jobs=1,
+        partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    expname = f"{expname_prefix}-no-tools-scicode"
+    eval(
+        ctx=wrap_arguments(NO_TOOLS_PARAMS),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="scicode:4",
+        num_jobs=num_jobs,
+        partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    expname = f"{expname_prefix}-no-tools-hle"
+    eval(
+        ctx=wrap_arguments(NO_TOOLS_PARAMS),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="hle:1",
+        num_jobs=1,
+        partition=partition,
+        judge_model=get_local_judge_model_path(workspace),
+        judge_server_type="vllm",
+        judge_server_gpus=server_gpus,
+        judge_server_container=server_container,
+        extra_judge_args="++inference.tokens_to_generate=4096 ++server.enable_soft_fail=True",
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    return expnames
+
+
+def eval_with_tools(
+    workspace,
+    cluster,
+    expname_prefix,
+    wandb_project,
+    partition,
+    num_jobs,
+    server_gpus,
+    server_container,
+    run_after,
+):
+    output_dir = f"{workspace}/with_tools"
+    server_args = build_server_args(
+        parser_path=f"{workspace}/nano_v3_parser/{REASONING_PARSER_FILENAME}",
+        enable_tools=True,
+    )
+    expnames = []
+
+    expname = f"{expname_prefix}-with-tools-aime25"
+    eval(
+        ctx=wrap_arguments(WITH_TOOLS_COMMON_PARAMS + "++prompt_config=qwen/math-tir "),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="aime25:4",
+        with_sandbox=True,
+        num_jobs=num_jobs,
+        partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    expname = f"{expname_prefix}-with-tools-gpqa"
+    eval(
+        ctx=wrap_arguments(WITH_TOOLS_COMMON_PARAMS + "++prompt_config=eval/aai/mcq-4choices-boxed "),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="gpqa:4",
+        with_sandbox=True,
+        num_jobs=num_jobs,
+        partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    expname = f"{expname_prefix}-with-tools-hle"
+    eval(
+        ctx=wrap_arguments(WITH_TOOLS_COMMON_PARAMS + "++prompt_config=generic/hle "),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="hle:1",
+        with_sandbox=True,
+        num_jobs=1,
+        partition=partition,
+        judge_model=get_local_judge_model_path(workspace),
+        judge_server_type="vllm",
+        judge_server_gpus=server_gpus,
+        judge_server_container=server_container,
+        extra_judge_args="++inference.tokens_to_generate=4096 ++server.enable_soft_fail=True",
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    return expnames
+
+
+def eval_formal_math(
+    workspace,
+    cluster,
+    expname_prefix,
+    wandb_project,
+    partition,
+    server_gpus,
+    server_container,
+    run_after,
+):
+    server_args = build_server_args(
+        parser_path=f"{workspace}/nano_v3_parser/{REASONING_PARSER_FILENAME}",
+        enable_tools=False,
+    )
+    expname = f"{expname_prefix}-formal-math-pass32"
+    eval(
+        ctx=wrap_arguments(FORMAL_MATH_PARAMS),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=f"{workspace}/formal_math",
+        benchmarks="minif2f:32",
+        with_sandbox=True,
+        num_jobs=1,
+        partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    return [expname]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", required=True, help="Workspace directory containing all experiment data")
+    parser.add_argument("--cluster", required=True, help="Cluster name")
+    parser.add_argument("--expname_prefix", required=True, help="Experiment name prefix")
+    parser.add_argument("--wandb_project", default="nemo-skills-slurm-ci", help="W&B project name")
+    parser.add_argument("--partition", default=None, help="Cluster partition to use")
+    parser.add_argument("--num_jobs", type=int, default=1, help="Number of parallel jobs")
+    parser.add_argument("--server_gpus", type=int, default=8, help="Number of GPUs for the model server")
+    parser.add_argument(
+        "--server_container",
+        default=DEFAULT_SERVER_CONTAINER,
+        help="Container image used for both model and judge vLLM servers",
+    )
+
+    args = parser.parse_args()
+
+    prepare_data(ctx=wrap_arguments("mmlu-pro gpqa hle scicode aime25 minif2f"))
+    prepare_data(ctx=wrap_arguments("livecodebench --release_version v6 --start_date 2024-08 --end_date 2025-05"))
+
+    setup_expname = setup(workspace=args.workspace, cluster=args.cluster, expname_prefix=args.expname_prefix)
+
+    no_tools_expnames = eval_no_tools(
+        workspace=args.workspace,
+        cluster=args.cluster,
+        expname_prefix=args.expname_prefix,
+        wandb_project=args.wandb_project,
+        partition=args.partition,
+        num_jobs=args.num_jobs,
+        server_gpus=args.server_gpus,
+        server_container=args.server_container,
+        run_after=setup_expname,
+    )
+
+    with_tools_expnames = eval_with_tools(
+        workspace=args.workspace,
+        cluster=args.cluster,
+        expname_prefix=args.expname_prefix,
+        wandb_project=args.wandb_project,
+        partition=args.partition,
+        num_jobs=args.num_jobs,
+        server_gpus=args.server_gpus,
+        server_container=args.server_container,
+        run_after=setup_expname,
+    )
+
+    formal_math_expnames = eval_formal_math(
+        workspace=args.workspace,
+        cluster=args.cluster,
+        expname_prefix=args.expname_prefix,
+        wandb_project=args.wandb_project,
+        partition=args.partition,
+        server_gpus=args.server_gpus,
+        server_container=args.server_container,
+        run_after=setup_expname,
+    )
+
+    checker_cmd = f"python tests/slurm-tests/nano_30b_eval/check_results.py --workspace {args.workspace}"
+
+    run_cmd(
+        ctx=wrap_arguments(checker_cmd),
+        cluster=args.cluster,
+        expname=args.expname_prefix + "-check-results",
+        log_dir=f"{args.workspace}/check-results-logs",
+        run_after=no_tools_expnames + with_tools_expnames + formal_math_expnames,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/slurm-tests/nano_30b_eval/run_test.py
+++ b/tests/slurm-tests/nano_30b_eval/run_test.py
@@ -322,7 +322,6 @@ def eval_no_tools(
         server_container=server_container,
         output_dir=output_dir,
         benchmarks="mmlu-prox:1",
-        num_jobs=1,
         num_chunks=4,
         partition=partition,
         run_after=run_after,

--- a/tests/slurm-tests/nano_30b_eval/run_test.py
+++ b/tests/slurm-tests/nano_30b_eval/run_test.py
@@ -29,13 +29,18 @@ DEFAULT_SERVER_CONTAINER = (
 )
 
 NO_TOOLS_PARAMS = (
-    "++inference.tokens_to_generate=65536 ++inference.temperature=1.0 ++inference.top_p=1.0 ++parse_reasoning=True "
+    "++inference.tokens_to_generate=65536 "
+    "++inference.temperature=1.0 "
+    "++inference.top_p=1.0 "
+    "++chat_template_kwargs.enable_thinking=true "
 )
 
 WITH_TOOLS_COMMON_PARAMS = (
     "++inference.tokens_to_generate=65536 "
     "++inference.temperature=1.0 "
     "++inference.top_p=0.95 "
+    "++chat_template_kwargs.enable_thinking=true "
+    "++parse_reasoning=True "
     "++tool_modules=[nemo_skills.mcp.servers.python_tool::DirectPythonTool] "
     "++max_tool_calls=100 "
 )

--- a/tests/slurm-tests/nano_30b_eval/run_test.py
+++ b/tests/slurm-tests/nano_30b_eval/run_test.py
@@ -172,6 +172,28 @@ def eval_no_tools(
     )
     expnames.append(expname)
 
+    expname = f"{expname_prefix}-no-tools-ifbench"
+    eval(
+        ctx=wrap_arguments(
+            NO_TOOLS_PARAMS + "++generation_key=response ++prompt_config=generic/default ++eval_type=ifbench "
+        ),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="ifbench:5",
+        num_jobs=1,
+        partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
     expname = f"{expname_prefix}-no-tools-livecodebench"
     eval(
         ctx=wrap_arguments(NO_TOOLS_PARAMS),
@@ -186,6 +208,30 @@ def eval_no_tools(
         split="test_v6_2408_2505",
         num_jobs=1,
         partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    expnames.append(expname)
+
+    expname = f"{expname_prefix}-no-tools-arena-hard-v2"
+    eval(
+        ctx=wrap_arguments(NO_TOOLS_PARAMS),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=output_dir,
+        benchmarks="arena-hard-v2:1",
+        num_jobs=1,
+        partition=partition,
+        judge_model=get_local_judge_model_path(workspace),
+        judge_server_type="vllm",
+        judge_server_gpus=server_gpus,
+        judge_server_container=server_container,
         run_after=run_after,
         expname=expname,
         wandb_project=wandb_project,
@@ -448,7 +494,9 @@ def main():
 
     args = parser.parse_args()
 
-    prepare_data(ctx=wrap_arguments("mmlu-pro gpqa hle scicode aime25 minif2f aalcr mmlu-prox wmt24pp"))
+    prepare_data(
+        ctx=wrap_arguments("mmlu-pro gpqa hle scicode aime25 minif2f aalcr mmlu-prox wmt24pp ifbench arena-hard-v2")
+    )
     prepare_data(ctx=wrap_arguments("livecodebench --release_version v6 --start_date 2024-08 --end_date 2025-05"))
 
     setup_expname = setup(workspace=args.workspace, cluster=args.cluster, expname_prefix=args.expname_prefix)

--- a/tests/slurm-tests/nano_30b_eval/run_test.py
+++ b/tests/slurm-tests/nano_30b_eval/run_test.py
@@ -51,6 +51,8 @@ FORMAL_MATH_PARAMS = (
     "++eval_config.timeout=400 "
 )
 
+AGENTIC_PARAMS = "++agent_framework=openhands ++inference.temperature=0.7 ++inference.top_p=0.8 ++inference.top_k=20 "
+
 
 def build_server_args(parser_path: str, enable_tools: bool) -> str:
     parts = [
@@ -477,6 +479,47 @@ def eval_formal_math(
     return [expname]
 
 
+def eval_agentic(
+    workspace,
+    cluster,
+    expname_prefix,
+    wandb_project,
+    partition,
+    server_gpus,
+    server_container,
+    run_after,
+):
+    server_args = (
+        build_server_args(
+            parser_path=f"{workspace}/nano_v3_parser/{REASONING_PARSER_FILENAME}",
+            enable_tools=True,
+        )
+        + " --async-scheduling --enforce-eager"
+    )
+    expname = f"{expname_prefix}-agentic-openhands"
+    eval(
+        ctx=wrap_arguments(AGENTIC_PARAMS),
+        cluster=cluster,
+        model=get_local_model_path(workspace),
+        server_type="vllm",
+        server_gpus=server_gpus,
+        server_nodes=1,
+        server_args=server_args,
+        server_container=server_container,
+        output_dir=f"{workspace}/agentic",
+        benchmarks="swe-bench",
+        num_chunks=8,
+        dependent_jobs=2,
+        reuse_code=False,
+        partition=partition,
+        run_after=run_after,
+        expname=expname,
+        wandb_project=wandb_project,
+        wandb_name=expname,
+    )
+    return [expname]
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--workspace", required=True, help="Workspace directory containing all experiment data")
@@ -495,7 +538,9 @@ def main():
     args = parser.parse_args()
 
     prepare_data(
-        ctx=wrap_arguments("mmlu-pro gpqa hle scicode aime25 minif2f aalcr mmlu-prox wmt24pp ifbench arena-hard-v2")
+        ctx=wrap_arguments(
+            "mmlu-pro gpqa hle scicode aime25 minif2f aalcr mmlu-prox wmt24pp ifbench arena-hard-v2 swe-bench"
+        )
     )
     prepare_data(ctx=wrap_arguments("livecodebench --release_version v6 --start_date 2024-08 --end_date 2025-05"))
 
@@ -536,6 +581,17 @@ def main():
         run_after=setup_expname,
     )
 
+    agentic_expnames = eval_agentic(
+        workspace=args.workspace,
+        cluster=args.cluster,
+        expname_prefix=args.expname_prefix,
+        wandb_project=args.wandb_project,
+        partition=args.partition,
+        server_gpus=args.server_gpus,
+        server_container=args.server_container,
+        run_after=setup_expname,
+    )
+
     checker_cmd = f"python tests/slurm-tests/nano_30b_eval/check_results.py --workspace {args.workspace}"
 
     run_cmd(
@@ -543,7 +599,7 @@ def main():
         cluster=args.cluster,
         expname=args.expname_prefix + "-check-results",
         log_dir=f"{args.workspace}/check-results-logs",
-        run_after=no_tools_expnames + with_tools_expnames + formal_math_expnames,
+        run_after=no_tools_expnames + with_tools_expnames + formal_math_expnames + agentic_expnames,
     )
 
 

--- a/tests/slurm-tests/nano_30b_eval/run_test.py
+++ b/tests/slurm-tests/nano_30b_eval/run_test.py
@@ -16,7 +16,8 @@
 
 import argparse
 
-from nemo_skills.pipeline.cli import eval, prepare_data, run_cmd, wrap_arguments
+from nemo_skills.pipeline.cli import eval as run_eval
+from nemo_skills.pipeline.cli import prepare_data, run_cmd, wrap_arguments
 
 MODEL = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
 MODEL_DIRNAME = MODEL.split("/")[-1]
@@ -115,7 +116,7 @@ def eval_no_tools(
     expnames = []
 
     expname = f"{expname_prefix}-no-tools-aime25"
-    eval(
+    run_eval(
         ctx=wrap_arguments(NO_TOOLS_PARAMS),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -135,7 +136,7 @@ def eval_no_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-no-tools-gpqa"
-    eval(
+    run_eval(
         ctx=wrap_arguments(NO_TOOLS_PARAMS + "++prompt_config=eval/aai/mcq-4choices-boxed "),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -155,7 +156,7 @@ def eval_no_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-no-tools-mmlu-pro"
-    eval(
+    run_eval(
         ctx=wrap_arguments(NO_TOOLS_PARAMS + "++prompt_config=eval/aai/mcq-10choices-boxed "),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -175,7 +176,7 @@ def eval_no_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-no-tools-ifbench"
-    eval(
+    run_eval(
         ctx=wrap_arguments(
             NO_TOOLS_PARAMS + "++generation_key=response ++prompt_config=generic/default ++eval_type=ifbench "
         ),
@@ -197,7 +198,7 @@ def eval_no_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-no-tools-livecodebench"
-    eval(
+    run_eval(
         ctx=wrap_arguments(NO_TOOLS_PARAMS),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -218,7 +219,7 @@ def eval_no_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-no-tools-arena-hard-v2"
-    eval(
+    run_eval(
         ctx=wrap_arguments(NO_TOOLS_PARAMS),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -242,7 +243,7 @@ def eval_no_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-no-tools-scicode"
-    eval(
+    run_eval(
         ctx=wrap_arguments(NO_TOOLS_PARAMS + "++prompt_config=eval/scicode/background ++eval_type=scicode "),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -262,7 +263,7 @@ def eval_no_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-no-tools-hle"
-    eval(
+    run_eval(
         ctx=wrap_arguments(NO_TOOLS_PARAMS),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -287,7 +288,7 @@ def eval_no_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-no-tools-aalcr"
-    eval(
+    run_eval(
         ctx=wrap_arguments(NO_TOOLS_PARAMS),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -312,7 +313,7 @@ def eval_no_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-no-tools-mmlu-prox"
-    eval(
+    run_eval(
         ctx=wrap_arguments(NO_TOOLS_PARAMS + "++prompt_config=generic/default ++eval_type=multichoice "),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -332,7 +333,7 @@ def eval_no_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-no-tools-wmt24pp"
-    eval(
+    run_eval(
         ctx=wrap_arguments(NO_TOOLS_PARAMS + "++prompt_config=multilingual/segment-translation "),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -373,7 +374,7 @@ def eval_with_tools(
     expnames = []
 
     expname = f"{expname_prefix}-with-tools-aime25"
-    eval(
+    run_eval(
         ctx=wrap_arguments(WITH_TOOLS_COMMON_PARAMS + "++prompt_config=qwen/math-tir "),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -394,7 +395,7 @@ def eval_with_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-with-tools-gpqa"
-    eval(
+    run_eval(
         ctx=wrap_arguments(WITH_TOOLS_COMMON_PARAMS + "++prompt_config=eval/aai/mcq-4choices-boxed "),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -415,7 +416,7 @@ def eval_with_tools(
     expnames.append(expname)
 
     expname = f"{expname_prefix}-with-tools-hle"
-    eval(
+    run_eval(
         ctx=wrap_arguments(WITH_TOOLS_COMMON_PARAMS + "++prompt_config=generic/hle "),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -458,7 +459,7 @@ def eval_formal_math(
         enable_tools=False,
     )
     expname = f"{expname_prefix}-formal-math-pass32"
-    eval(
+    run_eval(
         ctx=wrap_arguments(FORMAL_MATH_PARAMS),
         cluster=cluster,
         model=get_local_model_path(workspace),
@@ -497,7 +498,7 @@ def eval_agentic(
         + " --async-scheduling --enforce-eager"
     )
     expname = f"{expname_prefix}-agentic-openhands"
-    eval(
+    run_eval(
         ctx=wrap_arguments(AGENTIC_PARAMS),
         cluster=cluster,
         model=get_local_model_path(workspace),

--- a/tests/slurm-tests/nano_30b_eval/run_test.py
+++ b/tests/slurm-tests/nano_30b_eval/run_test.py
@@ -323,6 +323,7 @@ def eval_no_tools(
         output_dir=output_dir,
         benchmarks="mmlu-prox:1",
         num_jobs=1,
+        num_chunks=4,
         partition=partition,
         run_after=run_after,
         expname=expname,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end SLURM evaluation workflow for Nano-30B covering no-tools, with-tools, formal-math, and agentic modes.
  * Added a results validation CLI that aggregates metrics, normalizes percent/fraction values, and enforces metric bounds.
  * Added checks for tool usage patterns and detection of timeout regressions across evaluation outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->