### PR TITLE
fix(proof-arena-judge): pin MathArena/*_2025_outputs to 2026-03-25 revisions

### DIFF
--- a/nemo_skills/dataset/proof-arena-judge/prepare.py
+++ b/nemo_skills/dataset/proof-arena-judge/prepare.py
@@ -27,14 +27,21 @@ JUDGEMENT_NO = "Judgement: No"
 SUBSET_PROOFS = "proofs"
 MAX_QWEN_TOKENS = 10000
 
+# Pin to the 2026-03-25 dataset uploads. The 2026-04-25 uploads changed the
+# schema of `grading_details_judge_*` so each entry is a string instead of a
+# dict, which breaks `grading_scheme_to_rubric`.
+IMO_OUTPUTS_REVISION = "d995fc906b58"
+USAMO_OUTPUTS_REVISION = "0fafbf629a32"
+IMC_OUTPUTS_REVISION = "d4f93c209272"
+
 qwen3_tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
 
 
 def prepare_data(output_path):
     # Load data
-    imo_data = datasets.load_dataset("MathArena/imo_2025_outputs")["train"]
-    usamo_data = datasets.load_dataset("MathArena/usamo_2025_outputs")["train"]
-    imc_data = datasets.load_dataset("MathArena/imc_2025_outputs")["train"]
+    imo_data = datasets.load_dataset("MathArena/imo_2025_outputs", revision=IMO_OUTPUTS_REVISION)["train"]
+    usamo_data = datasets.load_dataset("MathArena/usamo_2025_outputs", revision=USAMO_OUTPUTS_REVISION)["train"]
+    imc_data = datasets.load_dataset("MathArena/imc_2025_outputs", revision=IMC_OUTPUTS_REVISION)["train"]
     openai_imo_data = load_openai_imo_proofs()
     gemini_imo_data = load_gemini_imo_proofs()
     processed_data = []


### PR DESCRIPTION
## Summary

- The 2026-04-25 uploads to `MathArena/{imo,usamo,imc}_2025_outputs` changed the schema of `grading_details_judge_*` so each entry is now a string instead of a dict with a `grading_scheme_desc` field.
- This breaks `grading_scheme_to_rubric` in `nemo_skills/dataset/proof-arena-judge/prepare.py` with `TypeError: string indices must be integers`, which fails `tests/gpu-tests/test_eval.py::test_aaa_prepare_and_eval_all_datasets` on every PR running GPU CI.
- This PR pins all three datasets to the prior 2026-03-25 revisions to unblock CI. A proper fix for the new schema can follow up.

Confirmed the same `TypeError` reproduces on at least two unrelated PRs from today (#1376, #1378-era contextasr branch) — it is not branch-specific.

## Test plan

- [ ] Trigger GPU tests on this PR (toggle the `run GPU tests` label) and confirm `test_aaa_prepare_and_eval_all_datasets` passes.
- [ ] Sanity check the three pinned revisions still resolve via `datasets.load_dataset(..., revision=...)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dataset versioning for mathematical problem evaluation to use pinned versions, ensuring correct schema compatibility and preventing processing errors in downstream evaluation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->