### PR TITLE
fix(parse_reasoning): preserve generation when end tag is missing

### DIFF
--- a/nemo_skills/evaluation/metrics/mcq_multilingual_metrics.py
+++ b/nemo_skills/evaluation/metrics/mcq_multilingual_metrics.py
@@ -72,8 +72,9 @@ class MCQMultilingualMetrics(MathMetrics):
                 # so we don't mutate the original prediction dict
                 temp = {"generation": prediction["generation"]}
                 parse_reasoning(temp)
-                # _generation_finished_thinking=False means no </think> tag was found,
-                # in which case parse_reasoning sets generation="" — fall back to original
+                # _generation_finished_thinking=False means no </think> tag was found;
+                # parse_reasoning leaves generation unchanged in that case but we fall back
+                # to the original for clarity.
                 text_for_lang_detection = (
                     temp["generation"] if temp.get("_generation_finished_thinking") else prediction["generation"]
                 )

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -50,16 +50,20 @@ def parse_reasoning(sample: dict, generation_key: str = "generation", end_reason
     if not isinstance(sample[generation_key], str):
         return
     sample[f"_{generation_key}_finished_thinking"] = end_reasoning_string in sample[generation_key]
+    sample[f"_full_{generation_key}"] = sample[generation_key]
     if end_reasoning_string in sample[generation_key]:
-        sample[f"_full_{generation_key}"] = sample[generation_key]
         sample[generation_key] = sample[generation_key].split(end_reasoning_string)[-1].strip()
     else:
-        sample[f"_full_{generation_key}"] = sample[generation_key]
-        sample[generation_key] = ""  # no end tag, so setting the generation to empty
+        # End tag missing — either the model never closed its reasoning (truncation) or the
+        # generation was already stripped upstream (e.g. server-side reasoning parser that
+        # returns clean `content` + separate `reasoning_content`). In both cases wiping the
+        # generation is destructive; leave it untouched and rely on `_finished_thinking` as
+        # the diagnostic signal.
         LOG.warning(
-            "Thinking end tag `%s` not found in generation; setting generation to empty. "
+            "Thinking end tag `%s` not found in generation; leaving generation unchanged. "
             "If this happens for every generation, you might have accidentally set ++parse_reasoning=True for a "
-            "non-reasoning model or have incorrect end tag.",
+            "non-reasoning model, have an incorrect end tag, or the generation was already stripped upstream "
+            "(e.g. server-side reasoning parser).",
             end_reasoning_string,
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for nemo_skills.utils."""
+
+from nemo_skills.utils import parse_reasoning
+
+
+def test_parse_reasoning_splits_on_end_tag():
+    sample = {"generation": "<think>reasoning here</think>\n\nFinal answer"}
+    parse_reasoning(sample)
+    assert sample["generation"] == "Final answer"
+    assert sample["_generation_finished_thinking"] is True
+    assert sample["_full_generation"] == "<think>reasoning here</think>\n\nFinal answer"
+
+
+def test_parse_reasoning_keeps_text_after_last_end_tag():
+    sample = {"generation": "<think>one</think>middle<think>two</think>answer"}
+    parse_reasoning(sample)
+    assert sample["generation"] == "answer"
+    assert sample["_generation_finished_thinking"] is True
+
+
+def test_parse_reasoning_preserves_generation_when_end_tag_missing():
+    """No </think> → leave generation untouched.
+
+    Covers two real cases: (1) server-side reasoning parser already stripped
+    the tags and returned clean text, and (2) non-reasoning model accidentally
+    had parse_reasoning=True. Wiping the generation loses data in both cases.
+    """
+    original = "The answer is 42."
+    sample = {"generation": original}
+    parse_reasoning(sample)
+    assert sample["generation"] == original
+    assert sample["_generation_finished_thinking"] is False
+    assert sample["_full_generation"] == original
+
+
+def test_parse_reasoning_preserves_partial_think_when_truncated():
+    """Truncated reasoning (no closing tag) → keep partial text, flag as unfinished."""
+    original = "<think>reasoning that got cut of"
+    sample = {"generation": original}
+    parse_reasoning(sample)
+    assert sample["generation"] == original
+    assert sample["_generation_finished_thinking"] is False
+
+
+def test_parse_reasoning_custom_end_string():
+    sample = {"generation": "<reason>x</reason>\nanswer"}
+    parse_reasoning(sample, end_reasoning_string="</reason>")
+    assert sample["generation"] == "answer"
+    assert sample["_generation_finished_thinking"] is True
+
+
+def test_parse_reasoning_custom_generation_key():
+    sample = {"out": "<think>x</think>\nanswer"}
+    parse_reasoning(sample, generation_key="out")
+    assert sample["out"] == "answer"
+    assert sample["_out_finished_thinking"] is True
+    assert sample["_full_out"] == "<think>x</think>\nanswer"
+
+
+def test_parse_reasoning_non_string_no_op():
+    sample = {"generation": ["not", "a", "string"]}
+    parse_reasoning(sample)
+    assert sample["generation"] == ["not", "a", "string"]
+    assert "_generation_finished_thinking" not in sample


### PR DESCRIPTION
Fixes #1390.

## Summary

`parse_reasoning()` used to set `generation = ""` whenever the end-reasoning tag (default `</think>`) was absent from the sample. This silently wipes real data in two legitimate cases:

1. **Server-side reasoning parser already stripped the tags** (vLLM `--reasoning-parser`, SGLang equivalents). `content` is the clean answer, `reasoning_content` holds the trace — but with no `</think>` in `content`, `parse_reasoning` wiped it.
2. **`parse_reasoning=True` set by mistake on a non-reasoning model.** Every row got wiped instead of passing through.

The `_{generation_key}_finished_thinking` flag is already the explicit diagnostic signal downstream code gates on. This PR keeps the original text in the missing-tag branch and lets the flag do its job.

## Changes

- `nemo_skills/utils.py`: in the missing-tag branch, no longer set `generation=""`; update warning text to mention the server-side-parser case. Deduplicates `_full_{generation_key}` assignment by hoisting it above the conditional.
- `nemo_skills/evaluation/metrics/mcq_multilingual_metrics.py`: existing fallback already gates on `_generation_finished_thinking`, so behavior is unchanged — just refresh the now-stale comment.
- `tests/test_utils.py` (new): 7 unit tests covering the end-tag-present branch, end-tag-missing branch, multiple tags, custom `end_reasoning_string`, custom `generation_key`, and the non-string no-op path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved text preservation logic to prevent unintended data loss when processing content with specific markers or tags.

* **Tests**
  * Added comprehensive test suite covering multiple scenarios and edge cases for text processing functionality.

* **Documentation**
  * Enhanced inline documentation with clarified comments about text handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
