### PR TITLE
feat(nemo_gym_rollouts): add --gym_container override

### DIFF
--- a/nemo_skills/pipeline/nemo_gym_rollouts.py
+++ b/nemo_skills/pipeline/nemo_gym_rollouts.py
@@ -110,7 +110,8 @@ def nemo_gym_rollouts(
     gym_container: str = typer.Option(
         None,
         help="Container image path/ref (e.g. a .sqsh file or docker:// reference) for the "
-        "NeMo Gym rollouts step. If not specified, falls back to "
+        "NeMo Gym rollouts step. If not specified, uses "
+        "cluster_config['containers']['nemo-gym'] when present, otherwise falls back to "
         "cluster_config['containers']['nemo-rl'].",
     ),
     gym_path: str = typer.Option(
@@ -267,9 +268,16 @@ def nemo_gym_rollouts(
             resolved_server_container = cluster_config["containers"][server_type_str]
 
     # Resolve the container for the NeMo Gym rollouts step.
-    # Explicit --gym_container (a .sqsh path or docker:// ref) wins; otherwise the
-    # pipeline falls back to the RL container, which still bundles Gym today.
-    resolved_gym_container = gym_container or cluster_config["containers"]["nemo-rl"]
+    # Precedence: explicit --gym_container > cluster_config['containers']['nemo-gym'] > 'nemo-rl'.
+    # Using `is not None` (not truthiness) so an explicit empty string passes through as caller input
+    # rather than silently falling back and masking misconfiguration.
+    containers = cluster_config["containers"]
+    if gym_container is not None:
+        resolved_gym_container = gym_container
+    elif "nemo-gym" in containers:
+        resolved_gym_container = containers["nemo-gym"]
+    else:
+        resolved_gym_container = containers["nemo-rl"]
     LOG.info(f"Using gym container: {resolved_gym_container}")
 
     # Filter out seeds with existing output files (unless rerun_done=True)

--- a/nemo_skills/pipeline/nemo_gym_rollouts.py
+++ b/nemo_skills/pipeline/nemo_gym_rollouts.py
@@ -107,6 +107,12 @@ def nemo_gym_rollouts(
         "If not specified, uses cluster_config['containers'][server_type].",
     ),
     with_sandbox: bool = typer.Option(False, help="If True, start a sandbox container for code execution"),
+    gym_container: str = typer.Option(
+        None,
+        help="Container image path/ref (e.g. a .sqsh file or docker:// reference) for the "
+        "NeMo Gym rollouts step. If not specified, falls back to "
+        "cluster_config['containers']['nemo-rl'].",
+    ),
     gym_path: str = typer.Option(
         "/opt/NeMo-RL/3rdparty/Gym-workspace/Gym",
         help="Path to NeMo Gym installation. Defaults to container built-in. Use for mounted/custom Gym.",
@@ -260,6 +266,12 @@ def nemo_gym_rollouts(
         else:
             resolved_server_container = cluster_config["containers"][server_type_str]
 
+    # Resolve the container for the NeMo Gym rollouts step.
+    # Explicit --gym_container (a .sqsh path or docker:// ref) wins; otherwise the
+    # pipeline falls back to the RL container, which still bundles Gym today.
+    resolved_gym_container = gym_container or cluster_config["containers"]["nemo-rl"]
+    LOG.info(f"Using gym container: {resolved_gym_container}")
+
     # Filter out seeds with existing output files (unless rerun_done=True)
     if not rerun_done and seed_indices != [None]:
         filtered_seeds = []
@@ -346,7 +358,7 @@ def nemo_gym_rollouts(
 
         nemo_gym_cmd = Command(
             script=nemo_gym_script,
-            container=cluster_config["containers"]["nemo-rl"],
+            container=resolved_gym_container,
             name=f"{expname}_nemo_gym{job_suffix}",
             avoid_nemo_run_code=not use_mounted_nemo_skills,
         )


### PR DESCRIPTION
## Summary

Previously `nemo_gym_rollouts` hard-coded `cluster_config["containers"]["nemo-rl"]` for the Gym step, so running Gym in a dedicated (non-RL) container required editing the cluster config. This adds an optional `--gym_container` flag that accepts a direct image path/ref (a `.sqsh` path or `docker://` reference) and takes precedence over the nemo-rl default.

The fallback remains `cluster_config["containers"]["nemo-rl"]`, so existing configs keep working unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --gym_container CLI option to specify a custom container image for NeMo Gym rollouts.
  * When provided (including an explicit empty string) the option takes precedence over configured defaults; if omitted the pipeline falls back to the configured container.
  * The resolved container choice is logged at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->