### PR TITLE
Fix ASR leaderboard audio root import

### DIFF
--- a/nemo_skills/dataset/asr-leaderboard/prepare.py
+++ b/nemo_skills/dataset/asr-leaderboard/prepare.py
@@ -30,6 +30,7 @@ Usage:
 
 import argparse
 import json
+import os
 from pathlib import Path
 
 import soundfile as sf


### PR DESCRIPTION
## Summary

- Add the missing `os` import in `nemo_skills/dataset/asr-leaderboard/prepare.py`.
- This unblocks `NEMO_SKILLS_AUDIO_ROOT=/data`, which the prepare script already reads when writing audio paths into the ASR leaderboard JSONL.

## Test plan

- `python -m py_compile nemo_skills/dataset/asr-leaderboard/prepare.py`
- Verified via downstream Draco prepare job that generated JSONL paths start with `/data/asr-leaderboard/data/...`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal code updates with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->