### PR TITLE
Add RASB-26H1 benchmark integration

### DIFF
--- a/docs/evaluation/rasb.md
+++ b/docs/evaluation/rasb.md
@@ -1,0 +1,294 @@
+# RASB (Real Agent Scaffolds Bench)
+
+## Overview
+
+RASB evaluates how well LLMs follow complex agent scaffolding rather than solving problems autonomously. It tests models as "bearers of scaffolds" - following extensive system prompts, using tools correctly, and producing outputs in specified formats.
+
+The benchmark uses bi-annual snapshots:
+
+- **26H1**: First 2026 snapshot with 193 environments and 5,731 verified synthetic test samples from 63 real agent repositories
+
+## Architecture
+
+The Skills integration follows the original RASB benchmark architecture for reproducibility:
+
+1. **Base image**: Built from each environment's Dockerfile
+2. **Overlay image**: Adds evaluation infrastructure (evaluate.py, judge.py, lm.py, callable)
+3. **Container execution**: Runs `evaluate.py` which processes all `synth_*.json` samples
+4. **Results collection**: Reads `results/results.json` from the container
+
+The container logic is identical to the original RASB benchmark. Only orchestration and results aggregation are adapted for Skills.
+
+## Benchmark Definition
+
+- Dataset: [`nemo_skills/dataset/rasb-26h1/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/rasb-26h1/__init__.py)
+- Generation module: [`nemo_skills/inference/eval/rasb.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/inference/eval/rasb.py)
+- Container files: [`nemo_skills/inference/eval/rasb_container/`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/inference/eval/rasb_container/)
+- Evaluator: [`nemo_skills/evaluation/evaluator/rasb.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/evaluation/evaluator/rasb.py)
+
+## Environment Types
+
+RASB covers six environment types based on the primary task:
+
+| Type | Samples | Description |
+|------|---------|-------------|
+| generation | 2,463 | Content generation (text, code, structured data) |
+| evaluation | 1,075 | Judging, scoring, or comparing outputs |
+| retrieval | 860 | Finding relevant information from context |
+| extraction | 720 | Extracting structured data from unstructured input |
+| coding | 330 | Code generation with execution validation |
+| codebase | 283 | Working with multi-file code repositories |
+
+## Data Preparation
+
+RASB requires Docker for evaluation. Each environment contains a Dockerfile that builds the execution container.
+
+### Prerequisites
+
+1. Docker must be installed and running
+2. Access to RASB 26H1 environment data (contact the RASB maintainers or refer to the RASB technical report for data access)
+
+### Setup
+
+Once you have obtained the RASB 26H1 data, link the environments to the dataset directory:
+
+```bash
+ln -s /path/to/rasb-26h1/26h1 nemo_skills/dataset/rasb-26h1/26h1
+```
+
+Prepare the benchmark data:
+
+```bash
+ns prepare_data rasb-26h1
+```
+
+Or specify a custom data source:
+
+```bash
+ns prepare_data rasb-26h1 --data_source=/path/to/rasb-26h1/26h1
+```
+
+This creates `test.jsonl` with pointers to each environment and input file.
+
+## Evaluation
+
+### Quickstart Example
+
+```bash
+ns eval \
+  --benchmarks rasb-26h1 \
+  --server_type openai \
+  --model azure/anthropic/claude-opus-4-5 \
+  --server_address https://inference-api.nvidia.com \
+  --output_dir /workspace/rasb-eval
+```
+
+### Supported Endpoints and Models
+
+RASB supports multiple API types and model providers:
+
+| Server Type | Compatible Models | Example Endpoint |
+|-------------|-------------------|------------------|
+| `openai` | GPT-4, GPT-4o, Claude (via proxy), Gemini (via proxy) | OpenAI-compatible APIs |
+| `anthropic` | Claude models | Anthropic SDK-compatible APIs |
+
+Supported endpoint types:
+- OpenAI-compatible APIs (completions and responses endpoints)
+- Anthropic SDK-compatible APIs
+- Local model servers with compatible APIs
+
+### Controlling Evaluation Scope
+
+The `++max_samples` parameter controls how many samples (and thus environments) to evaluate. Samples are ordered by environment in test.jsonl, with each environment containing ~30 samples (range: 20-30).
+
+| max_samples | Environments | Use case |
+|-------------|--------------|----------|
+| `30` | ~1 | Quick smoke test |
+| `300` | ~10 | Development testing |
+| `3000` | ~100 | Partial benchmark |
+| `-1` | all 193 | Full benchmark (5,731 samples) |
+
+**Formula**: To evaluate N environments, set `max_samples` to approximately `N × 30`.
+
+### Docker Configuration
+
+RASB runs each environment in an isolated Docker container (processing all samples for that environment). Key configuration options:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `++docker_timeout` | 1800 | Timeout per environment in seconds (30 min) |
+| `++docker_memory_limit` | 4g | Memory limit per container |
+| `++max_concurrent_containers` | 2 | Parallel container execution |
+| `++keep_containers` | False | Keep containers for debugging |
+| `++rebuild_images` | False | Force rebuild Docker images |
+| `++docker_build_timeout` | 600 | Image build timeout (10 min) |
+
+### Example with Docker Settings
+
+```bash
+ns eval \
+  --benchmarks rasb-26h1 \
+  --server_type openai \
+  --model gpt-4o \
+  --output_dir /workspace/rasb-eval \
+  ++docker_timeout=3600 \
+  ++max_concurrent_containers=4 \
+  ++docker_memory_limit=8g
+```
+
+## Judgment Types
+
+RASB uses two judgment types (evaluated inside the container):
+
+| Type | Description |
+|------|-------------|
+| `exact` | Exact match comparison (normalized JSON or string) |
+| `requirements` | LLM judge committee evaluates against requirements list |
+
+The requirements-based judgment uses a committee of LLM judges for open-ended tasks where exact matching isn't appropriate.
+
+## Output Parsing Strategies
+
+RASB uses four output parsing strategies defined per environment:
+
+| Strategy | Description |
+|----------|-------------|
+| `face_value` | Use model output as-is |
+| `json_parse` | Parse output as JSON (handles markdown fences) |
+| `regex_extraction` | Extract output using regex patterns from metadata |
+| `tool_call_result` | Extract from tool call arguments |
+
+## Benchmark Results
+
+Results from the RASB 26H1 technical report (pass rates in %):
+
+| Model | Overall | Mean | Std | Median | Q1 | Q3 |
+|-------|---------|------|-----|--------|----|----|
+| Claude 4.5 Opus | 85.8 | 85.5 | 17.2 | 90.0 | 80.0 | 96.7 |
+| Claude 4.6 Opus | 83.0 | 82.8 | 19.1 | 90.0 | 76.7 | 96.7 |
+| Claude 4.6 Sonnet | 78.4 | 78.0 | 23.5 | 86.7 | 70.0 | 96.0 |
+| Claude 4.7 Opus | 78.6 | 78.3 | 23.1 | 86.7 | 66.7 | 96.7 |
+| Claude 4.5 Sonnet | 77.0 | 76.7 | 22.2 | 83.3 | 66.7 | 93.3 |
+| Claude 4.5 Haiku | 71.1 | 70.9 | 24.9 | 76.7 | 60.0 | 90.0 |
+| Gemini 3 Flash | 71.1 | 70.8 | 23.7 | 76.7 | 56.7 | 90.0 |
+| GPT-5.1 | 70.9 | 70.6 | 28.0 | 76.7 | 60.0 | 90.0 |
+| GPT-5.3 Codex | 70.4 | 70.0 | 28.1 | 76.7 | 56.7 | 92.0 |
+| Gemini 3.1 Pro | 70.4 | 70.1 | 25.1 | 73.3 | 52.0 | 93.3 |
+| GPT-5.3 | 68.9 | 68.4 | 29.0 | 76.7 | 53.3 | 90.0 |
+| Gemini 2.5 Flash | 66.7 | 66.4 | 24.8 | 70.0 | 46.7 | 84.0 |
+| Gemini 3.1 Flash Lite | 64.8 | 64.5 | 27.7 | 66.7 | 46.7 | 86.7 |
+| Nemotron Super | 63.3 | 62.9 | 25.9 | 63.3 | 43.3 | 83.3 |
+| Nemotron Nano | 55.6 | 55.2 | 28.0 | 53.3 | 33.3 | 80.0 |
+
+Overall is the sample-weighted pass rate across all 5,731 samples. Mean, Std, Median, Q1, and Q3 are computed over per-environment pass rates (193 environments).
+
+## Metrics
+
+RASB reports pass rates aggregated by:
+
+- **Overall**: Total correct / total samples
+- **By environment type**: Pass rate per type (generation, evaluation, etc.)
+- **By output parsing**: Pass rate by parsing strategy
+- **By judgment type**: Pass rate for exact vs requirements judgments
+- **By tool usage**: Pass rate for samples with/without tools
+- **By repository**: Pass rate per source repository
+
+### Aggregate Statistics
+
+RASB also computes statistics across all environments:
+
+| Metric | Description |
+|--------|-------------|
+| `mean_pass_rate` | Average pass rate across environments |
+| `median_pass_rate` | Median pass rate (50th percentile) |
+| `q1_pass_rate` | First quartile (25th percentile) |
+| `q3_pass_rate` | Third quartile (75th percentile) |
+| `std_pass_rate` | Standard deviation of pass rates |
+| `overall_pass_rate` | Total correct / total samples |
+| `num_environments` | Number of environments evaluated |
+
+The mean treats all environments equally regardless of sample count, while the overall rate weights by sample count. The quartiles help identify performance distribution across environments.
+
+### Example Metrics Output
+
+```json
+{
+  "pass@1": {
+    "pass_rate": 72.5,
+    "pass_rate_generation": 78.2,
+    "pass_rate_evaluation": 65.1,
+    "pass_rate_retrieval": 71.8,
+    "pass_rate_judgment_exact": 85.3,
+    "pass_rate_judgment_requirements": 58.7,
+    "pass_rate_with_tools": 68.4,
+    "pass_rate_no_tools": 74.1,
+    "errors": 15,
+    "container_errors": 2,
+    "mean_pass_rate": 71.3,
+    "median_pass_rate": 73.5,
+    "q1_pass_rate": 58.2,
+    "q3_pass_rate": 85.0,
+    "std_pass_rate": 18.7,
+    "overall_pass_rate": 72.5,
+    "num_environments": 193
+  }
+}
+```
+
+## Execution Flow
+
+1. **Group samples**: Samples grouped by environment
+2. **Build base image**: Docker image built from environment's Dockerfile (cached)
+3. **Build overlay image**: Adds evaluate.py, judge.py, lm.py, callable, .env
+4. **Run container**: Container executes `evaluate.py` processing all `synth_*.json` files
+5. **Collect results**: Results read from `results/results.json`
+6. **Map to samples**: Container results mapped back to individual sample entries
+
+## Troubleshooting
+
+### Container Build Failures
+
+Check the environment's Dockerfile and requirements:
+
+```bash
+cd nemo_skills/dataset/rasb-26h1/26h1/<environment>/
+docker build -t test .
+```
+
+### Debugging Container Execution
+
+Enable `keep_containers` to inspect failed containers:
+
+```bash
+ns eval ... ++keep_containers=True
+```
+
+Then inspect the container logs:
+
+```bash
+# Check the results directory
+ls /workspace/rasb-eval/environments/<env_id>/
+cat /workspace/rasb-eval/environments/<env_id>/container_stdout.log
+cat /workspace/rasb-eval/environments/<env_id>/results.json
+```
+
+### Network Issues
+
+By default, containers use `host` network mode to access the LLM server. If your server is not on localhost, ensure the container can reach it.
+
+### API Credentials
+
+The container needs API credentials. Set the appropriate environment variable before running:
+
+```bash
+# For OpenAI
+export OPENAI_API_KEY=your-openai-key
+
+# For Anthropic
+export ANTHROPIC_API_KEY=your-anthropic-key
+
+# For NVIDIA Inference API
+export NVAPI_KEY=your-nvidia-key
+```
+
+Ensure the endpoint URL and model name match your API provider. Connection errors inside Docker containers often indicate mismatched endpoint/model configuration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
     - evaluation/instruction-following.md
     - evaluation/long-context.md
     - evaluation/tool-calling.md
+    - evaluation/rasb.md
     - evaluation/multilingual.md
     - evaluation/speech-audio.md
     - evaluation/vlm.md

--- a/nemo_skills/dataset/rasb-26h1/README.md
+++ b/nemo_skills/dataset/rasb-26h1/README.md
@@ -1,0 +1,108 @@
+# RASB-26H1 Benchmark
+
+## Overview
+
+RASB (Real Agent Scaffolds Bench) 26H1 is the first bi-annual snapshot containing 193 environments with 5,731 verified synthetic test samples from 63 real agent repositories.
+
+## Setup
+
+### 1. Link Environment Data
+
+The RASB environments must be symlinked from the agentcompiler repository:
+
+```bash
+ln -s /path/to/rasb-26h1/26h1 nemo_skills/dataset/rasb-26h1/26h1
+```
+
+### 2. Prepare Data
+
+```bash
+ns prepare_data rasb-26h1
+```
+
+This creates `test.jsonl` with pointers to each environment.
+
+## Running Evaluation
+
+### NVIDIA Inference API (Ouickstart Example)
+
+Use the NVIDIA Inference API endpoint for Anthropic models:
+
+```bash
+ns eval \
+  --benchmarks rasb-26h1 \
+  --output_dir /path/to/output \
+  --model azure/anthropic/claude-opus-4-5 \
+  --server_type openai \
+  --server_address https://inference-api.nvidia.com \
+  ++max_samples=150 \
+  ++docker_timeout=3600 \
+  ++max_concurrent_containers=2
+```
+
+### Environment Variables
+
+Set the API key before running:
+
+```bash
+export NVAPI_KEY=your-nvidia-api-key
+```
+
+### Controlling Evaluation Scope
+
+The `++max_samples` parameter controls how many samples to evaluate. Samples are ordered by environment in test.jsonl, with each environment containing ~30 samples.
+
+| max_samples | Environments | Use case |
+|-------------|--------------|----------|
+| `30` | ~1 | Quick smoke test |
+| `300` | ~10 | Development testing |
+| `3000` | ~100 | Partial benchmark |
+| `-1` | all 193 | Full benchmark (5,731 samples) |
+
+**Formula**: To evaluate N environments, set `max_samples` to approximately `N × 30`.
+
+### Configuration Reference
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `--server_address` | `https://inference-api.nvidia.com` | NVIDIA Inference API endpoint |
+| `--model` | `azure/anthropic/claude-opus-4-5` | Claude Opus via NVIDIA NIM |
+| `++docker_timeout` | `3600` | 1 hour timeout per environment |
+| `++max_concurrent_containers` | `2` | Parallel container execution |
+| `++max_samples` | `-1` | All samples, or `N × 30` for N envs |
+
+## Common Issues
+
+### Connection Errors Inside Docker Containers
+
+If you see `"Error querying ... Connection error."` for all samples in an environment:
+
+1. **Wrong endpoint**: Ensure you're using the correct endpoint address, e.g., `https://inference-api.nvidia.com`
+
+2. **Wrong model name**: Use the correct full model path string, e.g., `azure/anthropic/claude-opus-4-5`
+
+3. **Network mode**: Containers use `--network host` by default. Ensure Docker can reach external APIs.
+
+4. **API key**: Ensure `NVAPI_KEY` (or other applicable API key environment variable) is set and valid.
+
+
+## Metrics
+
+RASB reports aggregate statistics across environments:
+
+| Metric | Description |
+|--------|-------------|
+| `pass_rate` | Overall pass rate (sample-weighted) |
+| `mean_pass_rate` | Average pass rate across environments |
+| `median_pass_rate` | Median pass rate (50th percentile) |
+| `q1_pass_rate` | First quartile (25th percentile) |
+| `q3_pass_rate` | Third quartile (75th percentile) |
+| `std_pass_rate` | Standard deviation |
+| `num_environments` | Number of environments evaluated |
+
+## Files
+
+- `__init__.py` - Benchmark registration
+- `prepare.py` - Data preparation script
+- `test.jsonl` - Generated test samples (after `ns prepare_data`)
+- `26h1/` - Symlink to environment folders (must be created manually)

--- a/nemo_skills/dataset/rasb-26h1/__init__.py
+++ b/nemo_skills/dataset/rasb-26h1/__init__.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+RASB 26H1 benchmark dataset module.
+
+RASB (Real Agent Scaffolds Bench) 26H1 is the first bi-annual snapshot
+containing 193 environments with 5,731 verified synthetic test samples
+from 63 real agent repositories.
+
+Environment types: generation (83), evaluation (36), retrieval (29),
+extraction (24), coding (11), codebase (10).
+"""
+
+# Environment folders are stored alongside the JSONL (like images in MMMU-Pro)
+REQUIRES_DATA_DIR = True
+
+# Custom generation module handles Docker container orchestration
+GENERATION_MODULE = "nemo_skills.inference.eval.rasb"
+
+# Custom metrics for RASB-specific aggregation by environment type
+METRICS_TYPE = "rasb"
+
+# Default generation arguments with custom evaluator
+GENERATION_ARGS = "++eval_type=rasb"
+
+# Default evaluation split
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/rasb-26h1/prepare.py
+++ b/nemo_skills/dataset/rasb-26h1/prepare.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Prepare RASB 26H1 benchmark data.
+
+This script creates a pointer JSONL that references environment folders
+rather than converting them. Each entry contains:
+- environment_path: relative path to the environment folder
+- input_file: name of the input JSON file
+- metadata fields for filtering and metrics aggregation
+
+The actual environment folders (Dockerfile, tools.py, prompts, inputs)
+remain as-is, following the pattern used by SWE-bench (container references)
+and MMMU-Pro (image paths).
+
+Usage:
+    ns prepare_data rasb-26h1
+
+    Or with custom data location:
+    ns prepare_data rasb-26h1 --data_source=/path/to/rasb-26h1/26h1
+"""
+
+import argparse
+import json
+import os
+import urllib.request
+from pathlib import Path
+
+
+# Default location for RASB 26H1 data
+# Users can override this with --data_source argument
+DEFAULT_DATA_URL = None  # TODO: Add HuggingFace or other hosted URL when available
+
+
+def load_metadata(env_path: Path) -> dict:
+    """Load and validate environment metadata."""
+    metadata_file = env_path / "metadata.json"
+    if not metadata_file.exists():
+        raise FileNotFoundError(f"No metadata.json in {env_path}")
+
+    with open(metadata_file, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_input_files(env_path: Path) -> list[Path]:
+    """Get verified synthetic test inputs from the environment's inputs directory.
+
+    Only synth_*.json files are used for benchmarking (matching the original
+    RASB benchmark behavior). Example files and candidate files are excluded.
+    """
+    inputs_dir = env_path / "inputs"
+    if not inputs_dir.exists():
+        return []
+    return sorted(inputs_dir.glob("synth_*.json"))
+
+
+def create_entry(
+    env_path: Path,
+    input_file: Path,
+    metadata: dict,
+    base_dir: Path,
+) -> dict:
+    """Create a single JSONL entry for an environment/input pair."""
+    # Relative path from the dataset directory
+    rel_env_path = env_path.relative_to(base_dir)
+
+    # Extract output parsing strategy
+    output_schema = metadata.get("output_schema", {})
+    output_parsing = output_schema.get("parsing", "face_value")
+
+    return {
+        # Pointers to environment and input (like image_path in MMMU-Pro)
+        "environment_path": str(rel_env_path),
+        "input_file": input_file.name,
+        # Metadata for filtering and metrics
+        "task_id": metadata.get("id", env_path.name),
+        "environment_type": metadata.get("environment_type", "unknown"),
+        "interaction_mode": metadata.get("interaction_mode", "single_shot"),
+        "output_parsing": output_parsing,
+        "max_turns": metadata.get("max_turns", 1),
+        "has_tools": bool(metadata.get("tools", [])),
+        # Additional metadata for analysis
+        "repo": metadata.get("repo", ""),
+        "input_mode": metadata.get("input_mode", ""),
+    }
+
+
+def save_data(split: str = "test", data_source: str | None = None):
+    """Prepare RASB 26H1 data by creating pointer JSONL."""
+    data_dir = Path(__file__).absolute().parent
+
+    # Determine where environments are located
+    if data_source:
+        environments_dir = Path(data_source)
+    else:
+        environments_dir = data_dir / "26h1"
+
+    if not environments_dir.exists():
+        # Try to download if URL is configured
+        if DEFAULT_DATA_URL:
+            print(f"Downloading RASB 26H1 data from {DEFAULT_DATA_URL}...")
+            # TODO: Implement download logic when hosting is available
+            raise NotImplementedError("Automatic download not yet implemented")
+
+        raise FileNotFoundError(
+            f"Environment directory not found: {environments_dir}\n\n"
+            "Please provide the path to RASB 26H1 environments using:\n"
+            "  ns prepare_data rasb-26h1 --data_source=/path/to/rasb-26h1/26h1\n\n"
+            "Or create a symlink:\n"
+            f"  ln -s /path/to/rasb-26h1/26h1 {data_dir / '26h1'}"
+        )
+
+    output_file = data_dir / f"{split}.jsonl"
+
+    entries = []
+    env_count = 0
+    input_count = 0
+    skipped_envs = []
+
+    print(f"Scanning environments in {environments_dir}...")
+
+    for env_path in sorted(environments_dir.iterdir()):
+        if not env_path.is_dir():
+            continue
+
+        # Skip hidden directories
+        if env_path.name.startswith("."):
+            continue
+
+        try:
+            metadata = load_metadata(env_path)
+        except FileNotFoundError as e:
+            skipped_envs.append((env_path.name, str(e)))
+            continue
+
+        input_files = get_input_files(env_path)
+        if not input_files:
+            skipped_envs.append((env_path.name, "No input files found"))
+            continue
+
+        env_count += 1
+
+        for input_file in input_files:
+            entry = create_entry(env_path, input_file, metadata, data_dir)
+            entries.append(entry)
+            input_count += 1
+
+    # Write output
+    with open(output_file, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+    # Summary
+    print(f"\nRASB 26H1 Preparation Summary")
+    print(f"{'=' * 40}")
+    print(f"Environments processed: {env_count}")
+    print(f"Total samples: {input_count}")
+    print(f"Output file: {output_file}")
+
+    if skipped_envs:
+        print(f"\nSkipped {len(skipped_envs)} environments:")
+        for name, reason in skipped_envs[:5]:
+            print(f"  - {name}: {reason}")
+        if len(skipped_envs) > 5:
+            print(f"  ... and {len(skipped_envs) - 5} more")
+
+    # Environment type breakdown
+    type_counts = {}
+    for entry in entries:
+        env_type = entry["environment_type"]
+        type_counts[env_type] = type_counts.get(env_type, 0) + 1
+
+    print(f"\nSamples by environment type:")
+    for env_type, count in sorted(type_counts.items(), key=lambda x: -x[1]):
+        print(f"  {env_type}: {count}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Prepare RASB 26H1 benchmark data"
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=("test",),
+        help="Dataset split to prepare (default: test)",
+    )
+    parser.add_argument(
+        "--data_source",
+        type=str,
+        default=None,
+        help="Path to RASB 26H1 environments directory (default: ./26h1)",
+    )
+    args = parser.parse_args()
+
+    save_data(args.split, args.data_source)

--- a/nemo_skills/evaluation/evaluator/__init__.py
+++ b/nemo_skills/evaluation/evaluator/__init__.py
@@ -57,6 +57,7 @@ _EVALUATOR_CLASS_MAP_PATHS = {
     "compute-eval": "nemo_skills.evaluation.evaluator.compute_eval:ComputeEvalEvaluator",
     "critpt": "nemo_skills.evaluation.evaluator.critpt:CritPtEvaluator",
     "dsbench": "nemo_skills.evaluation.evaluator.dsbench:DSBenchEvaluator",
+    "rasb": "nemo_skills.evaluation.evaluator.rasb:RasbEvaluator",
 }
 
 # Validation: Ensure no overlap between class and function maps

--- a/nemo_skills/evaluation/evaluator/rasb.py
+++ b/nemo_skills/evaluation/evaluator/rasb.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+RASB evaluator module.
+
+This evaluator passes through results from the Docker container evaluation.
+The actual evaluation (output parsing, exact match, requirements judging)
+is done by evaluate.py inside the container for reproducibility.
+
+The evaluator here simply extracts the evaluation results from rasb_result
+and formats them for Skills metrics aggregation.
+"""
+
+import logging
+from typing import Any, Dict
+
+from nemo_skills.evaluation.evaluator.base import BaseEvaluator
+from nemo_skills.utils import get_logger_name
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+
+class RasbEvaluator(BaseEvaluator):
+    """
+    Evaluator for RASB benchmark.
+
+    Evaluation is performed inside Docker containers by evaluate.py
+    (matching the original RASB benchmark for reproducibility).
+    This evaluator extracts and formats those results for Skills.
+
+    The rasb_result field from generation contains:
+    - passed: bool - Whether the sample passed evaluation
+    - judgment_type: str - "exact" or "requirements"
+    - judgment_details: dict - Details of the judgment
+    - model_output: str - Raw model output
+    - parsed_output: Any - Parsed output (JSON, regex match, etc.)
+    - error: str | None - Error message if evaluation failed
+    """
+
+    def __init__(self, config: Dict[str, Any], num_parallel_requests: int = 10):
+        super().__init__(config, num_parallel_requests)
+
+    async def eval_single(self, data_point: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Extract evaluation results from the container output.
+
+        The is_correct field is already set by the generation task
+        based on the container's evaluate.py results.
+        """
+        rasb_result = data_point.get("rasb_result", {})
+
+        # The container sets 'passed' field
+        is_correct = rasb_result.get("passed", False)
+
+        # Extract additional evaluation details
+        judgment_type = rasb_result.get("judgment_type", "unknown")
+        judgment_details = rasb_result.get("judgment_details", {})
+        parsed_output = rasb_result.get("parsed_output")
+        error = rasb_result.get("error")
+
+        result = {
+            "is_correct": is_correct,
+            "judgment_type": judgment_type,
+        }
+
+        # Include parsed output if available
+        if parsed_output is not None:
+            result["parsed_output"] = parsed_output
+
+        # Include error if present
+        if error:
+            result["error"] = error
+            result["is_correct"] = False
+
+        # Include judgment details for debugging
+        if judgment_details:
+            # For requirements-based judgments, include requirement-level results
+            if judgment_type == "requirements" and "requirements" in judgment_details:
+                result["requirements_passed"] = sum(
+                    1 for r in judgment_details["requirements"] if r.get("pass")
+                )
+                result["requirements_total"] = len(judgment_details["requirements"])
+
+        return result
+
+    def supports_single_eval(self) -> bool:
+        """RASB evaluation is done inside containers, not during generation."""
+        return False

--- a/nemo_skills/evaluation/metrics/map_metrics.py
+++ b/nemo_skills/evaluation/metrics/map_metrics.py
@@ -44,6 +44,7 @@ from nemo_skills.evaluation.metrics.mmau_pro_metrics import MMAUProMetrics
 from nemo_skills.evaluation.metrics.mrcr_metrics import MRCRMetrics
 from nemo_skills.evaluation.metrics.omni_metrics import OmniMetrics
 from nemo_skills.evaluation.metrics.physics_metrics import PhysicsMetrics
+from nemo_skills.evaluation.metrics.rasb_metrics import RasbMetrics
 from nemo_skills.evaluation.metrics.ruler2_metrics import Ruler2Metrics
 from nemo_skills.evaluation.metrics.ruler_metrics import RulerMetrics
 from nemo_skills.evaluation.metrics.simpleqa_metrics import SimpleQAMetrics
@@ -86,6 +87,7 @@ METRICS_MAP = {
     "scicode": SciCodeMetrics,
     "bigcodebench": BigCodeBenchMetrics,
     "mrcr": MRCRMetrics,
+    "rasb": RasbMetrics,
     "aalcr": AALCRMetrics,
     "livebench_coding": LiveCodeBenchMetrics,
     "translation": TranslationMetrics,

--- a/nemo_skills/evaluation/metrics/rasb_metrics.py
+++ b/nemo_skills/evaluation/metrics/rasb_metrics.py
@@ -1,0 +1,357 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+RASB metrics module.
+
+Computes pass rates aggregated by:
+- Overall pass rate
+- Environment type (generation, evaluation, retrieval, extraction, coding, codebase)
+- Output parsing strategy (face_value, json_parse, regex_extraction, tool_call_result)
+- Judgment type (exact, requirements)
+- Source repository
+
+Also computes aggregate statistics across environments:
+- Mean pass rate
+- Median pass rate
+- First quartile (Q1) pass rate
+- Third quartile (Q3) pass rate
+- Standard deviation
+"""
+
+import logging
+import math
+from collections import defaultdict
+from typing import Any
+
+from nemo_skills.evaluation.metrics.base import BaseMetrics
+from nemo_skills.utils import get_logger_name
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+
+class RasbMetrics(BaseMetrics):
+    """
+    Metrics class for RASB benchmark.
+
+    Provides aggregated pass rates across multiple dimensions:
+    - Overall pass rate
+    - Pass rate by environment type
+    - Pass rate by output parsing strategy
+    - Pass rate by judgment type (exact vs requirements)
+    - Pass rate by tool usage
+    - Pass rate by source repository
+    """
+
+    def __init__(self, compute_no_answer: bool = True):
+        super().__init__(compute_no_answer=compute_no_answer)
+
+    def reset(self):
+        """Reset all counters."""
+        self.total = 0
+        self.correct = 0
+        self.avg_tokens = 0
+        self.max_k = 1
+        self.min_start_time = float("inf")
+        self.max_end_time = float("-inf")
+        self.eval_dict = {"pass@1": {}}
+        self.all_scores = defaultdict(list)
+
+        # RASB-specific counters
+        self.by_env_type = defaultdict(lambda: {"total": 0, "correct": 0})
+        self.by_output_parsing = defaultdict(lambda: {"total": 0, "correct": 0})
+        self.by_judgment_type = defaultdict(lambda: {"total": 0, "correct": 0})
+        self.by_interaction_mode = defaultdict(lambda: {"total": 0, "correct": 0})
+        self.by_repo = defaultdict(lambda: {"total": 0, "correct": 0})
+        self.by_has_tools = {True: {"total": 0, "correct": 0}, False: {"total": 0, "correct": 0}}
+
+        # Error tracking
+        self.errors = 0
+        self.container_errors = 0
+
+        # Per-environment tracking for aggregate statistics
+        self.by_env_id = defaultdict(lambda: {"total": 0, "correct": 0})
+
+    def _get_score_dict(self, prediction: dict) -> dict[str, bool | int | float]:
+        """Return score dictionary for a prediction."""
+        return {"is_correct": prediction.get("is_correct", False)}
+
+    def get_incorrect_sample(self, prediction: dict) -> dict:
+        """Return a modified prediction marked as incorrect."""
+        return {**prediction, "is_correct": False}
+
+    def update(self, predictions: list[dict]):
+        """
+        Update metrics with a list of predictions for a single sample.
+
+        For RASB, we typically have 1 prediction per sample.
+        """
+        super().update(predictions)
+
+        # Use first prediction for aggregation
+        pred = predictions[0]
+        rasb_result = pred.get("rasb_result", {})
+
+        # Overall metrics - use is_correct which is set from rasb_result["passed"]
+        is_correct = pred.get("is_correct", False)
+        self.correct += int(is_correct)
+
+        # Token counting
+        if "num_generated_tokens" in pred:
+            self.avg_tokens += pred["num_generated_tokens"]
+
+        # Timing
+        if "_generation_start_time" in pred:
+            self.min_start_time = min(self.min_start_time, pred["_generation_start_time"])
+        if "_generation_end_time" in pred:
+            self.max_end_time = max(self.max_end_time, pred["_generation_end_time"])
+
+        # By environment type
+        env_type = pred.get("environment_type", "unknown")
+        self.by_env_type[env_type]["total"] += 1
+        self.by_env_type[env_type]["correct"] += int(is_correct)
+
+        # By output parsing (from metadata in input)
+        output_parsing = pred.get("output_parsing", "unknown")
+        self.by_output_parsing[output_parsing]["total"] += 1
+        self.by_output_parsing[output_parsing]["correct"] += int(is_correct)
+
+        # By judgment type (from rasb_result)
+        judgment_type = rasb_result.get("judgment_type", "unknown")
+        self.by_judgment_type[judgment_type]["total"] += 1
+        self.by_judgment_type[judgment_type]["correct"] += int(is_correct)
+
+        # By interaction mode
+        interaction_mode = pred.get("interaction_mode", "unknown")
+        self.by_interaction_mode[interaction_mode]["total"] += 1
+        self.by_interaction_mode[interaction_mode]["correct"] += int(is_correct)
+
+        # By repository
+        repo = pred.get("repo", "unknown")
+        self.by_repo[repo]["total"] += 1
+        self.by_repo[repo]["correct"] += int(is_correct)
+
+        # By tool usage
+        has_tools = pred.get("has_tools", False)
+        self.by_has_tools[has_tools]["total"] += 1
+        self.by_has_tools[has_tools]["correct"] += int(is_correct)
+
+        # Per-environment tracking (for aggregate stats)
+        env_id = pred.get("env_id", "unknown")
+        self.by_env_id[env_id]["total"] += 1
+        self.by_env_id[env_id]["correct"] += int(is_correct)
+
+        # Error tracking
+        if rasb_result.get("error"):
+            self.errors += 1
+        if rasb_result.get("status") in ("container_error", "base_build_failed", "bench_build_failed"):
+            self.container_errors += 1
+
+        # Store score for pass@k computation
+        self.all_scores["is_correct"].append([is_correct])
+
+        # Update pass@1 metric
+        self.eval_dict["pass@1"]["is_correct"] = self.correct
+
+    def _compute_rate(self, counter: dict) -> float:
+        """Compute pass rate as percentage."""
+        if counter["total"] == 0:
+            return 0.0
+        return 100.0 * counter["correct"] / counter["total"]
+
+    def _compute_percentile(self, sorted_values: list, percentile: float) -> float:
+        """Compute percentile from sorted list of values."""
+        if not sorted_values:
+            return 0.0
+        n = len(sorted_values)
+        idx = (n - 1) * percentile
+        lower = int(idx)
+        upper = lower + 1
+        if upper >= n:
+            return sorted_values[-1]
+        weight = idx - lower
+        return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight
+
+    def _compute_aggregate_stats(self) -> dict[str, float]:
+        """
+        Compute aggregate statistics across all environments.
+
+        Returns:
+            Dictionary with mean, median, Q1, Q3, std, and overall pass rates.
+        """
+        # Collect per-environment pass rates
+        pass_rates = []
+        for env_id, counter in self.by_env_id.items():
+            if counter["total"] > 0:
+                rate = 100.0 * counter["correct"] / counter["total"]
+                pass_rates.append(rate)
+
+        if not pass_rates:
+            return {
+                "mean_pass_rate": 0.0,
+                "median_pass_rate": 0.0,
+                "q1_pass_rate": 0.0,
+                "q3_pass_rate": 0.0,
+                "std_pass_rate": 0.0,
+                "overall_pass_rate": 0.0,
+                "num_environments": 0,
+            }
+
+        # Sort for percentile calculations
+        sorted_rates = sorted(pass_rates)
+        n = len(sorted_rates)
+
+        # Mean
+        mean = sum(pass_rates) / n
+
+        # Standard deviation
+        variance = sum((r - mean) ** 2 for r in pass_rates) / n
+        std = math.sqrt(variance)
+
+        # Median (Q2)
+        median = self._compute_percentile(sorted_rates, 0.5)
+
+        # First quartile (Q1)
+        q1 = self._compute_percentile(sorted_rates, 0.25)
+
+        # Third quartile (Q3)
+        q3 = self._compute_percentile(sorted_rates, 0.75)
+
+        # Overall pass rate (total correct / total samples across all envs)
+        total_samples = sum(c["total"] for c in self.by_env_id.values())
+        total_correct = sum(c["correct"] for c in self.by_env_id.values())
+        overall = 100.0 * total_correct / total_samples if total_samples > 0 else 0.0
+
+        return {
+            "mean_pass_rate": mean,
+            "median_pass_rate": median,
+            "q1_pass_rate": q1,
+            "q3_pass_rate": q3,
+            "std_pass_rate": std,
+            "overall_pass_rate": overall,
+            "num_environments": n,
+        }
+
+    def get_metrics(self) -> dict[str, Any]:
+        """
+        Get all computed metrics.
+
+        Returns:
+            Dictionary with metrics organized by aggregation mode.
+        """
+        metrics = super().get_metrics()
+
+        # Add overall pass rate
+        if "pass@1" in metrics:
+            metrics["pass@1"]["pass_rate"] = (
+                100.0 * self.correct / self.total if self.total > 0 else 0.0
+            )
+
+        # Add pass rates by environment type
+        env_type_metrics = {}
+        for env_type, counter in sorted(self.by_env_type.items()):
+            env_type_metrics[f"pass_rate_{env_type}"] = self._compute_rate(counter)
+            env_type_metrics[f"count_{env_type}"] = counter["total"]
+
+        if "pass@1" in metrics:
+            metrics["pass@1"].update(env_type_metrics)
+
+        # Add pass rates by output parsing
+        parsing_metrics = {}
+        for parsing, counter in sorted(self.by_output_parsing.items()):
+            parsing_metrics[f"pass_rate_parsing_{parsing}"] = self._compute_rate(counter)
+
+        if "pass@1" in metrics:
+            metrics["pass@1"].update(parsing_metrics)
+
+        # Add pass rates by judgment type
+        judgment_metrics = {}
+        for jtype, counter in sorted(self.by_judgment_type.items()):
+            judgment_metrics[f"pass_rate_judgment_{jtype}"] = self._compute_rate(counter)
+            judgment_metrics[f"count_judgment_{jtype}"] = counter["total"]
+
+        if "pass@1" in metrics:
+            metrics["pass@1"].update(judgment_metrics)
+
+        # Add pass rates by tool usage
+        if "pass@1" in metrics:
+            tools_counter = self.by_has_tools[True]
+            no_tools_counter = self.by_has_tools[False]
+            metrics["pass@1"]["pass_rate_with_tools"] = self._compute_rate(tools_counter)
+            metrics["pass@1"]["pass_rate_no_tools"] = self._compute_rate(no_tools_counter)
+            metrics["pass@1"]["count_with_tools"] = tools_counter["total"]
+            metrics["pass@1"]["count_no_tools"] = no_tools_counter["total"]
+
+        # Add error counts
+        if "pass@1" in metrics:
+            metrics["pass@1"]["errors"] = self.errors
+            metrics["pass@1"]["container_errors"] = self.container_errors
+
+        # Add aggregate statistics across environments
+        if "pass@1" in metrics:
+            aggregate_stats = self._compute_aggregate_stats()
+            metrics["pass@1"].update(aggregate_stats)
+
+        return metrics
+
+    def get_breakdown_by_repo(self) -> dict[str, dict]:
+        """
+        Get detailed breakdown by source repository.
+
+        Returns:
+            Dictionary mapping repo name to pass rate and count.
+        """
+        breakdown = {}
+        for repo, counter in sorted(self.by_repo.items(), key=lambda x: -x[1]["total"]):
+            breakdown[repo] = {
+                "pass_rate": self._compute_rate(counter),
+                "total": counter["total"],
+                "correct": counter["correct"],
+            }
+        return breakdown
+
+    def get_breakdown_by_type(self) -> dict[str, dict]:
+        """
+        Get detailed breakdown by environment type.
+
+        Returns:
+            Dictionary mapping environment type to pass rate and count.
+        """
+        breakdown = {}
+        for env_type, counter in sorted(self.by_env_type.items()):
+            breakdown[env_type] = {
+                "pass_rate": self._compute_rate(counter),
+                "total": counter["total"],
+                "correct": counter["correct"],
+            }
+        return breakdown
+
+    def get_breakdown_by_env_id(self) -> dict[str, dict]:
+        """
+        Get detailed breakdown by environment ID.
+
+        Returns:
+            Dictionary mapping environment ID to pass rate and count,
+            sorted by pass rate (ascending) for easy identification of
+            challenging environments.
+        """
+        breakdown = {}
+        for env_id, counter in self.by_env_id.items():
+            breakdown[env_id] = {
+                "pass_rate": self._compute_rate(counter),
+                "total": counter["total"],
+                "correct": counter["correct"],
+            }
+        # Sort by pass rate (ascending) to show hardest environments first
+        return dict(sorted(breakdown.items(), key=lambda x: x[1]["pass_rate"]))

--- a/nemo_skills/inference/eval/rasb.py
+++ b/nemo_skills/inference/eval/rasb.py
@@ -1,0 +1,767 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+RASB generation module with Docker container orchestration.
+
+This module runs RASB environments inside Docker containers following
+the original RASB benchmark architecture:
+1. Build base image from environment's Dockerfile
+2. Create overlay image with evaluate.py, judge.py, lm.py, and callable
+3. Run evaluate.py inside the container to process all synth_*.json samples
+4. Collect results from results/results.json
+
+The container logic is identical to the original RASB benchmark for
+reproducibility. Only the orchestration and results aggregation differ.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+import shutil
+import tempfile
+from collections import defaultdict
+from dataclasses import field
+from pathlib import Path
+
+import docker
+import hydra
+
+from nemo_skills.inference.generate import GenerationTask
+from nemo_skills.utils import get_logger_name, nested_dataclass, setup_logging
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+# Path to container files (evaluate.py, judge.py, lm.py)
+CONTAINER_FILES_DIR = Path(__file__).parent / "rasb_container"
+
+# Overlay Dockerfile template (matches original RASB benchmark)
+OVERLAY_DOCKERFILE = """\
+FROM {base_image}
+
+# Copy evaluation infrastructure into the container's WORKDIR
+COPY lm.py ./lm.py
+COPY judge.py ./judge.py
+COPY evaluate.py ./evaluate.py
+COPY .env ./.env
+
+# Callable package
+COPY callable_pkg/ ./callable_pkg/
+COPY callable_pkg/callable.py ./callable.py
+RUN if [ -f callable_pkg/requirements.txt ]; then \\
+      pip install --no-cache-dir -r callable_pkg/requirements.txt; fi
+RUN if [ -f callable_pkg/setup.sh ]; then \\
+      chmod +x callable_pkg/setup.sh && ./callable_pkg/setup.sh; fi
+
+RUN mkdir -p results
+
+CMD ["python", "evaluate.py"]
+"""
+
+
+def _detect_workdir(env_dir: Path) -> str:
+    """Read the WORKDIR from an environment's Dockerfile."""
+    dockerfile = env_dir / "Dockerfile"
+    if dockerfile.exists():
+        for line in dockerfile.read_text().splitlines():
+            m = re.match(r'^\s*WORKDIR\s+(\S+)', line, re.IGNORECASE)
+            if m:
+                return m.group(1)
+    return "/benchmark"
+
+
+def _sanitize_tag(name: str) -> str:
+    """Sanitize a string for use in Docker tags."""
+    # Docker tags: lowercase alphanumeric, dots, underscores, hyphens
+    name = name.lower()
+    name = re.sub(r'[^a-z0-9._-]', '_', name)
+    name = re.sub(r'_+', '_', name)
+    return name[:128]  # Docker tag length limit
+
+
+@nested_dataclass(kw_only=True)
+class RasbInferenceConfig:
+    """Inference parameters for RASB."""
+
+    temperature: float = 0.0
+    top_p: float = 0.95
+    tokens_to_generate: int = 4096
+    timeout: int = 120  # Timeout per LLM call in seconds
+
+
+@nested_dataclass(kw_only=True)
+class RasbGenerationConfig:
+    """Configuration for RASB generation task."""
+
+    input_file: str  # Path to the JSONL file with sample pointers
+    output_file: str  # Where to save the results
+    data_dir: str | None = None  # Base directory for environment folders
+
+    # Inference server configuration
+    server: dict = field(default_factory=dict)
+    inference: RasbInferenceConfig = field(default_factory=RasbInferenceConfig)
+
+    # Docker settings
+    docker_timeout: int = 1800  # 30 minutes per environment (all samples)
+    docker_memory_limit: str = "4g"
+    docker_network_mode: str = "host"  # Allow container to access host network
+    keep_containers: bool = False  # Keep containers after execution (debugging)
+    rebuild_images: bool = False  # Force rebuild of Docker images
+    docker_build_timeout: int = 600  # 10 minutes for image builds
+
+    # Parallelization
+    max_concurrent_containers: int = 2  # Conservative for API limits
+
+    # Data handling
+    max_samples: int = -1  # Limit samples for debugging
+    skip_filled: bool = False  # Skip already processed environments
+    num_chunks: int | None = None
+    chunk_id: int | None = None
+
+    # Output handling
+    generation_key: str = "generation"
+    add_generation_stats: bool = True
+    dry_run: bool = False
+
+    # Evaluation (handled by evaluate.py inside container)
+    eval_type: str | None = None
+    eval_config: dict = field(default_factory=dict)
+
+
+cs = hydra.core.config_store.ConfigStore.instance()
+cs.store(name="base_rasb_generation_config", node=RasbGenerationConfig)
+
+
+class RasbGenerationTask(GenerationTask):
+    """
+    Generation task for RASB benchmark using Docker containers.
+
+    Follows the original RASB benchmark architecture:
+    - Build base image from environment Dockerfile
+    - Create overlay image with evaluation infrastructure
+    - Run evaluate.py to process all samples for the environment
+    - Collect results from results/results.json
+    """
+
+    def __init__(self, cfg: RasbGenerationConfig):
+        self.cfg = cfg
+        self.docker_client = docker.from_env()
+        self.semaphore = asyncio.Semaphore(cfg.max_concurrent_containers)
+
+        # Image cache: environment_path -> (base_tag, bench_tag)
+        self._image_cache: dict[str, tuple[str, str]] = {}
+
+        # Resolve data directory
+        if cfg.data_dir:
+            self.data_dir = Path(cfg.data_dir)
+        else:
+            self.data_dir = Path(cfg.input_file).parent
+
+        LOG.info("RASB generation task initialized")
+        LOG.info(f"  Data directory: {self.data_dir}")
+        LOG.info(f"  Max concurrent containers: {cfg.max_concurrent_containers}")
+        LOG.info(f"  Docker timeout: {cfg.docker_timeout}s per environment")
+
+    def setup_prompt(self):
+        """No prompt setup needed - prompts come from environments."""
+        return None
+
+    def setup_llm(self):
+        """No LLM setup needed - LLM calls happen inside containers."""
+        return None
+
+    def setup_litellm_cache(self):
+        """No cache needed."""
+        pass
+
+    def cleanup_litellm_cache(self):
+        """No cache to clean."""
+        pass
+
+    def log_example_prompt(self, data):
+        """Log an example from the first environment."""
+        if data:
+            first = data[0]
+            env_path = self.data_dir / first["environment_path"]
+            LOG.info(f"Example environment: {first['environment_path']}")
+            LOG.info(f"  Task ID: {first['task_id']}")
+            LOG.info(f"  Environment type: {first['environment_type']}")
+
+            # Show system prompt preview
+            system_prompt_file = env_path / "prompt_system.txt"
+            if system_prompt_file.exists():
+                content = system_prompt_file.read_text()[:500]
+                LOG.info(f"  System prompt preview:\n{content}...")
+
+    async def evaluate_single_datapoint(self, data_point):
+        """Evaluation happens inside the container."""
+        return data_point
+
+    def _get_image_tags(self, env_path: Path, run_name: str = "skills") -> tuple[str, str]:
+        """Generate Docker image tags for base and overlay images."""
+        env_name = _sanitize_tag(env_path.name)
+        base_tag = f"rasb-env-{env_name}"
+        bench_tag = f"rasb-bench-{env_name}-{_sanitize_tag(run_name)}"
+        return base_tag, bench_tag
+
+    def _image_exists(self, tag: str) -> bool:
+        """Check if a Docker image exists."""
+        try:
+            self.docker_client.images.get(tag)
+            return True
+        except docker.errors.ImageNotFound:
+            return False
+
+    def _build_base_image(self, env_path: Path, base_tag: str) -> bool:
+        """Build base image from environment Dockerfile."""
+        if self._image_exists(base_tag) and not self.cfg.rebuild_images:
+            LOG.info(f"Reusing existing base image: {base_tag}")
+            return True
+
+        LOG.info(f"Building base image: {base_tag}")
+        dockerfile_path = env_path / "Dockerfile"
+
+        if not dockerfile_path.exists():
+            raise FileNotFoundError(f"No Dockerfile in {env_path}")
+
+        try:
+            image, logs = self.docker_client.images.build(
+                path=str(env_path),
+                tag=base_tag,
+                rm=True,
+                forcerm=True,
+                timeout=self.cfg.docker_build_timeout,
+            )
+            LOG.info(f"Built base image: {base_tag}")
+            return True
+        except docker.errors.BuildError as e:
+            LOG.error(f"Failed to build base image for {env_path}: {e}")
+            return False
+
+    def _build_overlay_image(
+        self,
+        base_tag: str,
+        bench_tag: str,
+        build_context: Path,
+    ) -> bool:
+        """Build overlay image with evaluation infrastructure."""
+        if self._image_exists(bench_tag) and not self.cfg.rebuild_images:
+            LOG.info(f"Reusing existing overlay image: {bench_tag}")
+            return True
+
+        LOG.info(f"Building overlay image: {bench_tag}")
+
+        # Write overlay Dockerfile
+        dockerfile_content = OVERLAY_DOCKERFILE.format(base_image=base_tag)
+        (build_context / "Dockerfile.bench").write_text(dockerfile_content)
+
+        try:
+            image, logs = self.docker_client.images.build(
+                path=str(build_context),
+                dockerfile="Dockerfile.bench",
+                tag=bench_tag,
+                rm=True,
+                forcerm=True,
+                timeout=self.cfg.docker_build_timeout,
+            )
+            LOG.info(f"Built overlay image: {bench_tag}")
+            return True
+        except docker.errors.BuildError as e:
+            LOG.error(f"Failed to build overlay image: {e}")
+            return False
+
+    def _generate_callable_code(self) -> str:
+        """Generate callable.py that uses lm.py to connect to the configured server."""
+        server_cfg = self.cfg.server
+        inference_cfg = self.cfg.inference
+
+        # Get server configuration
+        base_url = server_cfg.get("base_url", "https://inference-api.nvidia.com")
+        api_key = server_cfg.get("api_key", os.environ.get("NVAPI_KEY", os.environ.get("OPENAI_API_KEY", "")))
+        model = server_cfg.get("model", "gpt-4")
+
+        # Remove /v1 suffix if present (lm.py handles endpoints internally)
+        if base_url.endswith("/v1"):
+            base_url = base_url[:-3]
+
+        # Detect if this is an Anthropic model (via Azure/NVIDIA proxy)
+        is_anthropic = "anthropic" in model.lower() or "claude" in model.lower()
+        lm_class = "AnthropicLM" if is_anthropic else "LM"
+
+        return f'''"""Auto-generated callable for RASB benchmark (Skills integration)."""
+
+import json
+import logging
+import os
+from pathlib import Path
+
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+_log = logging.getLogger("callable.skills")
+
+from lm import {lm_class}
+
+# Load metadata and build tool schemas
+_metadata = json.loads(Path("metadata.json").read_text())
+_tools_meta = _metadata.get("tools", [])
+
+
+def _build_openai_tools() -> list[dict]:
+    """Build OpenAI function-calling format tool definitions."""
+    tools = []
+    _type_map = {{"str": "string", "int": "integer", "float": "number", "bool": "boolean",
+                 "list": "array", "dict": "object", "none": "null"}}
+
+    if _tools_meta and isinstance(_tools_meta[0], dict):
+        for t in _tools_meta:
+            raw_params = t.get("parameters", {{}})
+            if isinstance(raw_params, dict) and "properties" in raw_params:
+                params = raw_params["properties"]
+                schema_required = raw_params.get("required", [])
+            else:
+                params = raw_params
+                schema_required = []
+            properties = {{}}
+            required = list(schema_required)
+            for pname, pspec in params.items():
+                if isinstance(pspec, dict):
+                    raw_type = pspec.get("type", "string")
+                    properties[pname] = {{
+                        "type": _type_map.get(raw_type, raw_type),
+                        "description": pspec.get("description", ""),
+                    }}
+                    if pspec.get("required", False):
+                        required.append(pname)
+                else:
+                    raw_type = str(pspec)
+                    properties[pname] = {{"type": _type_map.get(raw_type, raw_type), "description": ""}}
+            tools.append({{
+                "type": "function",
+                "function": {{
+                    "name": t["name"],
+                    "description": t.get("description", ""),
+                    "parameters": {{
+                        "type": "object",
+                        "properties": properties,
+                        "required": required,
+                    }},
+                }},
+            }})
+        return tools
+
+    # Fallback: try tools.py
+    if _tools_meta:
+        try:
+            from tools import TOOLS
+            for name, spec in TOOLS.items():
+                params = spec.get("parameters", {{}})
+                properties = {{}}
+                required = []
+                for pname, pspec in params.items():
+                    properties[pname] = {{
+                        "type": pspec.get("type", "string"),
+                        "description": pspec.get("description", ""),
+                    }}
+                    if pspec.get("required", False):
+                        required.append(pname)
+                tools.append({{
+                    "type": "function",
+                    "function": {{
+                        "name": name,
+                        "description": spec.get("description", ""),
+                        "parameters": {{
+                            "type": "object",
+                            "properties": properties,
+                            "required": required,
+                        }},
+                    }},
+                }})
+        except Exception as exc:
+            _log.warning("Failed to load tools from tools.py: %s", exc)
+
+    return tools
+
+
+_openai_tools = _build_openai_tools()
+if _openai_tools:
+    _log.info("Loaded %d tool schemas: %s", len(_openai_tools),
+              [t["function"]["name"] for t in _openai_tools])
+
+# Initialize model client
+_model = {lm_class}(
+    model="{model}",
+    api_key="{api_key}",
+    base_url="{base_url}",
+    max_tokens={inference_cfg.tokens_to_generate},
+    temperature={inference_cfg.temperature if inference_cfg.temperature > 0 else None},
+)
+
+_call_count = 0
+
+
+def call(messages: list[dict]) -> list[dict]:
+    """Send messages to the configured LLM server and return the response."""
+    global _call_count
+    _call_count += 1
+    call_id = _call_count
+
+    _log.info("[call #%d] Sending %d messages to {model} (tools=%d)",
+              call_id, len(messages), len(_openai_tools))
+
+    try:
+        if _openai_tools:
+            # Use query_messages_raw which handles both OpenAI and Anthropic APIs
+            response = _model.query_messages_raw(messages, tools=_openai_tools)
+            msg = response.choices[0].message
+            result: dict = {{"role": "assistant", "content": msg.content or ""}}
+            if msg.tool_calls:
+                result["tool_calls"] = [
+                    {{
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {{
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments
+                            if isinstance(tc.function.arguments, str)
+                            else json.dumps(tc.function.arguments),
+                        }},
+                    }}
+                    for tc in msg.tool_calls
+                ]
+                _log.info("[call #%d] Got response with %d tool calls",
+                          call_id, len(msg.tool_calls))
+            else:
+                _log.info("[call #%d] Got text response, %d chars",
+                          call_id, len(msg.content or ""))
+            return [result]
+        else:
+            text = _model.query_messages(messages)
+            _log.info("[call #%d] Got text response, %d chars", call_id, len(text))
+            return [{{"role": "assistant", "content": text}}]
+    except Exception as exc:
+        _log.error("[call #%d] LM query failed: %s", call_id, exc)
+        raise
+'''
+
+    def _generate_env_file(self) -> str:
+        """Generate .env file content for the container."""
+        server_cfg = self.cfg.server
+        model = server_cfg.get("model", "gpt-4")
+        base_url = server_cfg.get("base_url", "https://inference-api.nvidia.com")
+
+        # For Anthropic models via NVIDIA proxy, prefer NVAPI_KEY
+        is_anthropic = "anthropic" in model.lower() or "claude" in model.lower()
+        if is_anthropic:
+            api_key = server_cfg.get("api_key", os.environ.get("NVAPI_KEY", os.environ.get("ANTHROPIC_API_KEY", "")))
+        else:
+            api_key = server_cfg.get("api_key", os.environ.get("OPENAI_API_KEY", ""))
+
+        # Remove /v1 suffix for NVIDIA_BASE_URL (lm.py handles this)
+        nvidia_base_url = base_url
+        if nvidia_base_url.endswith("/v1"):
+            nvidia_base_url = nvidia_base_url[:-3]
+
+        lines = [
+            f"TARGET_MODEL={model}",
+            f"NVIDIA_BASE_URL={nvidia_base_url}",
+        ]
+
+        # Add API key - use NVAPI_KEY for NVIDIA proxy, OPENAI_API_KEY for OpenAI
+        if is_anthropic:
+            lines.append(f"NVAPI_KEY={api_key}")
+        else:
+            lines.append(f"OPENAI_API_KEY={api_key}")
+
+        # Include any additional relevant environment variables
+        for key in ["NVAPI_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "MODEL_ANTHROPIC"]:
+            if key in os.environ and f"{key}=" not in "\n".join(lines):
+                lines.append(f"{key}={os.environ[key]}")
+
+        return "\n".join(lines) + "\n"
+
+    async def _run_environment(
+        self,
+        env_path: Path,
+        env_id: str,
+        results_dir: Path,
+    ) -> dict:
+        """Run evaluation for an entire environment (all samples)."""
+        workdir = _detect_workdir(env_path)
+        base_tag, bench_tag = self._get_image_tags(env_path)
+        container_name = f"rasb-run-{_sanitize_tag(env_id)}"
+
+        # Remove existing container if present
+        try:
+            old_container = self.docker_client.containers.get(container_name)
+            old_container.remove(force=True)
+        except docker.errors.NotFound:
+            pass
+
+        # Create build context for overlay image
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+
+            # Step 1: Build base image
+            if not self._build_base_image(env_path, base_tag):
+                return {
+                    "env_id": env_id,
+                    "status": "base_build_failed",
+                    "error": "Failed to build base image",
+                    "samples": [],
+                }
+
+            # Step 2: Prepare overlay build context
+            # Copy evaluation infrastructure
+            shutil.copy2(CONTAINER_FILES_DIR / "evaluate.py", tmp / "evaluate.py")
+            shutil.copy2(CONTAINER_FILES_DIR / "judge.py", tmp / "judge.py")
+            shutil.copy2(CONTAINER_FILES_DIR / "lm.py", tmp / "lm.py")
+
+            # Write .env file
+            (tmp / ".env").write_text(self._generate_env_file())
+
+            # Create callable package
+            callable_pkg = tmp / "callable_pkg"
+            callable_pkg.mkdir()
+            (callable_pkg / "callable.py").write_text(self._generate_callable_code())
+            (callable_pkg / "requirements.txt").write_text("openai>=1.0.0\nhttpx\npython-dotenv\nanthropic\n")
+
+            # Step 3: Build overlay image
+            if not self._build_overlay_image(base_tag, bench_tag, tmp):
+                return {
+                    "env_id": env_id,
+                    "status": "bench_build_failed",
+                    "error": "Failed to build overlay image",
+                    "samples": [],
+                }
+
+            # Step 4: Run container
+            LOG.info(f"Running evaluation for {env_id} (timeout={self.cfg.docker_timeout}s)")
+
+            # Mount inputs directory (for any new samples) and results directory
+            results_dir.mkdir(parents=True, exist_ok=True)
+            volumes = {
+                str((env_path / "inputs").resolve()): {"bind": f"{workdir}/inputs", "mode": "ro"},
+                str(results_dir.resolve()): {"bind": f"{workdir}/results", "mode": "rw"},
+            }
+
+            container = None
+            try:
+                container = self.docker_client.containers.run(
+                    bench_tag,
+                    name=container_name,
+                    working_dir=workdir,
+                    volumes=volumes,
+                    mem_limit=self.cfg.docker_memory_limit,
+                    network_mode=self.cfg.docker_network_mode,
+                    detach=True,
+                )
+
+                # Wait for completion
+                result = container.wait(timeout=self.cfg.docker_timeout)
+                exit_code = result["StatusCode"]
+                container_output = container.logs().decode("utf-8")
+
+                if exit_code != 0:
+                    LOG.warning(f"[{env_id}] Container exited with code {exit_code}")
+
+                # Save container output
+                (results_dir / "container_stdout.log").write_text(container_output)
+
+            except Exception as e:
+                LOG.error(f"[{env_id}] Container execution failed: {e}")
+                return {
+                    "env_id": env_id,
+                    "status": "container_error",
+                    "error": str(e),
+                    "samples": [],
+                }
+            finally:
+                if container and not self.cfg.keep_containers:
+                    try:
+                        container.remove(force=True)
+                    except Exception:
+                        pass
+
+            # Step 5: Collect results
+            results_file = results_dir / "results.json"
+            if results_file.exists():
+                env_results = json.loads(results_file.read_text())
+                env_results["status"] = "completed"
+                return env_results
+            else:
+                return {
+                    "env_id": env_id,
+                    "status": "no_results",
+                    "error": "No results.json generated",
+                    "container_output": container_output[-2000:] if 'container_output' in locals() else "",
+                    "samples": [],
+                }
+
+    async def process_environment(self, env_path_str: str, samples: list[dict]) -> list[dict]:
+        """Process all samples for a single environment."""
+        env_path = self.data_dir / env_path_str
+        env_id = env_path.name
+
+        async with self.semaphore:
+            # Create results directory for this environment
+            output_dir = Path(self.cfg.output_file).parent
+            results_dir = output_dir / "environments" / env_id
+
+            # Run the environment
+            env_results = await self._run_environment(env_path, env_id, results_dir)
+
+            # Map results back to individual samples
+            sample_results_map = {}
+            for sample in env_results.get("samples", []):
+                sample_results_map[sample["input_file"]] = sample
+
+            # Build output for each sample in the input
+            outputs = []
+            for sample in samples:
+                input_file = sample["input_file"]
+                if input_file in sample_results_map:
+                    result = sample_results_map[input_file]
+                    outputs.append({
+                        **sample,
+                        self.cfg.generation_key: result.get("model_output", ""),
+                        "is_correct": result.get("passed", False),
+                        "rasb_result": result,
+                    })
+                else:
+                    # Sample not in results (maybe filtered or error)
+                    outputs.append({
+                        **sample,
+                        self.cfg.generation_key: "",
+                        "is_correct": False,
+                        "rasb_result": {
+                            "error": f"Sample not found in results (env status: {env_results.get('status')})",
+                        },
+                    })
+
+            return outputs
+
+    def generate(self):
+        """Run the RASB generation task."""
+        LOG.info("Starting RASB generation...")
+
+        # Load input data
+        input_file = Path(self.cfg.input_file)
+        if not input_file.exists():
+            raise FileNotFoundError(f"Input file not found: {input_file}")
+
+        with open(input_file, "r") as f:
+            data = [json.loads(line) for line in f]
+
+        LOG.info(f"Loaded {len(data)} samples")
+
+        # Apply chunking if specified
+        if self.cfg.num_chunks is not None and self.cfg.chunk_id is not None:
+            chunk_size = len(data) // self.cfg.num_chunks
+            start = self.cfg.chunk_id * chunk_size
+            end = start + chunk_size if self.cfg.chunk_id < self.cfg.num_chunks - 1 else len(data)
+            data = data[start:end]
+            LOG.info(f"Processing chunk {self.cfg.chunk_id}: samples {start} to {end}")
+
+        # Apply max_samples limit
+        if self.cfg.max_samples > 0:
+            data = data[: self.cfg.max_samples]
+            LOG.info(f"Limited to {len(data)} samples")
+
+        # Group samples by environment
+        samples_by_env: dict[str, list[dict]] = defaultdict(list)
+        for sample in data:
+            samples_by_env[sample["environment_path"]].append(sample)
+
+        LOG.info(f"Grouped into {len(samples_by_env)} environments")
+
+        # Log example
+        self.log_example_prompt(data)
+
+        if self.cfg.dry_run:
+            LOG.info("Dry run - skipping generation")
+            return
+
+        # Load existing results if skip_filled
+        existing_results = {}
+        output_file = Path(self.cfg.output_file)
+        completed_envs = set()
+        if self.cfg.skip_filled and output_file.exists():
+            with open(output_file, "r") as f:
+                for line in f:
+                    entry = json.loads(line)
+                    key = (entry["environment_path"], entry["input_file"])
+                    existing_results[key] = entry
+                    completed_envs.add(entry["environment_path"])
+            LOG.info(f"Loaded {len(existing_results)} existing results from {len(completed_envs)} environments")
+
+        # Filter out completed environments
+        envs_to_process = {
+            env_path: samples
+            for env_path, samples in samples_by_env.items()
+            if env_path not in completed_envs
+        }
+
+        LOG.info(f"Processing {len(envs_to_process)} environments")
+
+        # Process environments
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+
+        async def process_all():
+            tasks = []
+            for env_path, samples in envs_to_process.items():
+                tasks.append(self.process_environment(env_path, samples))
+
+            all_results = []
+            for coro in asyncio.as_completed(tasks):
+                results = await coro
+                all_results.extend(results)
+
+                # Write results immediately
+                with open(output_file, "a") as f:
+                    for result in results:
+                        f.write(json.dumps(result) + "\n")
+
+            return all_results
+
+        results = asyncio.run(process_all())
+
+        # Write any existing results that were skipped
+        if existing_results:
+            with open(output_file, "a") as f:
+                for result in existing_results.values():
+                    f.write(json.dumps(result) + "\n")
+
+        total_samples = len(results) + len(existing_results)
+        correct = sum(1 for r in results if r.get("is_correct", False))
+        correct += sum(1 for r in existing_results.values() if r.get("is_correct", False))
+
+        LOG.info(f"Generation complete. {correct}/{total_samples} correct ({100*correct/total_samples:.1f}%)")
+        LOG.info(f"Results written to {output_file}")
+
+
+GENERATION_TASK_CLASS = RasbGenerationTask
+
+
+@hydra.main(version_base=None, config_name="base_rasb_generation_config")
+def generate(cfg: RasbGenerationConfig):
+    cfg = RasbGenerationConfig(_init_nested=True, **cfg)
+    LOG.info("Config used: %s", cfg)
+    task = RasbGenerationTask(cfg)
+    task.generate()
+
+
+if __name__ == "__main__":
+    setup_logging()
+    generate()

--- a/nemo_skills/inference/eval/rasb_container/__init__.py
+++ b/nemo_skills/inference/eval/rasb_container/__init__.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+RASB container files.
+
+This package contains the evaluation infrastructure that gets injected into
+RASB Docker containers:
+- evaluate.py: Main evaluation orchestrator (runs synth_*.json samples)
+- judge.py: Requirements-based LLM committee judging
+- lm.py: Model wrapper classes for API calls
+
+These files are copied from the original RASB benchmark to ensure
+reproducibility of evaluation results.
+"""
+
+from pathlib import Path
+
+CONTAINER_FILES_DIR = Path(__file__).parent

--- a/nemo_skills/inference/eval/rasb_container/evaluate.py
+++ b/nemo_skills/inference/eval/rasb_container/evaluate.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+"""In-container evaluation script for RASB benchmarking.
+
+Runs inside a Docker container at /benchmark/. Iterates over synthetic
+samples, invokes the callable, evaluates outputs against expected results
+(exact match or LLM judge committee), and writes structured results.
+"""
+
+import json
+import logging
+import os
+import re
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+# Ensure the working directory is on sys.path so judge.py can find lm.py
+sys.path.insert(0, os.getcwd())
+
+Path("results").mkdir(exist_ok=True)
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler("results/evaluate.log", mode="w"),
+    ],
+)
+log = logging.getLogger("evaluate")
+
+from dotenv import load_dotenv
+
+load_dotenv(".env")
+
+log.info("Working directory: %s", os.getcwd())
+log.info("Python: %s", sys.version)
+log.info("TARGET_MODEL: %s", os.environ.get("TARGET_MODEL", "(not set)"))
+log.info("MODEL_ANTHROPIC: %s", os.environ.get("MODEL_ANTHROPIC", "(not set)"))
+
+from callable import call
+from tools import TOOLS, execute_tool
+from judge import judge_requirements
+
+# Try to import apply_inputs from harness for assembled_user_message support
+_harness_apply_inputs = None
+try:
+    from harness import apply_inputs as _harness_apply_inputs
+    log.info("Imported apply_inputs from harness.py")
+except (ImportError, AttributeError):
+    pass
+
+log.info("Imports OK. TOOLS defined: %d", len(TOOLS))
+if TOOLS:
+    for tname, tspec in TOOLS.items():
+        params = list(tspec.get("parameters", {}).keys())
+        has_func = callable(tspec.get("function"))
+        log.info("  Tool '%s': params=%s, function=%s", tname, params,
+                 "OK" if has_func else "MISSING")
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrored from harness.py to avoid import issues across envs)
+# ---------------------------------------------------------------------------
+
+def apply_placeholders(template: str, fields: dict) -> str:
+    result = template
+    for key, value in fields.items():
+        placeholder = "{" + key + "}"
+        if placeholder in result:
+            result = result.replace(placeholder, str(value))
+    return result
+
+
+def _build_prompts(input_mode, system_template, user_template, fields):
+    """Build system/user prompts from fields using input_mode routing."""
+    # Try harness.apply_inputs first (handles assembled_user_message and custom logic)
+    if _harness_apply_inputs is not None:
+        try:
+            result = _harness_apply_inputs(system_template, user_template, fields, input_mode)
+            if isinstance(result, tuple) and len(result) == 2:
+                sys_out, usr_out = result
+                # Only accept plain text prompts; reject multimodal content blocks
+                if isinstance(sys_out, str) and isinstance(usr_out, str):
+                    return result
+                log.warning("Harness returned non-string prompt content (multimodal?), falling through to built-in")
+        except Exception:
+            pass  # Fall through to built-in handling
+
+    if input_mode == "placeholder_system":
+        return apply_placeholders(system_template, fields), user_template
+    elif input_mode == "placeholder_user":
+        return system_template, apply_placeholders(user_template, fields)
+    elif input_mode == "placeholder_both":
+        return apply_placeholders(system_template, fields), apply_placeholders(user_template, fields)
+    elif input_mode == "direct_user_message":
+        return system_template, str(list(fields.values())[0]) if fields else ""
+    else:
+        return apply_placeholders(system_template, fields), apply_placeholders(user_template, fields)
+
+
+def _extract_full_response(messages):
+    """Extract complete response including tool call activity.
+
+    For non-tool envs: returns last assistant text (existing behavior).
+    For tool envs: concatenates assistant text + tool call summaries + tool results.
+    """
+    has_tool_calls = any(m.get("tool_calls") for m in messages if m.get("role") == "assistant")
+
+    if not has_tool_calls:
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant":
+                return msg.get("content", "")
+        return ""
+
+    parts = []
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant":
+            content = msg.get("content", "")
+            if content:
+                parts.append(content)
+            for tc in msg.get("tool_calls", []):
+                fn = tc.get("function", tc)
+                name = fn.get("name", "") if isinstance(fn, dict) else tc.get("name", "")
+                parts.append(f"[Called tool: {name}]")
+        elif role == "tool":
+            content = msg.get("content", "")
+            name = msg.get("name", "tool")
+            parts.append(f"[{name} result]: {content}")
+    return "\n".join(parts)
+
+
+def parse_json_output(text: str):
+    """Extract JSON from response text."""
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    # Code blocks
+    for match in re.findall(r"```(?:json)?\s*([\s\S]*?)```", text):
+        try:
+            return json.loads(match.strip())
+        except json.JSONDecodeError:
+            continue
+    # Bare JSON object
+    for match in re.findall(r"\{[\s\S]*\}", text):
+        try:
+            return json.loads(match)
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def parse_regex_extraction(text: str, pattern):
+    """Extract output using a regex pattern from parsing_details."""
+    if isinstance(pattern, dict):
+        # Multi-pattern extraction: {name: regex_pattern, ...}
+        # Only process keys that look like patterns (end with _pattern) or are strings
+        results = {}
+        for name, pat in pattern.items():
+            # Skip non-pattern keys (e.g., intensity_type, intensity_range)
+            if not isinstance(pat, str):
+                continue
+            try:
+                matches = re.findall(pat, text)
+                results[name] = matches[0] if len(matches) == 1 else matches if matches else None
+            except re.error:
+                # Invalid regex pattern, skip it
+                results[name] = None
+        return results
+    if not isinstance(pattern, str):
+        return None
+    matches = re.findall(pattern, text)
+    if matches:
+        return matches[0] if len(matches) == 1 else matches
+    return None
+
+
+def extract_tool_call_result(messages: list[dict], parsing_details: str):
+    """Extract output from tool call arguments.
+
+    Looks for the last tool call matching the description in parsing_details
+    and returns its arguments (or a specific field).
+    """
+    for msg in reversed(messages):
+        if msg.get("role") != "assistant":
+            continue
+        for tc in msg.get("tool_calls", []):
+            fn = tc.get("function", tc)
+            args = fn.get("arguments", {})
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except (json.JSONDecodeError, TypeError):
+                    args = {}
+            if args:
+                return args
+    return None
+
+
+def _get_written_files() -> dict[str, str]:
+    """Collect files written by tools during the session.
+
+    Checks for get_virtual_filesystem() in tools.py first (in-memory writes),
+    then falls back to scanning the results directory for any written artifacts.
+    """
+    try:
+        from tools import get_virtual_filesystem
+        return get_virtual_filesystem()
+    except (ImportError, AttributeError):
+        pass
+    return {}
+
+
+def process_tool_calls(messages: list[dict], max_iterations: int = 10) -> list[dict]:
+    if not TOOLS:
+        return messages
+    iterations = 0
+    while iterations < max_iterations:
+        last = messages[-1] if messages else None
+        if not last or not last.get("tool_calls"):
+            break
+        for tc in last["tool_calls"]:
+            # Support both OpenAI format {"function": {"name": ..., "arguments": ...}}
+            # and flat format {"name": ..., "arguments": ...}
+            if "function" in tc:
+                name = tc["function"]["name"]
+                args_raw = tc["function"].get("arguments", "{}")
+                args = json.loads(args_raw) if isinstance(args_raw, str) else args_raw
+            else:
+                name = tc["name"]
+                args = tc.get("arguments", {})
+            try:
+                result = execute_tool(name, args)
+                messages.append({"role": "tool", "name": name, "content": str(result),
+                                 "tool_call_id": tc.get("id", "")})
+            except Exception as e:
+                messages.append({"role": "tool", "name": name, "content": f"Error: {e}",
+                                 "tool_call_id": tc.get("id", "")})
+        try:
+            messages.extend(call(messages))
+        except Exception as e:
+            messages.append({"role": "assistant", "content": f"Error: {e}"})
+            break
+        iterations += 1
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Evaluation logic
+# ---------------------------------------------------------------------------
+
+def _normalize_for_exact(value) -> str:
+    """Normalize a value for exact comparison."""
+    if isinstance(value, str):
+        # Try parsing as JSON for canonical form
+        try:
+            parsed = json.loads(value)
+            return json.dumps(parsed, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+        except (json.JSONDecodeError, TypeError):
+            return value.strip()
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return str(value).strip()
+
+
+def evaluate_exact(model_output: str, parsed_output, expected_value) -> dict:
+    """Evaluate an exact-match judgment."""
+    # Try matching against parsed output first (for json_parse environments)
+    if parsed_output is not None:
+        norm_parsed = _normalize_for_exact(parsed_output)
+        norm_expected = _normalize_for_exact(expected_value)
+        if norm_parsed == norm_expected:
+            return {"passed": True, "comparison": "parsed_output_match"}
+
+    # Fall back to raw output comparison
+    norm_raw = _normalize_for_exact(model_output)
+    norm_expected = _normalize_for_exact(expected_value)
+    passed = norm_raw == norm_expected
+    return {"passed": passed, "comparison": "raw_output_match" if passed else "no_match",
+            "expected_normalized": norm_expected, "actual_normalized": norm_raw}
+
+
+def evaluate_requirements(
+    system_prompt: str, user_prompt: str,
+    model_output: str, requirements: list[str],
+) -> dict:
+    """Evaluate a requirements-based judgment using LLM judge committee."""
+    result = judge_requirements(system_prompt, user_prompt, model_output, requirements)
+    return {"passed": result["overall_pass"], **result}
+
+
+# ---------------------------------------------------------------------------
+# Incremental results writing
+# ---------------------------------------------------------------------------
+
+def _write_incremental_results(env_id: str, sample_results: list[dict]) -> None:
+    """Write current results to disk so timeout preserves progress."""
+    total = len(sample_results)
+    passed = sum(1 for s in sample_results if s["passed"])
+    errors = sum(1 for s in sample_results if s.get("error"))
+    failed = total - passed
+
+    results = {
+        "env_id": env_id,
+        "pass_rate": passed / total if total else 0,
+        "passed": passed,
+        "failed": failed,
+        "errors": errors,
+        "total": total,
+        "samples": sample_results,
+    }
+
+    Path("results").mkdir(exist_ok=True)
+    Path("results/results.json").write_text(
+        json.dumps(results, indent=2, ensure_ascii=False) + "\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main evaluation loop
+# ---------------------------------------------------------------------------
+
+def run_evaluation():
+    """Run evaluation on all synthetic samples."""
+    # Load config
+    metadata = json.loads(Path("metadata.json").read_text())
+    env_id = metadata.get("id", "unknown")
+    input_mode = metadata.get("input_mode", "placeholder_system")
+    max_turns = metadata.get("max_turns", 1)
+    output_schema = metadata.get("output_schema", {})
+    parsing_method = output_schema.get("parsing", "face_value")
+
+    # Load prompts
+    system_template = Path("prompt_system.txt").read_text()
+    user_template = Path("prompt_user.txt").read_text() if Path("prompt_user.txt").exists() else ""
+
+    # Collect synthetic input files (only those with expected_output)
+    inputs_dir = Path("inputs")
+    synth_files = sorted(inputs_dir.glob("synth_*.json"))
+    if not synth_files:
+        print("No synthetic sample files found.")
+        results = {"env_id": env_id, "pass_rate": 0, "passed": 0, "failed": 0,
+                   "errors": 0, "total": 0, "samples": []}
+        Path("results").mkdir(exist_ok=True)
+        Path("results/results.json").write_text(json.dumps(results, indent=2))
+        return
+
+    # Load existing results for resumption (skip already-evaluated, error-free samples)
+    existing_results: dict[str, dict] = {}
+    results_file = Path("results/results.json")
+    if results_file.exists():
+        try:
+            cached = json.loads(results_file.read_text())
+            for sample in cached.get("samples", []):
+                fname = sample.get("input_file")
+                if fname and not sample.get("error"):
+                    existing_results[fname] = sample
+            if existing_results:
+                log.info("Resuming: found %d existing error-free results", len(existing_results))
+        except (json.JSONDecodeError, OSError) as e:
+            log.warning("Could not load existing results for resumption: %s", e)
+
+    sample_results = []
+
+    for sf in synth_files:
+        # Skip if already evaluated without error
+        if sf.name in existing_results:
+            log.info("--- Skipping: %s (already evaluated) ---", sf.name)
+            sample_results.append(existing_results[sf.name])
+            continue
+
+        log.info("--- Evaluating: %s ---", sf.name)
+        start = time.time()
+        sample_data = json.loads(sf.read_text())
+        fields = sample_data.get("fields", {})
+        expected = sample_data.get("expected_output")
+        log.debug("Fields: %s", json.dumps(fields, ensure_ascii=False)[:500])
+        log.debug("Expected judgment: %s", expected.get("judgment") if expected else "none")
+
+        if not expected:
+            print(f"  Skipping {sf.name} (no expected_output)")
+            continue
+
+        try:
+            sys_prompt, usr_prompt = _build_prompts(input_mode, system_template, user_template, fields)
+
+            messages = [
+                {"role": "system", "content": sys_prompt},
+                {"role": "user", "content": usr_prompt},
+            ]
+
+            # Invoke callable
+            response_msgs = call(messages)
+            messages.extend(response_msgs)
+            messages = process_tool_calls(messages, max_iterations=max_turns * 2)
+
+            final_response = _extract_full_response(messages)
+
+            # Append written file contents so the judge can see them
+            written_files = _get_written_files()
+            if written_files:
+                file_section = "\n\n--- Written Files ---\n"
+                for fpath, fcontent in written_files.items():
+                    file_section += f"\n=== {fpath} ===\n{fcontent}\n"
+                final_response += file_section
+
+            # Parse output
+            parsed_output = None
+            if parsing_method == "json_parse":
+                parsed_output = parse_json_output(final_response)
+            elif parsing_method == "regex_extraction":
+                pattern = output_schema.get("parsing_details", "")
+                parsed_output = parse_regex_extraction(final_response, pattern)
+            elif parsing_method == "tool_call_result":
+                parsed_output = extract_tool_call_result(messages, output_schema.get("parsing_details", ""))
+                if parsed_output is not None:
+                    final_response += f"\n\n[Tool call result]: {json.dumps(parsed_output, ensure_ascii=False)}"
+            else:
+                parsed_output = final_response
+
+            # Evaluate
+            judgment_type = expected.get("judgment")
+            if judgment_type == "exact":
+                judgment = evaluate_exact(final_response, parsed_output, expected["value"])
+            elif judgment_type == "requirements":
+                judgment = evaluate_requirements(
+                    sys_prompt, usr_prompt, final_response, expected["requirements"],
+                )
+            else:
+                judgment = {"passed": False, "error": f"Unknown judgment type: {judgment_type}"}
+
+            duration_ms = int((time.time() - start) * 1000)
+            sample_results.append({
+                "input_file": sf.name,
+                "passed": judgment["passed"],
+                "judgment_type": judgment_type,
+                "judgment_details": judgment,
+                "model_output": final_response,
+                "parsed_output": parsed_output if isinstance(parsed_output, (dict, list, str, type(None))) else str(parsed_output),
+                "messages": messages,
+                "error": None,
+                "duration_ms": duration_ms,
+            })
+            status = "PASS" if judgment["passed"] else "FAIL"
+            log.info("%s -> %s (%dms)", sf.name, status, duration_ms)
+            if not judgment["passed"] and judgment_type == "requirements":
+                failed_reqs = [r for r in judgment.get("requirements", []) if not r.get("pass")]
+                for fr in failed_reqs:
+                    log.debug("  FAILED req: %s", fr.get("text", "")[:100])
+
+        except Exception as exc:
+            duration_ms = int((time.time() - start) * 1000)
+            sample_results.append({
+                "input_file": sf.name,
+                "passed": False,
+                "judgment_type": expected.get("judgment", "unknown"),
+                "judgment_details": {},
+                "model_output": None,
+                "parsed_output": None,
+                "messages": messages if 'messages' in locals() else [],
+                "error": str(exc),
+                "duration_ms": duration_ms,
+            })
+            log.error("%s -> ERROR: %s (%dms)", sf.name, exc, duration_ms)
+
+        # Write incremental results after each sample (so timeout preserves progress)
+        _write_incremental_results(env_id, sample_results)
+
+    # Compute stats
+    total = len(sample_results)
+    passed = sum(1 for s in sample_results if s["passed"])
+    errors = sum(1 for s in sample_results if s["error"])
+    failed = total - passed
+
+    results = {
+        "env_id": env_id,
+        "pass_rate": passed / total if total else 0,
+        "passed": passed,
+        "failed": failed,
+        "errors": errors,
+        "total": total,
+        "samples": sample_results,
+    }
+
+    Path("results").mkdir(exist_ok=True)
+    Path("results/results.json").write_text(
+        json.dumps(results, indent=2, ensure_ascii=False) + "\n"
+    )
+
+    print(f"\n{'='*50}")
+    print(f"EVALUATION: {env_id}")
+    print(f"{'='*50}")
+    print(f"Total: {total}  Passed: {passed}  Failed: {failed}  Errors: {errors}")
+    print(f"Pass rate: {results['pass_rate']:.1%}")
+    print(f"{'='*50}")
+
+
+def _check_one_sample(sf, input_mode, system_template, user_template,
+                      max_attempts, max_turns, parsing_method, output_schema=None):
+    """Check solvability of a single sample. Returns a result dict."""
+    log.info("--- Solvability: %s (up to %d attempts) ---", sf.name, max_attempts)
+    output_schema = output_schema or {}
+    sample_data = json.loads(sf.read_text())
+    fields = sample_data.get("fields", {})
+    expected = sample_data["expected_output"]
+
+    sys_prompt, usr_prompt = _build_prompts(input_mode, system_template, user_template, fields)
+
+    solved = False
+    solution = None
+    last_judgment = None
+    last_attempt = 0
+
+    for attempt in range(1, max_attempts + 1):
+        last_attempt = attempt
+        start = time.time()
+        try:
+            messages = [
+                {"role": "system", "content": sys_prompt},
+                {"role": "user", "content": usr_prompt},
+            ]
+
+            response_msgs = call(messages)
+            messages.extend(response_msgs)
+            messages = process_tool_calls(messages, max_iterations=max_turns * 2)
+
+            final_response = _extract_full_response(messages)
+
+            # Append written file contents so the judge can see them
+            written_files = _get_written_files()
+            if written_files:
+                file_section = "\n\n--- Written Files ---\n"
+                for fpath, fcontent in written_files.items():
+                    file_section += f"\n=== {fpath} ===\n{fcontent}\n"
+                final_response += file_section
+
+            parsed_output = None
+            if parsing_method == "json_parse":
+                parsed_output = parse_json_output(final_response)
+            elif parsing_method == "regex_extraction":
+                pattern = output_schema.get("parsing_details", "")
+                parsed_output = parse_regex_extraction(final_response, pattern)
+            elif parsing_method == "tool_call_result":
+                parsed_output = extract_tool_call_result(messages, output_schema.get("parsing_details", ""))
+                if parsed_output is not None:
+                    final_response += f"\n\n[Tool call result]: {json.dumps(parsed_output, ensure_ascii=False)}"
+            else:
+                parsed_output = final_response
+
+            judgment_type = expected.get("judgment")
+            if judgment_type == "exact":
+                judgment = evaluate_exact(final_response, parsed_output, expected["value"])
+            elif judgment_type == "requirements":
+                judgment = evaluate_requirements(
+                    sys_prompt, usr_prompt, final_response, expected["requirements"],
+                )
+            else:
+                judgment = {"passed": False, "error": f"Unknown judgment: {judgment_type}"}
+
+            last_judgment = judgment
+            duration_ms = int((time.time() - start) * 1000)
+
+            if judgment["passed"]:
+                log.info("%s attempt %d -> PASS (%dms)", sf.name, attempt, duration_ms)
+                solved = True
+                solution = {
+                    "model_output": final_response,
+                    "parsed_output": parsed_output if isinstance(parsed_output, (dict, list, str, type(None))) else str(parsed_output),
+                    "attempt_number": attempt,
+                    "total_attempts": attempt,
+                }
+                break
+            else:
+                log.info("%s attempt %d -> FAIL (%dms)", sf.name, attempt, duration_ms)
+
+        except Exception as exc:
+            log.error("%s attempt %d -> ERROR: %s", sf.name, attempt, exc)
+            last_judgment = {"passed": False, "error": str(exc)}
+
+    result = {
+        "input_file": sf.name,
+        "solvable": solved,
+        "total_attempts": last_attempt if not solved else solution["attempt_number"],
+    }
+    if solved:
+        result["solution"] = solution
+    else:
+        result["last_judgment"] = last_judgment
+    return result
+
+
+def run_solvability():
+    """Run solvability checking: retry each sample up to K times, record first success."""
+    max_attempts = int(os.environ.get("RASB_MAX_ATTEMPTS", "5"))
+    sample_filter = os.environ.get("RASB_SAMPLES", "all")
+    workers = int(os.environ.get("RASB_SOLVABILITY_WORKERS", "4"))
+
+    # Load config
+    metadata = json.loads(Path("metadata.json").read_text())
+    env_id = metadata.get("id", "unknown")
+    input_mode = metadata.get("input_mode", "placeholder_system")
+    max_turns = metadata.get("max_turns", 1)
+    output_schema = metadata.get("output_schema", {})
+    parsing_method = output_schema.get("parsing", "face_value")
+
+    system_template = Path("prompt_system.txt").read_text()
+    user_template = Path("prompt_user.txt").read_text() if Path("prompt_user.txt").exists() else ""
+
+    # Collect target samples
+    inputs_dir = Path("inputs")
+    if sample_filter == "all":
+        target_files = sorted(inputs_dir.glob("*.json"))
+    else:
+        names = [n.strip() for n in sample_filter.split(",") if n.strip()]
+        target_files = [inputs_dir / n for n in names if (inputs_dir / n).exists()]
+
+    target_files = [f for f in target_files
+                    if json.loads(f.read_text()).get("expected_output")]
+
+    log.info("Solvability check: %d samples, max_attempts=%d, workers=%d",
+             len(target_files), max_attempts, workers)
+
+    sample_results = []
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(
+                _check_one_sample, sf, input_mode, system_template,
+                user_template, max_attempts, max_turns, parsing_method, output_schema,
+            ): sf
+            for sf in target_files
+        }
+        for future in as_completed(futures):
+            sf = futures[future]
+            try:
+                result = future.result()
+                sample_results.append(result)
+                status = "SOLVABLE" if result["solvable"] else "unsolvable"
+                log.info("%s -> %s (%d attempts)", sf.name, status, result["total_attempts"])
+            except Exception as exc:
+                log.error("%s -> EXCEPTION: %s", sf.name, exc)
+                sample_results.append({
+                    "input_file": sf.name, "solvable": False,
+                    "total_attempts": max_attempts,
+                    "last_judgment": {"passed": False, "error": str(exc)},
+                })
+
+    Path("results").mkdir(exist_ok=True)
+    Path("results/solvability.json").write_text(
+        json.dumps({"env_id": env_id, "samples": sample_results},
+                   indent=2, ensure_ascii=False) + "\n"
+    )
+
+    solvable_count = sum(1 for s in sample_results if s["solvable"])
+    log.info("Solvability: %d/%d samples solvable", solvable_count, len(sample_results))
+
+
+if __name__ == "__main__":
+    mode = os.environ.get("RASB_MODE", "benchmark")
+    if mode == "solvability":
+        run_solvability()
+    else:
+        run_evaluation()

--- a/nemo_skills/inference/eval/rasb_container/judge.py
+++ b/nemo_skills/inference/eval/rasb_container/judge.py
@@ -1,0 +1,216 @@
+"""LLM judge for evaluating requirements-based expected outputs.
+
+Uses AnthropicLM from lm.py with Claude Opus 4.5 as a committee of judges
+to determine whether model outputs satisfy a list of requirements.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+# lm.py lives in the same directory
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lm import AnthropicLM, LMQueryError
+
+log = logging.getLogger("pap.judge")
+
+# Default judge model - should be a reliable, high-quality model
+DEFAULT_JUDGE_MODEL = "azure/anthropic/claude-opus-4-5"
+
+
+def resolve_judge_model() -> str:
+    """Resolve the model to use for judging.
+
+    Uses JUDGE_MODEL env var if set, otherwise defaults to Claude Opus 4.5.
+    This is intentionally separate from TARGET_MODEL (the model being tested)
+    to ensure judging works reliably regardless of which model is being benchmarked.
+    """
+    model = os.environ.get("JUDGE_MODEL", DEFAULT_JUDGE_MODEL)
+    if model.startswith("nvidia_nim/"):
+        model = model[len("nvidia_nim/"):]
+    return model
+
+JUDGE_SYSTEM_PROMPT = """\
+You are an expert judge evaluating whether an AI model's output satisfies a set of requirements.
+
+You will be given:
+1. The prompt that was given to the model (system + user messages)
+2. The model's actual output
+3. A list of requirements that the output should satisfy
+
+For each requirement, determine whether the output satisfies it. Be strict but fair:
+- A requirement is satisfied only if the output clearly and unambiguously meets it
+- Partial satisfaction counts as not satisfied
+- Interpret requirements literally unless context makes the intent obvious
+
+Respond with a JSON object (no markdown fences, just raw JSON):
+{
+  "evaluations": [
+    {"requirement": "<the requirement text>", "satisfied": true/false, "reasoning": "<brief explanation>"},
+    ...
+  ]
+}
+"""
+
+
+def _build_judge_prompt(
+    prompt_system: str,
+    prompt_user: str,
+    model_output: str,
+    requirements: list[str],
+) -> str:
+    """Build the user message for a single judge invocation."""
+    reqs_formatted = "\n".join(f"  {i+1}. {r}" for i, r in enumerate(requirements))
+    return f"""\
+## Prompt Given to Model
+
+**System:**
+{prompt_system}
+
+**User:**
+{prompt_user}
+
+## Model Output
+{model_output}
+
+## Requirements to Evaluate
+{reqs_formatted}
+
+Evaluate each requirement and respond with the JSON object."""
+
+
+def _parse_judge_response(response_text: str, requirements: list[str]) -> list[dict]:
+    """Parse a judge's JSON response into a list of evaluations."""
+    # Try to extract JSON from the response
+    text = response_text.strip()
+    # Handle markdown fences
+    if "```" in text:
+        match = re.search(r'```(?:json)?\s*\n?(.*?)```', text, re.DOTALL)
+        if match:
+            text = match.group(1).strip()
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        log.warning("Failed to parse judge response as JSON")
+        # Return all requirements as unsatisfied
+        return [{"requirement": r, "satisfied": False, "reasoning": "Judge response unparseable"} for r in requirements]
+
+    # Handle both {"evaluations": [...]} and raw list [...] formats
+    if isinstance(data, list):
+        evals = data
+    else:
+        evals = data.get("evaluations", [])
+    if len(evals) != len(requirements):
+        log.warning("Judge returned %d evaluations but %d requirements given", len(evals), len(requirements))
+
+    return evals
+
+
+def _run_single_judge(
+    judge: AnthropicLM,
+    prompt_system: str,
+    prompt_user: str,
+    model_output: str,
+    requirements: list[str],
+) -> list[dict]:
+    """Run a single judge instance and return its evaluations."""
+    user_msg = _build_judge_prompt(prompt_system, prompt_user, model_output, requirements)
+    try:
+        response = judge.query_messages([
+            {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
+            {"role": "user", "content": user_msg},
+        ], max_tokens=4096)
+        return _parse_judge_response(response, requirements)
+    except LMQueryError as exc:
+        log.error("Judge query failed: %s", exc)
+        return [{"requirement": r, "satisfied": False, "reasoning": f"Judge error: {exc}"} for r in requirements]
+
+
+def judge_requirements(
+    prompt_system: str,
+    prompt_user: str,
+    model_output: str,
+    requirements: list[str],
+    committee_size: int = 3,
+) -> dict:
+    """Judge whether model_output satisfies requirements using an LLM committee.
+
+    Args:
+        prompt_system: The system prompt that was given to the model.
+        prompt_user: The user message that was given to the model.
+        model_output: The model's actual output text.
+        requirements: List of requirement strings to evaluate.
+        committee_size: Number of parallel judge instances (default 3).
+
+    Returns:
+        {
+            "requirements": [
+                {
+                    "text": "the requirement",
+                    "pass": True/False,  # majority vote
+                    "votes": [True, False, True],  # individual judge votes
+                    "reasoning": ["...", "...", "..."],  # judge reasoning
+                },
+                ...
+            ],
+            "overall_pass": True/False,  # all requirements pass
+            "pass_count": int,  # number of requirements that passed
+            "total_count": int,  # total requirements
+        }
+    """
+    if not requirements:
+        return {"requirements": [], "overall_pass": True, "pass_count": 0, "total_count": 0}
+
+    judge = AnthropicLM(model=resolve_judge_model(), max_tokens=4096)
+
+    # Run committee in parallel
+    all_evals: list[list[dict]] = []
+    with ThreadPoolExecutor(max_workers=committee_size) as pool:
+        futures = [
+            pool.submit(
+                _run_single_judge, judge,
+                prompt_system, prompt_user, model_output, requirements,
+            )
+            for _ in range(committee_size)
+        ]
+        for fut in as_completed(futures):
+            all_evals.append(fut.result())
+
+    # Aggregate by majority vote
+    result_reqs = []
+    for i, req_text in enumerate(requirements):
+        votes = []
+        reasoning = []
+        for judge_evals in all_evals:
+            if i < len(judge_evals):
+                votes.append(bool(judge_evals[i].get("satisfied", False)))
+                reasoning.append(judge_evals[i].get("reasoning", ""))
+            else:
+                votes.append(False)
+                reasoning.append("No evaluation returned")
+
+        pass_count = sum(votes)
+        passes = pass_count > committee_size / 2  # majority
+
+        result_reqs.append({
+            "text": req_text,
+            "pass": passes,
+            "votes": votes,
+            "reasoning": reasoning,
+        })
+
+    passed = sum(1 for r in result_reqs if r["pass"])
+    return {
+        "requirements": result_reqs,
+        "overall_pass": passed == len(requirements),
+        "pass_count": passed,
+        "total_count": len(requirements),
+    }

--- a/nemo_skills/inference/eval/rasb_container/lm.py
+++ b/nemo_skills/inference/eval/rasb_container/lm.py
@@ -1,0 +1,668 @@
+import os
+import threading
+from typing import Any, Literal
+
+from openai import AsyncOpenAI, OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class LMQueryError(Exception):
+    """Raised when an LM endpoint query fails."""
+    pass
+
+
+ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+Verbosity = Literal["low", "medium", "high"]
+
+
+class LM:
+    """Wrapper around an OpenAI-compatible chat completions endpoint, bound to a specific model."""
+
+    def __init__(self, model: str, api_key: str | None = None, base_url: str = "https://inference-api.nvidia.com", max_tokens: int | None = None, temperature: float | None = None, **kwargs):
+        """Create a client for ``model``. Defaults to NVAPI_KEY and NVIDIA's inference API.
+        If ``max_tokens`` is set, it is used as the default token output limit for all queries.
+        If ``temperature`` is set, it is used as the default sampling temperature (e.g. 0.0–2.0).
+        kwargs are forwarded to the underlying API call.
+        """
+        self.model = model
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self.kwargs = kwargs
+        self.usage: dict[str, dict[str, int]] = {}
+        self._usage_lock = threading.Lock()
+        api_key = api_key or os.environ["NVAPI_KEY"]
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+    def _record_usage(self, response) -> None:
+        """Record token usage from a response into this instance's usage dict."""
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            return
+        inp = getattr(usage, "input_tokens", None) or getattr(usage, "prompt_tokens", 0) or 0
+        out = getattr(usage, "output_tokens", None) or getattr(usage, "completion_tokens", 0) or 0
+        if inp or out:
+            with self._usage_lock:
+                if self.model not in self.usage:
+                    self.usage[self.model] = {
+                        "input_tokens": 0, "output_tokens": 0,
+                        "cache_reused_input_tokens": 0, "cache_new_input_tokens": 0,
+                    }
+                self.usage[self.model]["input_tokens"] += inp
+                self.usage[self.model]["output_tokens"] += out
+
+    def _defaults(self, **kwargs) -> dict:
+        """Merge instance defaults into kwargs (caller's kwargs take precedence)."""
+        if self.max_tokens is not None and "max_tokens" not in kwargs:
+            kwargs = {**kwargs, "max_tokens": self.max_tokens}
+        if self.temperature is not None and "temperature" not in kwargs:
+            kwargs = {**kwargs, "temperature": self.temperature}
+        if self.kwargs is not None:
+            kwargs = {**kwargs, **self.kwargs}
+        return kwargs
+
+    def query(self, prompt: str, **kwargs) -> str:
+        """Send a single user prompt and return the response text."""
+        kwargs = self._defaults(**kwargs)
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+                **kwargs,
+            )
+            self._record_usage(response)
+            return response.choices[0].message.content or ""
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    async def aquery(self, prompt: str, **kwargs) -> str:
+        """Async version of ``query``."""
+        kwargs = self._defaults(**kwargs)
+        try:
+            response = await self.async_client.chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+                **kwargs,
+            )
+            self._record_usage(response)
+            return response.choices[0].message.content or ""
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    def query_messages(self, messages: list[dict], **kwargs) -> str:
+        """Send a full message list and return the response text."""
+        kwargs = self._defaults(**kwargs)
+        try:
+            response = self.client.chat.completions.create( # type: ignore
+            model=self.model,
+            messages=messages, # type: ignore
+            **kwargs,
+            )
+            self._record_usage(response)
+            return response.choices[0].message.content or ""
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    async def aquery_messages(self, messages: list[dict], **kwargs) -> str:
+        """Async version of ``query_messages``."""
+        kwargs = self._defaults(**kwargs)
+        try:
+            response = await self.async_client.chat.completions.create( # type: ignore
+            model=self.model,
+            messages=messages, # type: ignore
+            **kwargs,
+        )
+            self._record_usage(response)
+            return response.choices[0].message.content or ""
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    def query_messages_raw(self, messages: list[dict], **kwargs):
+        """Sync query returning the raw ``ChatCompletion`` response object."""
+        kwargs = self._defaults(**kwargs)
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=messages,  # type: ignore
+                **kwargs,
+            )
+            self._record_usage(response)
+            return response
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    async def aquery_messages_raw(self, messages: list[dict], **kwargs):
+        """Async query returning the raw ``ChatCompletion`` response object."""
+        kwargs = self._defaults(**kwargs)
+        try:
+            response = await self.async_client.chat.completions.create(
+            model=self.model,
+            messages=messages,  # type: ignore
+            **kwargs,
+            )
+            self._record_usage(response)
+            return response
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+
+def _messages_to_responses_input(messages: list[dict]) -> tuple[list[dict], str | None]:
+    """Convert chat completions-style messages to Responses API input list and instructions.
+
+    Handles:
+    - system messages -> instructions string
+    - user/assistant messages -> message items
+    - assistant messages with tool_calls -> function_call items
+    - tool role messages -> function_call_output items
+    """
+    import json as _json
+
+    input_items: list[dict] = []
+    instructions: str | None = None
+    for m in messages:
+        role = m.get("role", "user")
+        content = m.get("content", "")
+        if isinstance(content, list):
+            text = next(
+                (c.get("text", str(c)) for c in content if isinstance(c, dict)),
+                str(content),
+            )
+        else:
+            text = content
+
+        if role == "system":
+            if instructions is None:
+                instructions = text
+            else:
+                instructions = instructions + "\n" + text
+        elif role == "tool":
+            # Tool result -> function_call_output item
+            tool_call_id = m.get("tool_call_id", "")
+            input_items.append({
+                "type": "function_call_output",
+                "call_id": tool_call_id,
+                "output": text,
+            })
+        elif role == "assistant" and m.get("tool_calls"):
+            # Assistant message with tool calls
+            # First add any text content as a message
+            if text:
+                input_items.append({"type": "message", "role": "assistant", "content": text})
+            # Then add each tool call as a function_call item
+            for tc in m["tool_calls"]:
+                fn = tc.get("function", {})
+                args = fn.get("arguments", "{}")
+                if isinstance(args, str):
+                    try:
+                        args = _json.loads(args)
+                    except (ValueError, TypeError):
+                        args = {}
+                input_items.append({
+                    "type": "function_call",
+                    "call_id": tc.get("id", ""),
+                    "name": fn.get("name", ""),
+                    "arguments": args,
+                })
+        else:
+            input_items.append({"type": "message", "role": role, "content": text})
+    return input_items, instructions
+
+
+def _response_output_text(response) -> str:
+    """Extract assistant text from a Responses API response including any errors and reasoning."""
+    if getattr(response, "error", None) is not None:
+        raise RuntimeError(f"OpenAI Responses API error: {response.error}")
+    ret = ""
+    for item in response.output:
+        if item.type == "reasoning":
+            ret += "Reasoning: " + item.content if item.content else "Empty." + "\n"
+        if item.type == "message" and item.content:
+            for part in item.content:
+                if part.type == "output_text":
+                    return part.text
+        
+    return ""
+
+
+class OpenAILM(LM):
+    """LM implementation using the OpenAI Responses API (client.responses) with configurable reasoning effort and verbosity."""
+
+    def __init__(
+        self,
+        model: str,
+        api_key: str | None = None,
+        base_url: str = "https://inference-api.nvidia.com",
+        max_tokens: int | None = None,
+        reasoning_effort: ReasoningEffort | None = None,
+        verbosity: Verbosity | None = None,
+        **kwargs,
+    ):
+        """Create a client for ``model`` using the OpenAI Responses API.
+        Uses NVIDIA Inference API key by default. ``reasoning_effort`` and ``verbosity``
+        are applied to every request unless overridden in kwargs.
+        """
+        api_key = api_key or os.environ.get("NVAPI_KEY")
+        super().__init__(
+            model,
+            api_key=api_key,
+            base_url=base_url,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+        self.reasoning_effort = reasoning_effort
+        self.verbosity = verbosity
+
+    def _defaults(self, **kwargs) -> dict:
+        kwargs = super()._defaults(**kwargs)
+        if "max_tokens" in kwargs:
+            kwargs["max_output_tokens"] = kwargs.pop("max_tokens")
+        reasoning_effort = kwargs.pop("reasoning_effort", self.reasoning_effort)
+        verbosity = kwargs.pop("verbosity", self.verbosity)
+        if reasoning_effort is not None and "reasoning" not in kwargs:
+            kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "detailed"}
+        if verbosity is not None:
+            kwargs["text"] = {**(kwargs.get("text") or {}), "verbosity": verbosity}
+        return kwargs
+
+    def query(self, prompt: str, **kwargs) -> str:
+        kwargs = self._defaults(**kwargs)
+        try:
+            response = self.client.responses.create(
+            model=self.model,
+            input=prompt,
+            **kwargs,
+        )
+            self._record_usage(response)
+            return _response_output_text(response)
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    async def aquery(self, prompt: str, **kwargs) -> str:
+        kwargs = self._defaults(**kwargs)
+        try:
+            response = await self.async_client.responses.create(
+            model=self.model,
+            input=prompt,
+            **kwargs,
+            )
+            self._record_usage(response)
+            return _response_output_text(response)
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    def query_messages(self, messages: list[dict], **kwargs) -> str:
+        input_items, instructions = _messages_to_responses_input(messages)
+        try:
+            kwargs = self._defaults(**kwargs)
+            create_kwargs: dict = {k: v for k, v in kwargs.items() if k not in ("messages",)}
+            if instructions is not None:
+                create_kwargs["instructions"] = instructions
+            response = self.client.responses.create(
+                model=self.model,
+                input=input_items,
+                **create_kwargs,
+            )
+            self._record_usage(response)
+            return _response_output_text(response)
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    async def aquery_messages(self, messages: list[dict], **kwargs) -> str:
+        input_items, instructions = _messages_to_responses_input(messages)
+        kwargs = self._defaults(**kwargs)
+        create_kwargs = {k: v for k, v in kwargs.items() if k not in ("messages",)}
+        if instructions is not None:
+            create_kwargs["instructions"] = instructions
+        try:
+            response = await self.async_client.responses.create(
+            model=self.model,
+            input=input_items,
+            **create_kwargs,
+        )
+            self._record_usage(response)
+            return _response_output_text(response)
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    def query_messages_raw(self, messages: list[dict], **kwargs):
+        """Sync query returning the raw Responses API response object."""
+        input_items, instructions = _messages_to_responses_input(messages)
+        kwargs = self._defaults(**kwargs)
+        create_kwargs = {k: v for k, v in kwargs.items() if k not in ("messages",)}
+        if instructions is not None:
+            create_kwargs["instructions"] = instructions
+        try:
+            response = self.client.responses.create(
+                model=self.model,
+                input=input_items,
+                **create_kwargs,
+            )
+            self._record_usage(response)
+            return response
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    async def aquery_messages_raw(self, messages: list[dict], **kwargs):
+        """Async query returning the raw Responses API response object."""
+        input_items, instructions = _messages_to_responses_input(messages)
+        kwargs = self._defaults(**kwargs)
+        create_kwargs = {k: v for k, v in kwargs.items() if k not in ("messages",)}
+        if instructions is not None:
+            create_kwargs["instructions"] = instructions
+        try:
+            response = await self.async_client.responses.create(
+            model=self.model,
+            input=input_items,
+            **create_kwargs,
+        )
+            self._record_usage(response)
+            return response
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# Anthropic-native LM (uses anthropic SDK via NVIDIA proxy)
+# ---------------------------------------------------------------------------
+
+
+def _openai_tools_to_anthropic(tools: list[dict]) -> list[dict]:
+    """Convert OpenAI-format tool schemas to Anthropic format."""
+    out = []
+    for t in tools:
+        if t.get("type") == "function":
+            fn = t["function"]
+            out.append({
+                "name": fn["name"],
+                "description": fn.get("description", ""),
+                "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+            })
+        else:
+            out.append(t)
+    return out
+
+
+def _openai_messages_to_anthropic(messages: list[dict]) -> tuple[str | None, list[dict]]:
+    """Split system message out and convert the rest to Anthropic format.
+
+    Returns (system_prompt, anthropic_messages).
+    """
+    system_parts: list[str] = []
+    anthropic_msgs: list[dict] = []
+
+    for m in messages:
+        role = m.get("role", "user")
+        content = m.get("content", "")
+
+        if role == "system":
+            system_parts.append(content if isinstance(content, str) else str(content))
+            continue
+
+        if role == "tool":
+            # OpenAI tool results -> Anthropic tool_result content block in a user message
+            tool_call_id = m.get("tool_call_id", "")
+            block = {
+                "type": "tool_result",
+                "tool_use_id": tool_call_id,
+                "content": content if isinstance(content, str) else str(content),
+            }
+            # Merge into the last user message if it exists, otherwise create one
+            if anthropic_msgs and anthropic_msgs[-1]["role"] == "user":
+                last_content = anthropic_msgs[-1]["content"]
+                if isinstance(last_content, list):
+                    last_content.append(block)
+                else:
+                    anthropic_msgs[-1]["content"] = [{"type": "text", "text": last_content}, block]
+            else:
+                anthropic_msgs.append({"role": "user", "content": [block]})
+            continue
+
+        if role == "assistant" and "tool_calls" in m and m["tool_calls"]:
+            # Convert OpenAI assistant tool_calls to Anthropic content blocks
+            blocks: list[dict] = []
+            if content:
+                blocks.append({"type": "text", "text": content})
+            for tc in m["tool_calls"]:
+                fn = tc["function"]
+                import json as _json
+                try:
+                    tool_input = _json.loads(fn["arguments"])
+                except (ValueError, TypeError):
+                    tool_input = {}
+                blocks.append({
+                    "type": "tool_use",
+                    "id": tc["id"],
+                    "name": fn["name"],
+                    "input": tool_input,
+                })
+            anthropic_msgs.append({"role": "assistant", "content": blocks})
+            continue
+
+        # Regular user/assistant message
+        anthropic_msgs.append({"role": role, "content": content})
+
+    system = "\n".join(system_parts) if system_parts else None
+    return system, anthropic_msgs
+
+
+class _FakeToolCall:
+    """Mimics OpenAI's tool call object for compatibility with Cache."""
+
+    def __init__(self, tc_id: str, name: str, arguments: str):
+        self.id = tc_id
+        self.function = type("Function", (), {"name": name, "arguments": arguments})()
+
+
+class _FakeMessage:
+    """Mimics OpenAI's ChatCompletionMessage for compatibility with Cache."""
+
+    def __init__(self, content: str | None, tool_calls: list[_FakeToolCall] | None):
+        self.content = content
+        self.tool_calls = tool_calls if tool_calls else None
+
+
+class _FakeChoice:
+    """Mimics OpenAI's Choice for compatibility with Cache."""
+
+    def __init__(self, message: _FakeMessage, finish_reason: str):
+        self.message = message
+        self.finish_reason = finish_reason
+
+
+class _FakeChatCompletion:
+    """Mimics OpenAI's ChatCompletion so Cache's ``hasattr(response, 'choices')`` path works."""
+
+    def __init__(self, choice: _FakeChoice, thinking: str | None = None):
+        self.choices = [choice]
+        self.thinking = thinking
+
+
+def _anthropic_response_to_fake_completion(response) -> _FakeChatCompletion:
+    """Convert an Anthropic Messages response to a fake OpenAI ChatCompletion."""
+    import json as _json
+
+    text_parts: list[str] = []
+    tool_calls: list[_FakeToolCall] = []
+    thinking_text: str | None = None
+
+    for block in response.content:
+        if block.type == "thinking":
+            thinking_text = block.thinking
+        elif block.type == "text":
+            text_parts.append(block.text)
+        elif block.type == "tool_use":
+            tool_calls.append(_FakeToolCall(
+                tc_id=block.id,
+                name=block.name,
+                arguments=_json.dumps(block.input),
+            ))
+
+    content = "\n".join(text_parts) if text_parts else None
+
+    if response.stop_reason == "tool_use":
+        finish_reason = "tool_calls"
+    elif response.stop_reason == "end_turn":
+        finish_reason = "stop"
+    elif response.stop_reason == "max_tokens":
+        finish_reason = "length"
+    else:
+        finish_reason = response.stop_reason or "stop"
+
+    message = _FakeMessage(content=content, tool_calls=tool_calls or None)
+    choice = _FakeChoice(message=message, finish_reason=finish_reason)
+    return _FakeChatCompletion(choice=choice, thinking=thinking_text)
+
+
+class AnthropicLM(LM):
+    """LM using the Anthropic Messages API (via NVIDIA proxy) with extended thinking support."""
+
+    def __init__(
+        self,
+        model: str,
+        api_key: str | None = None,
+        base_url: str = "https://inference-api.nvidia.com",
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        thinking_budget: int | None = None,
+        **kwargs,
+    ):
+        """Create a client using the Anthropic SDK pointed at the NVIDIA proxy.
+
+        ``thinking_budget``: if set, enables extended thinking with this many
+        budget tokens. Thinking content is returned via the ``thinking``
+        attribute on the fake ChatCompletion returned by ``*_raw`` methods.
+        Set to ``None`` (default) to disable thinking.
+        """
+        api_key = api_key or os.environ["NVAPI_KEY"]
+        super().__init__(
+            model,
+            api_key=api_key,
+            base_url=base_url,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            **kwargs,
+        )
+        import anthropic
+        self.thinking_budget = thinking_budget
+        self.anthropic_client = anthropic.Anthropic(api_key=api_key, base_url=base_url)
+        self.anthropic_async_client = anthropic.AsyncAnthropic(api_key=api_key, base_url=base_url)
+
+    def _anthropic_kwargs(self, **kwargs) -> dict:
+        """Build kwargs for an Anthropic messages.create call."""
+        kw: dict[str, Any] = {"model": self.model}
+        kw["max_tokens"] = kwargs.pop("max_tokens", self.max_tokens) or 4096
+
+        temperature = kwargs.pop("temperature", self.temperature)
+        thinking_budget = kwargs.pop("thinking_budget", self.thinking_budget)
+        if thinking_budget is not None:
+            kw["thinking"] = {"type": "enabled", "budget_tokens": thinking_budget}
+            kw["temperature"] = 1.0  # Anthropic requires temperature=1 with thinking
+        elif temperature is not None:
+            kw["temperature"] = temperature
+
+        return kw
+
+    def _extract_text(self, response) -> str:
+        """Extract the text content from an Anthropic response."""
+        for block in response.content:
+            if block.type == "text":
+                return block.text
+        return ""
+
+    def query(self, prompt: str, **kwargs) -> str:
+        kw = self._anthropic_kwargs(**kwargs)
+        try:
+            response = self.anthropic_client.messages.create(
+                messages=[{"role": "user", "content": prompt}],
+                **kw,
+            )
+            self._record_usage(response)
+            return self._extract_text(response)
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    async def aquery(self, prompt: str, **kwargs) -> str:
+        kw = self._anthropic_kwargs(**kwargs)
+        try:
+            response = await self.anthropic_async_client.messages.create(
+                messages=[{"role": "user", "content": prompt}],
+                **kw,
+            )
+            self._record_usage(response)
+            return self._extract_text(response)
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    def query_messages(self, messages: list[dict], **kwargs) -> str:
+        kw = self._anthropic_kwargs(**kwargs)
+        system, anthropic_msgs = _openai_messages_to_anthropic(messages)
+        if system is not None:
+            kw["system"] = system
+        try:
+            response = self.anthropic_client.messages.create(
+                messages=anthropic_msgs,
+                **kw,
+            )
+            self._record_usage(response)
+            return self._extract_text(response)
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    async def aquery_messages(self, messages: list[dict], **kwargs) -> str:
+        kw = self._anthropic_kwargs(**kwargs)
+        system, anthropic_msgs = _openai_messages_to_anthropic(messages)
+        if system is not None:
+            kw["system"] = system
+        try:
+            response = await self.anthropic_async_client.messages.create(
+                messages=anthropic_msgs,
+                **kw,
+            )
+            self._record_usage(response)
+            return self._extract_text(response)
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    def query_messages_raw(self, messages: list[dict], **kwargs):
+        """Returns a fake ChatCompletion wrapping the Anthropic response.
+
+        Compatible with Cache's ``hasattr(response, 'choices')`` code path.
+        Thinking summary (if enabled) is available as ``response.thinking``.
+        """
+        tools = kwargs.pop("tools", None)
+        kw = self._anthropic_kwargs(**kwargs)
+        system, anthropic_msgs = _openai_messages_to_anthropic(messages)
+        if system is not None:
+            kw["system"] = system
+        if tools:
+            kw["tools"] = _openai_tools_to_anthropic(tools)
+        try:
+            response = self.anthropic_client.messages.create(
+                messages=anthropic_msgs,
+                **kw,
+            )
+            self._record_usage(response)
+            return _anthropic_response_to_fake_completion(response)
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e
+
+    async def aquery_messages_raw(self, messages: list[dict], **kwargs):
+        """Async version of query_messages_raw."""
+        tools = kwargs.pop("tools", None)
+        kw = self._anthropic_kwargs(**kwargs)
+        system, anthropic_msgs = _openai_messages_to_anthropic(messages)
+        if system is not None:
+            kw["system"] = system
+        if tools:
+            kw["tools"] = _openai_tools_to_anthropic(tools)
+        try:
+            response = await self.anthropic_async_client.messages.create(
+                messages=anthropic_msgs,
+                **kw,
+            )
+            self._record_usage(response)
+            return _anthropic_response_to_fake_completion(response)
+        except Exception as e:
+            raise LMQueryError(f"Error querying {self.model}: {e}") from e

--- a/nemo_skills/inference/eval/rasb_container/lm.py
+++ b/nemo_skills/inference/eval/rasb_container/lm.py
@@ -1,3 +1,10 @@
+"""
+Language model client wrappers for RASB benchmark evaluation.
+
+Provides unified interfaces for OpenAI-compatible and Anthropic APIs,
+supporting both synchronous and asynchronous queries with tool calling.
+"""
+
 import os
 import threading
 from typing import Any, Literal
@@ -255,6 +262,7 @@ class OpenAILM(LM):
         self.verbosity = verbosity
 
     def _defaults(self, **kwargs) -> dict:
+        """Merge instance defaults and convert max_tokens to max_output_tokens."""
         kwargs = super()._defaults(**kwargs)
         if "max_tokens" in kwargs:
             kwargs["max_output_tokens"] = kwargs.pop("max_tokens")
@@ -267,6 +275,7 @@ class OpenAILM(LM):
         return kwargs
 
     def query(self, prompt: str, **kwargs) -> str:
+        """Send a single user prompt via the Responses API and return the response text."""
         kwargs = self._defaults(**kwargs)
         try:
             response = self.client.responses.create(
@@ -280,6 +289,7 @@ class OpenAILM(LM):
             raise LMQueryError(f"Error querying {self.model}: {e}") from e
 
     async def aquery(self, prompt: str, **kwargs) -> str:
+        """Async version of query using the Responses API."""
         kwargs = self._defaults(**kwargs)
         try:
             response = await self.async_client.responses.create(
@@ -293,6 +303,7 @@ class OpenAILM(LM):
             raise LMQueryError(f"Error querying {self.model}: {e}") from e
 
     def query_messages(self, messages: list[dict], **kwargs) -> str:
+        """Send a message list via the Responses API and return the response text."""
         input_items, instructions = _messages_to_responses_input(messages)
         try:
             kwargs = self._defaults(**kwargs)
@@ -310,6 +321,7 @@ class OpenAILM(LM):
             raise LMQueryError(f"Error querying {self.model}: {e}") from e
 
     async def aquery_messages(self, messages: list[dict], **kwargs) -> str:
+        """Async version of query_messages using the Responses API."""
         input_items, instructions = _messages_to_responses_input(messages)
         kwargs = self._defaults(**kwargs)
         create_kwargs = {k: v for k, v in kwargs.items() if k not in ("messages",)}
@@ -451,6 +463,7 @@ class _FakeToolCall:
     """Mimics OpenAI's tool call object for compatibility with Cache."""
 
     def __init__(self, tc_id: str, name: str, arguments: str):
+        """Create a fake tool call with the given id, function name, and arguments."""
         self.id = tc_id
         self.function = type("Function", (), {"name": name, "arguments": arguments})()
 
@@ -459,6 +472,7 @@ class _FakeMessage:
     """Mimics OpenAI's ChatCompletionMessage for compatibility with Cache."""
 
     def __init__(self, content: str | None, tool_calls: list[_FakeToolCall] | None):
+        """Create a fake message with optional content and tool calls."""
         self.content = content
         self.tool_calls = tool_calls if tool_calls else None
 
@@ -467,6 +481,7 @@ class _FakeChoice:
     """Mimics OpenAI's Choice for compatibility with Cache."""
 
     def __init__(self, message: _FakeMessage, finish_reason: str):
+        """Create a fake choice wrapping a message with the given finish reason."""
         self.message = message
         self.finish_reason = finish_reason
 
@@ -475,6 +490,7 @@ class _FakeChatCompletion:
     """Mimics OpenAI's ChatCompletion so Cache's ``hasattr(response, 'choices')`` path works."""
 
     def __init__(self, choice: _FakeChoice, thinking: str | None = None):
+        """Create a fake completion with choices list and optional thinking content."""
         self.choices = [choice]
         self.thinking = thinking
 
@@ -572,6 +588,7 @@ class AnthropicLM(LM):
         return ""
 
     def query(self, prompt: str, **kwargs) -> str:
+        """Send a single user prompt via Anthropic Messages API and return response text."""
         kw = self._anthropic_kwargs(**kwargs)
         try:
             response = self.anthropic_client.messages.create(
@@ -584,6 +601,7 @@ class AnthropicLM(LM):
             raise LMQueryError(f"Error querying {self.model}: {e}") from e
 
     async def aquery(self, prompt: str, **kwargs) -> str:
+        """Async version of query using the Anthropic Messages API."""
         kw = self._anthropic_kwargs(**kwargs)
         try:
             response = await self.anthropic_async_client.messages.create(
@@ -596,6 +614,7 @@ class AnthropicLM(LM):
             raise LMQueryError(f"Error querying {self.model}: {e}") from e
 
     def query_messages(self, messages: list[dict], **kwargs) -> str:
+        """Send a message list via Anthropic Messages API and return response text."""
         kw = self._anthropic_kwargs(**kwargs)
         system, anthropic_msgs = _openai_messages_to_anthropic(messages)
         if system is not None:
@@ -611,6 +630,7 @@ class AnthropicLM(LM):
             raise LMQueryError(f"Error querying {self.model}: {e}") from e
 
     async def aquery_messages(self, messages: list[dict], **kwargs) -> str:
+        """Async version of query_messages using the Anthropic Messages API."""
         kw = self._anthropic_kwargs(**kwargs)
         system, anthropic_msgs = _openai_messages_to_anthropic(messages)
         if system is not None:


### PR DESCRIPTION
RASB (Real Agent Scaffolds Bench) evaluates LLMs on complex agent scaffolding tasks scraped from open-source AI agent repositories. This adds support for the 26H1 evaluation snapshot with 193 environments and 5,731 test samples.
See the following NVIDIA tech report for details: [internal link](https://drive.google.com/file/d/1pwymoEZHeKHoftYd-9rKlwQ7QnBuNRwK/view?usp=drive_link).

Features:
- Docker-based evaluation matching original RASB benchmark setup
- Support for OpenAI, Anthropic, and other compatible APIs
- Aggregate metrics: mean, median, Q1, Q3, std across environments
- Per-environment, per-type, per-judgment breakdowns

Files:
- nemo_skills/dataset/rasb-26h1/: Dataset module and preparation
- nemo_skills/inference/eval/rasb.py: Generation with Docker orchestration
- nemo_skills/inference/eval/rasb_container/: Container evaluation files
- nemo_skills/evaluation/metrics/rasb_metrics.py: Metrics aggregation
- nemo_skills/evaluation/evaluator/rasb.py: Result passthrough evaluator
- docs/evaluation/rasb.md: Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RASB 26H1 evaluation: containerized runs with resumable outputs, solvability retries, judge-based judgments, dataset preparation CLI, unified LM adapter for multiple backends, and evaluator/metrics integration.
  * Enhanced reporting: pass-rate breakdowns (env/type/repo), per-environment statistics, errors/containers logging, and JSON output.

* **Documentation**
  * Comprehensive RASB guide and dataset README with setup, flags, Docker/run examples, metrics explanation, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->