### PR TITLE
Add ContextASR-Bench benchmark (contextual ASR with NE-WER/NE-FNR metrics)

### DIFF
--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -5,6 +5,7 @@
 
 bs4
 compute-eval @ git+https://github.com/NVIDIA/compute-eval.git@e01a5d2
+contractions
 datasets
 editdistance
 evalplus @ git+https://github.com/evalplus/evalplus@c91370f

--- a/docs/evaluation/speech-audio.md
+++ b/docs/evaluation/speech-audio.md
@@ -483,3 +483,110 @@ Numb3rs reports the following metrics:
 - **success_rate**: Percentage of samples with WER < 0.5
 
 Per-category breakdowns (e.g., `numb3rs-numb3rs_CARDINAL`, `numb3rs-numb3rs_MONEY`) are included automatically.
+
+## ContextASR-Bench
+
+ContextASR-Bench evaluates contextual ASR performance by measuring how well models transcribe speech when given different levels of contextual information. It focuses on named entity recognition accuracy alongside standard WER.
+
+**Dataset:** [MrSupW/ContextASR-Bench](https://huggingface.co/datasets/MrSupW/ContextASR-Bench) (English Speech subset: 15,326 samples, ~188 hours, 116,167 named entities across 10+ domains)
+
+**Evaluation Modes:**
+
+- `contextasr-bench.contextless`: Plain transcription (no context)
+- `contextasr-bench.coarse`: Domain label provided as context
+- `contextasr-bench.fine`: Domain label + entity list provided as context
+
+**Metrics:**
+
+- **WER**: Word Error Rate (corpus-level)
+- **NE-WER**: Named Entity WER — WER computed on fuzzy-matched entity token sequences
+- **NE-FNR**: Named Entity False Negative Rate — fraction of reference entities not found in the transcription
+
+### Dataset Location
+
+* Benchmark is defined in `nemo_skills/dataset/contextasr-bench/__init__.py`
+* Original dataset is hosted on [HuggingFace](https://huggingface.co/datasets/MrSupW/ContextASR-Bench)
+
+### Preparing ContextASR-Bench Data
+
+ContextASR-Bench requires audio files for meaningful evaluation. **Audio files are downloaded
+automatically by default** from HuggingFace (~22 GB, may take 30-60 minutes).
+
+```bash
+ns prepare_data contextasr-bench
+```
+
+!!! warning "Large download"
+
+    The automatic download fetches ~22 GB of audio data (JSONL + 8 tar files) from HuggingFace.
+    This can take 30-60 minutes depending on network speed. If you already have the data
+    downloaded, use `--data_dir` to skip the download.
+
+To download to a specific directory, or to use pre-downloaded data:
+
+```bash
+ns prepare_data contextasr-bench --data_dir=/path/to/ContextASR-Bench
+```
+
+If the directory already contains `ContextASR-Speech_English.jsonl`, the existing data is
+used directly. If the file is missing, data is downloaded there automatically.
+
+To use a custom audio path prefix (e.g., for container mount points):
+
+```bash
+ns prepare_data contextasr-bench --data_dir=/path/to/ContextASR-Bench --audio-prefix /data/contextasr
+```
+
+### Running ContextASR-Bench Evaluation
+
+Evaluate all three modes:
+
+```bash
+ns eval \
+    --cluster=local \
+    --benchmarks=contextasr-bench \
+    --server_type=openai \
+    --server_address=http://localhost:8000/v1 \
+    --model=Qwen/Qwen3-Omni-7B \
+    --output_dir=/workspace/contextasr-eval \
+    --data_dir=/path/to/ContextASR-Bench
+```
+
+Evaluate a single mode:
+
+```bash
+ns eval --benchmarks=contextasr-bench.fine ...
+```
+
+### Understanding ContextASR-Bench Results
+
+```
+<output_dir>/
+└── eval-results/
+    └── contextasr-bench/
+        ├── metrics.json                          # Overall aggregate
+        ├── contextasr-bench.contextless/
+        │   └── metrics.json
+        ├── contextasr-bench.coarse/
+        │   └── metrics.json
+        └── contextasr-bench.fine/
+            └── metrics.json
+```
+
+Example output:
+
+```
+----------------------- contextasr-bench.contextless -----------------------
+evaluation_mode | avg_tokens | gen_seconds | success_rate | wer    | ne_wer | ne_fnr | num_entries
+pass@1          | 128        | 12000       | 97.73%       | 2.27%  | 7.83%  | 9.08%  | 15326
+
+------------------------- contextasr-bench.coarse --------------------------
+evaluation_mode | avg_tokens | gen_seconds | success_rate | wer    | ne_wer | ne_fnr | num_entries
+pass@1          | 128        | 12000       | 97.83%       | 2.17%  | 8.11%  | 9.32%  | 15326
+
+-------------------------- contextasr-bench.fine ---------------------------
+evaluation_mode | avg_tokens | gen_seconds | success_rate | wer    | ne_wer | ne_fnr | num_entries
+pass@1          | 128        | 12000       | 98.87%       | 1.13%  | 1.55%  | 0.53%  | 15326
+```
+
+Per-domain breakdowns are included automatically based on the `domain_label` field.

--- a/nemo_skills/dataset/contextasr-bench/__init__.py
+++ b/nemo_skills/dataset/contextasr-bench/__init__.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ContextASR-Bench: Contextual ASR evaluation benchmark.
+
+Evaluates ASR models across three context settings:
+- Contextless: Plain transcription
+- Coarse-grained: Domain label provided as context
+- Fine-grained: Domain label + entity list provided as context
+
+Metrics: WER, NE-WER (entity-focused WER with fuzzy matching), NE-FNR (entity miss rate)
+
+Dataset: https://huggingface.co/datasets/MrSupW/ContextASR-Bench
+Paper: ContextASR-Bench (English Speech subset, 15,326 samples, ~188 hours)
+"""
+
+REQUIRES_DATA_DIR = True
+IS_BENCHMARK_GROUP = True
+SCORE_MODULE = "nemo_skills.dataset.contextasr-bench.contextasr_score"
+
+BENCHMARKS = {
+    "contextasr-bench.contextless": {},
+    "contextasr-bench.coarse": {},
+    "contextasr-bench.fine": {},
+}

--- a/nemo_skills/dataset/contextasr-bench/coarse/__init__.py
+++ b/nemo_skills/dataset/contextasr-bench/coarse/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ContextASR-Bench coarse mode: domain label provided as context."""
+
+METRICS_TYPE = "contextasr"
+EVAL_ARGS = "++eval_type=contextasr"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"

--- a/nemo_skills/dataset/contextasr-bench/contextasr_score.py
+++ b/nemo_skills/dataset/contextasr-bench/contextasr_score.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def compute_score(combined_metrics: dict) -> dict:
+    """Aggregate metrics from the three ContextASR-Bench sub-benchmarks.
+
+    Computes weighted averages of WER, NE-WER, NE-FNR across contextless,
+    coarse, and fine evaluation modes.
+    """
+    main_names = ["contextless", "coarse", "fine"]
+    benchmarks = {k: v for k, v in combined_metrics.items() if k.split(".")[-1] in main_names}
+
+    if not benchmarks:
+        return {}
+
+    first_benchmark = next(iter(benchmarks.values()))
+    eval_modes = list(first_benchmark.keys())
+
+    aggregated = {}
+    for eval_mode in eval_modes:
+        total_entries = 0
+        weighted_success = 0.0
+        total_gen_seconds = 0
+        weighted_tokens = 0.0
+        weighted_wer = 0.0
+        weighted_ne_wer = 0.0
+        weighted_ne_fnr = 0.0
+
+        for benchmark_data in benchmarks.values():
+            if eval_mode not in benchmark_data:
+                continue
+
+            metrics = benchmark_data[eval_mode]
+            num_entries = metrics.get("num_entries", 0)
+            if num_entries == 0:
+                continue
+
+            total_entries += num_entries
+            weighted_success += metrics.get("success_rate", 0.0) * num_entries
+            total_gen_seconds += metrics.get("gen_seconds", 0)
+            weighted_tokens += metrics.get("avg_tokens", 0.0) * num_entries
+
+            if "wer" in metrics:
+                weighted_wer += metrics["wer"] * num_entries
+            if "ne_wer" in metrics:
+                weighted_ne_wer += metrics["ne_wer"] * num_entries
+            if "ne_fnr" in metrics:
+                weighted_ne_fnr += metrics["ne_fnr"] * num_entries
+
+        if total_entries == 0:
+            continue
+
+        agg = {
+            "avg_tokens": int(weighted_tokens / total_entries),
+            "gen_seconds": total_gen_seconds,
+            "success_rate": weighted_success / total_entries,
+            "num_entries": total_entries,
+        }
+        has_wer = any("wer" in benchmark_data.get(eval_mode, {}) for benchmark_data in benchmarks.values())
+        has_ne_wer = any("ne_wer" in benchmark_data.get(eval_mode, {}) for benchmark_data in benchmarks.values())
+        has_ne_fnr = any("ne_fnr" in benchmark_data.get(eval_mode, {}) for benchmark_data in benchmarks.values())
+
+        if has_wer:
+            agg["wer"] = round(weighted_wer / total_entries, 2)
+        if has_ne_wer:
+            agg["ne_wer"] = round(weighted_ne_wer / total_entries, 2)
+        if has_ne_fnr:
+            agg["ne_fnr"] = round(weighted_ne_fnr / total_entries, 2)
+
+        aggregated[eval_mode] = agg
+
+    return aggregated

--- a/nemo_skills/dataset/contextasr-bench/contextasr_score.py
+++ b/nemo_skills/dataset/contextasr-bench/contextasr_score.py
@@ -37,27 +37,33 @@ def compute_score(combined_metrics: dict) -> dict:
         weighted_wer = 0.0
         weighted_ne_wer = 0.0
         weighted_ne_fnr = 0.0
+        wer_entries = 0
+        ne_wer_entries = 0
+        ne_fnr_entries = 0
 
         for benchmark_data in benchmarks.values():
             if eval_mode not in benchmark_data:
                 continue
 
             metrics = benchmark_data[eval_mode]
-            num_entries = metrics.get("num_entries", 0)
+            num_entries = metrics["num_entries"]
             if num_entries == 0:
                 continue
 
             total_entries += num_entries
-            weighted_success += metrics.get("success_rate", 0.0) * num_entries
-            total_gen_seconds += metrics.get("gen_seconds", 0)
-            weighted_tokens += metrics.get("avg_tokens", 0.0) * num_entries
+            weighted_success += metrics["success_rate"] * num_entries
+            total_gen_seconds += metrics["gen_seconds"]
+            weighted_tokens += metrics["avg_tokens"] * num_entries
 
             if "wer" in metrics:
                 weighted_wer += metrics["wer"] * num_entries
+                wer_entries += num_entries
             if "ne_wer" in metrics:
                 weighted_ne_wer += metrics["ne_wer"] * num_entries
+                ne_wer_entries += num_entries
             if "ne_fnr" in metrics:
                 weighted_ne_fnr += metrics["ne_fnr"] * num_entries
+                ne_fnr_entries += num_entries
 
         if total_entries == 0:
             continue
@@ -68,16 +74,13 @@ def compute_score(combined_metrics: dict) -> dict:
             "success_rate": weighted_success / total_entries,
             "num_entries": total_entries,
         }
-        has_wer = any("wer" in benchmark_data.get(eval_mode, {}) for benchmark_data in benchmarks.values())
-        has_ne_wer = any("ne_wer" in benchmark_data.get(eval_mode, {}) for benchmark_data in benchmarks.values())
-        has_ne_fnr = any("ne_fnr" in benchmark_data.get(eval_mode, {}) for benchmark_data in benchmarks.values())
 
-        if has_wer:
-            agg["wer"] = round(weighted_wer / total_entries, 2)
-        if has_ne_wer:
-            agg["ne_wer"] = round(weighted_ne_wer / total_entries, 2)
-        if has_ne_fnr:
-            agg["ne_fnr"] = round(weighted_ne_fnr / total_entries, 2)
+        if wer_entries > 0:
+            agg["wer"] = round(weighted_wer / wer_entries, 2)
+        if ne_wer_entries > 0:
+            agg["ne_wer"] = round(weighted_ne_wer / ne_wer_entries, 2)
+        if ne_fnr_entries > 0:
+            agg["ne_fnr"] = round(weighted_ne_fnr / ne_fnr_entries, 2)
 
         aggregated[eval_mode] = agg
 

--- a/nemo_skills/dataset/contextasr-bench/contextless/__init__.py
+++ b/nemo_skills/dataset/contextasr-bench/contextless/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ContextASR-Bench contextless mode: plain transcription without any context."""
+
+METRICS_TYPE = "contextasr"
+EVAL_ARGS = "++eval_type=contextasr"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"

--- a/nemo_skills/dataset/contextasr-bench/fine/__init__.py
+++ b/nemo_skills/dataset/contextasr-bench/fine/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ContextASR-Bench fine mode: domain label and entity list provided as context."""
+
+METRICS_TYPE = "contextasr"
+EVAL_ARGS = "++eval_type=contextasr"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"

--- a/nemo_skills/dataset/contextasr-bench/prepare.py
+++ b/nemo_skills/dataset/contextasr-bench/prepare.py
@@ -31,7 +31,7 @@ Usage:
     ns prepare_data contextasr-bench --data_dir=/path/to/ContextASR-Bench
 
     # Skip audio download (JSONL only, not recommended)
-    ns prepare_data contextasr-bench --no-audio --skip_data_dir_check
+    ns prepare_data contextasr-bench --no-audio
 """
 
 import argparse
@@ -253,14 +253,12 @@ def main():
 
     print("\nWriting JSONL splits...")
     for mode_name, output_path in modes.items():
+        entries = [format_entry(sample, mode_name, audio_prefix) for sample in samples]
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        count = 0
         with open(output_path, "w", encoding="utf-8") as fout:
-            for sample in samples:
-                entry = format_entry(sample, mode_name, audio_prefix)
+            for entry in entries:
                 fout.write(json.dumps(entry, ensure_ascii=False) + "\n")
-                count += 1
-        print(f"  {mode_name}: wrote {count} samples to {output_path}")
+        print(f"  {mode_name}: wrote {len(entries)} samples to {output_path}")
 
     print(f"\nDone. Total: {len(samples)} samples x 3 modes = {len(samples) * 3} records")
 

--- a/nemo_skills/dataset/contextasr-bench/prepare.py
+++ b/nemo_skills/dataset/contextasr-bench/prepare.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prepare ContextASR-Bench dataset for NeMo Skills evaluation.
+
+Downloads the ContextASR-Speech English subset from HuggingFace (JSONL + 8
+audio tar files, ~22 GB total), extracts audio, and produces three JSONL
+split files — one per evaluation mode (contextless, coarse, fine).
+
+If --data_dir is provided and already contains the dataset, the download
+step is skipped and the existing data is used directly.
+
+Dataset: https://huggingface.co/datasets/MrSupW/ContextASR-Bench
+
+Usage:
+    # Auto-download to default location (alongside this script)
+    ns prepare_data contextasr-bench
+
+    # Use pre-downloaded data
+    ns prepare_data contextasr-bench --data_dir=/path/to/ContextASR-Bench
+
+    # Skip audio download (JSONL only, not recommended)
+    ns prepare_data contextasr-bench --no-audio --skip_data_dir_check
+"""
+
+import argparse
+import json
+import tarfile
+from pathlib import Path
+
+HF_REPO_ID = "MrSupW/ContextASR-Bench"
+JSONL_FILENAME = "ContextASR-Speech_English.jsonl"
+AUDIO_TAR_PREFIX = "audio/ContextASR-Speech/English/ContextASR-Speech_English"
+NUM_AUDIO_TARS = 8
+
+PROMPT_CONTEXTLESS = "Transcribe the English audio into text, ensuring all punctuation marks are included."
+PROMPT_COARSE = (
+    "This audio belongs to the {domain_label} field. "
+    "Transcribe the English audio into text, ensuring all punctuation marks are included."
+)
+PROMPT_FINE = (
+    "This audio belongs to the {domain_label} field and may contain the following "
+    "words or phrases: {entity_list}. "
+    "Transcribe the English audio into text, ensuring all punctuation marks are included."
+)
+
+
+def download_dataset(download_dir):
+    """Download ContextASR-Speech English data from HuggingFace.
+
+    Downloads the JSONL metadata and 8 audio tar files (~22 GB total),
+    then extracts the tars. This can take 30-60 minutes depending on
+    network speed.
+    """
+    from huggingface_hub import hf_hub_download
+
+    download_dir = Path(download_dir)
+    download_dir.mkdir(parents=True, exist_ok=True)
+
+    jsonl_path = download_dir / JSONL_FILENAME
+    audio_dir = download_dir / "audio" / "ContextASR-Speech" / "English"
+
+    # Check if data already exists
+    if jsonl_path.exists() and audio_dir.exists():
+        wav_count = len(list(audio_dir.glob("*.wav")))
+        if wav_count > 15000:
+            print(f"Dataset already exists at {download_dir} ({wav_count} audio files found). Skipping download.")
+            return download_dir
+
+    print("=" * 70)
+    print("DOWNLOADING ContextASR-Bench English Speech data from HuggingFace")
+    print(f"Repository: {HF_REPO_ID}")
+    print(f"Destination: {download_dir}")
+    print("Total download size: ~22 GB (JSONL + 8 audio tar files)")
+    print("")
+    print("WARNING: This download may take 30-60 minutes depending on your")
+    print("network speed. You can skip this by pre-downloading the data and")
+    print("passing --data_dir=/path/to/ContextASR-Bench.")
+    print("=" * 70)
+
+    # Download JSONL
+    print(f"\n[1/{NUM_AUDIO_TARS + 1}] Downloading {JSONL_FILENAME}...")
+    hf_hub_download(
+        repo_id=HF_REPO_ID,
+        filename=JSONL_FILENAME,
+        repo_type="dataset",
+        local_dir=str(download_dir),
+    )
+    print(f"  Saved to {jsonl_path}")
+
+    # Download and extract audio tars
+    audio_dir.mkdir(parents=True, exist_ok=True)
+
+    for i in range(1, NUM_AUDIO_TARS + 1):
+        tar_filename = f"{AUDIO_TAR_PREFIX}_{i}.tar"
+        print(f"\n[{i + 1}/{NUM_AUDIO_TARS + 1}] Downloading {tar_filename}...")
+
+        local_tar = Path(
+            hf_hub_download(
+                repo_id=HF_REPO_ID,
+                filename=tar_filename,
+                repo_type="dataset",
+                local_dir=str(download_dir),
+            )
+        )
+
+        print(f"  Extracting {local_tar.name} to {audio_dir}...")
+        with tarfile.open(local_tar) as tf:
+            tf.extractall(path=audio_dir, filter="data")
+
+        print("  Extracted. Removing tar file to save space...")
+        local_tar.unlink()
+
+    wav_count = len(list(audio_dir.glob("*.wav")))
+    print(f"\nDownload complete! {wav_count} audio files extracted to {audio_dir}")
+
+    return download_dir
+
+
+def build_messages(prompt_text, audio_path, duration):
+    """Build OpenAI-format messages with audio metadata."""
+    return [
+        {
+            "role": "user",
+            "content": prompt_text,
+            "audio": {
+                "path": audio_path,
+                "duration": float(duration),
+            },
+        }
+    ]
+
+
+def format_entry(sample, mode, audio_prefix):
+    """Format a single dataset sample into a JSONL record for a given mode."""
+    audio_path = f"{audio_prefix}/{sample['audio']}"
+    entity_list = sample["entity_list"]
+    domain_label = sample["domain_label"]
+
+    if mode == "contextless":
+        prompt = PROMPT_CONTEXTLESS
+    elif mode == "coarse":
+        prompt = PROMPT_COARSE.format(domain_label=domain_label)
+    elif mode == "fine":
+        entity_str = ", ".join(entity_list)
+        prompt = PROMPT_FINE.format(domain_label=domain_label, entity_list=entity_str)
+    else:
+        raise ValueError(f"Unknown mode: {mode}")
+
+    return {
+        "messages": build_messages(prompt, audio_path, sample["duration"]),
+        "expected_answer": sample["text"],
+        "entity_list": entity_list,
+        "domain_label": domain_label,
+        "subset_for_metrics": domain_label,
+        "uniq_id": sample["uniq_id"],
+        "duration": float(sample["duration"]),
+        "audio_filepath": audio_path,
+    }
+
+
+def main():
+    """Parse arguments, download data if needed, and write per-mode JSONL splits."""
+    parser = argparse.ArgumentParser(description="Prepare ContextASR-Bench for NeMo Skills")
+    parser.add_argument(
+        "--data_dir",
+        type=str,
+        default=None,
+        help=(
+            "Path to ContextASR-Bench dataset root. If the directory already contains "
+            "ContextASR-Speech_English.jsonl, that data is used directly. If the "
+            "directory is empty or the file is missing, data will be downloaded there "
+            "automatically from HuggingFace. "
+            "If not provided, downloads to a 'data/' subdirectory next to this script."
+        ),
+    )
+    parser.add_argument(
+        "--audio-prefix",
+        type=str,
+        default=None,
+        help=(
+            "Override audio path prefix written into JSONL files. "
+            "Defaults to the data_dir value. Useful for container mount points "
+            "(e.g., --audio-prefix /data/contextasr-bench)."
+        ),
+    )
+    parser.add_argument(
+        "--no-audio",
+        action="store_true",
+        help="Skip downloading/verifying audio files (not recommended for actual evaluation)",
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(__file__).parent
+
+    data_dir = Path(args.data_dir) if args.data_dir else output_dir / "data"
+    jsonl_path = data_dir / JSONL_FILENAME
+
+    if jsonl_path.exists():
+        print(f"Using pre-downloaded data from {data_dir}")
+    elif args.no_audio:
+        raise FileNotFoundError(
+            f"Dataset file not found: {jsonl_path}\n"
+            f"Cannot use --no-audio when data has not been downloaded yet. "
+            f"Either run without --no-audio first to download, or point --data_dir "
+            f"to a directory that already contains {JSONL_FILENAME}."
+        )
+    else:
+        print(f"Data not found at {data_dir}. Downloading there...")
+        download_dataset(data_dir)
+
+    audio_prefix = args.audio_prefix if args.audio_prefix else str(data_dir)
+    audio_prefix = audio_prefix.rstrip("/")
+
+    jsonl_path = data_dir / JSONL_FILENAME
+
+    print(f"\nReading dataset from {jsonl_path}")
+    samples = []
+    with open(jsonl_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                samples.append(json.loads(line))
+
+    print(f"Loaded {len(samples)} samples")
+
+    if not args.no_audio:
+        sample_audio = Path(audio_prefix) / samples[0]["audio"]
+        if not sample_audio.exists():
+            print(
+                f"WARNING: Sample audio file not found at {sample_audio}. "
+                f"Audio paths may need adjustment via --audio-prefix."
+            )
+        else:
+            print(f"Audio files verified (sample check: {sample_audio})")
+
+    modes = {
+        "contextless": output_dir / "contextless" / "test.jsonl",
+        "coarse": output_dir / "coarse" / "test.jsonl",
+        "fine": output_dir / "fine" / "test.jsonl",
+    }
+
+    print("\nWriting JSONL splits...")
+    for mode_name, output_path in modes.items():
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        count = 0
+        with open(output_path, "w", encoding="utf-8") as fout:
+            for sample in samples:
+                entry = format_entry(sample, mode_name, audio_prefix)
+                fout.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                count += 1
+        print(f"  {mode_name}: wrote {count} samples to {output_path}")
+
+    print(f"\nDone. Total: {len(samples)} samples x 3 modes = {len(samples) * 3} records")
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_skills/evaluation/evaluator/__init__.py
+++ b/nemo_skills/evaluation/evaluator/__init__.py
@@ -55,9 +55,9 @@ _EVALUATOR_CLASS_MAP_PATHS = {
     "audio": "nemo_skills.evaluation.evaluator.audio:AudioEvaluator",
     "bird": "nemo_skills.evaluation.evaluator.bird:BirdEvaluator",
     "compute-eval": "nemo_skills.evaluation.evaluator.compute_eval:ComputeEvalEvaluator",
+    "contextasr": "nemo_skills.evaluation.evaluator.contextasr:ContextASREvaluator",
     "critpt": "nemo_skills.evaluation.evaluator.critpt:CritPtEvaluator",
     "dsbench": "nemo_skills.evaluation.evaluator.dsbench:DSBenchEvaluator",
-    "contextasr": "nemo_skills.evaluation.evaluator.contextasr:ContextASREvaluator",
 }
 
 # Validation: Ensure no overlap between class and function maps

--- a/nemo_skills/evaluation/evaluator/__init__.py
+++ b/nemo_skills/evaluation/evaluator/__init__.py
@@ -57,6 +57,7 @@ _EVALUATOR_CLASS_MAP_PATHS = {
     "compute-eval": "nemo_skills.evaluation.evaluator.compute_eval:ComputeEvalEvaluator",
     "critpt": "nemo_skills.evaluation.evaluator.critpt:CritPtEvaluator",
     "dsbench": "nemo_skills.evaluation.evaluator.dsbench:DSBenchEvaluator",
+    "contextasr": "nemo_skills.evaluation.evaluator.contextasr:ContextASREvaluator",
 }
 
 # Validation: Ensure no overlap between class and function maps

--- a/nemo_skills/evaluation/evaluator/contextasr.py
+++ b/nemo_skills/evaluation/evaluator/contextasr.py
@@ -227,7 +227,7 @@ def evaluate_contextasr_sample(data_point):
     """
     reference = data_point["expected_answer"]
     generation = data_point["generation"].strip()
-    entity_list = data_point.get("entity_list", [])
+    entity_list = data_point["entity_list"]
 
     norm_ref = simple_tokenize(reference)
     norm_hyp = simple_tokenize(generation)

--- a/nemo_skills/evaluation/evaluator/contextasr.py
+++ b/nemo_skills/evaluation/evaluator/contextasr.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ContextASR-Bench evaluator: WER, NE-WER, and NE-FNR metrics.
+
+Ports the official evaluation logic from the ContextASR-Bench paper:
+- Text normalization: contraction expansion, punctuation removal, single-letter merging
+- Entity extraction: exact match and fuzzy match (edit-distance based)
+- WER: word-level edit distance (I+D+S) / T
+- NE-WER: WER on fuzzy-matched entity token sequences
+- NE-FNR: 1 - (exact entity matches / total entities)
+"""
+
+import math
+from collections import defaultdict
+
+import editdistance
+import regex as re
+
+from nemo_skills.evaluation.evaluator.base import BaseEvaluator, BaseEvaluatorConfig
+from nemo_skills.utils import nested_dataclass
+
+EN_PUNCS_MID_STOP = re.escape(',;(){}[]"|:')
+EN_PUNCS_END_STOP = re.escape("!?.")
+EN_PUNCS_NON_STOP = re.escape('#$%&*+/<=>@\\^_`~"')
+CN_PUNCS_MID_STOP = re.escape("，；､、丶｟｠《》（）｢｣［］｛｝「｣『』【】〔〕〖〗〘〙〚〛〈〉｜：：")
+CN_PUNCS_END_STOP = re.escape("！？｡。")
+CN_PUNCS_NON_STOP = re.escape('＂＃＄％＆＇＊＋－／＜＝＞＠＼＾＿｀～〃〜〝〞〟〰〾〿‛""„‟…‧﹏·•・′″–—―')
+ALL_PUNCTUATIONS = (
+    EN_PUNCS_MID_STOP
+    + EN_PUNCS_END_STOP
+    + EN_PUNCS_NON_STOP
+    + CN_PUNCS_MID_STOP
+    + CN_PUNCS_END_STOP
+    + CN_PUNCS_NON_STOP
+)
+
+
+def _merge_single_letters(text):
+    """Combine adjacent single letters separated by spaces."""
+    words = text.split()
+    current = []
+    result = []
+    for word in words:
+        first_char = word[0]
+        remaining = word[1:] if len(word) > 1 else ""
+        if first_char.islower() or first_char.isupper():
+            if remaining == "" or remaining == "s" or remaining == "'s":
+                current.append(first_char)
+                if remaining:
+                    current.append(remaining)
+            else:
+                if current:
+                    result.append("".join(current))
+                    current = []
+                result.append(word)
+        else:
+            if current:
+                result.append("".join(current))
+                current = []
+            result.append(word)
+    if current:
+        result.append("".join(current))
+    return " ".join(result)
+
+
+def simple_tokenize(text):
+    """Normalize English text: expand contractions, remove punctuation, merge single letters, lowercase.
+
+    This replicates the ContextASR-Bench paper's normalization exactly.
+    """
+    import contractions
+
+    if text.isupper():
+        text = text.lower()
+    text = re.sub(r"^(O')\s|\s(O')$|\s(O')\s", " O ", text)
+    text = re.sub(r"^(o')\s|\s(o')$|\s(o')\s", " o ", text)
+    text = contractions.fix(text, leftovers=False, slang=False)
+    text = re.sub(rf"[{ALL_PUNCTUATIONS}]", " ", text)
+    text = text.replace("-", " ")
+    text = text.replace("'", " ")
+    ckj = r"\p{Han}\p{Hangul}\p{Hiragana}\p{Katakana}"
+    latin = r"\p{IsLatin}"
+    text = re.sub(rf"(?<=[{ckj}])(?=[{ckj}])", " ", text)
+    text = re.sub(rf"(?<=[{ckj}])(?={latin})", " ", text)
+    text = re.sub(rf"(?<={latin})(?=[{ckj}])", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    text = _merge_single_letters(text)
+    return text.lower()
+
+
+def extract_entities(text, entities_list, entity2count=None):
+    """Extract entities that appear exactly in the text, preserving order."""
+    text_tokens = text.split()
+    entities_with_tokens = [(entity.split(), entity) for entity in entities_list]
+
+    match_entity2count = defaultdict(int)
+    matches = []
+    n = len(text_tokens)
+
+    for i in range(n):
+        for e_tokens, e_str in entities_with_tokens:
+            length = len(e_tokens)
+            if i + length > n:
+                continue
+            if text_tokens[i : i + length] == e_tokens:
+                if entity2count and match_entity2count[e_str] >= entity2count[e_str]:
+                    continue
+                match_entity2count[e_str] += 1
+                matches.append((i, length, e_str))
+
+    matches.sort(key=lambda x: (x[0], x[1]))
+    return [entity for (_, _, entity) in matches]
+
+
+def extract_entities_fuzzy(text, entities_list):
+    """Fuzzy-match entities in text using edit distance, preserving order."""
+    text_tokens = text.split()
+    match_positions = []
+
+    for entity in entities_list:
+        entity_tokens = entity.split()
+        n = len(entity_tokens)
+        if n == 0:
+            continue
+        max_dist = math.ceil(n / 2) - 1
+        min_len = max(1, n - max_dist)
+        max_len = n + max_dist
+        lengths_to_search = [n] + list(range(n - 1, min_len - 1, -1)) + list(range(n + 1, max_len + 1))
+
+        next_start = 0
+        for start in range(len(text_tokens)):
+            if start < next_start:
+                continue
+            for length in lengths_to_search:
+                end = start + length
+                if end > len(text_tokens):
+                    break
+                window = text_tokens[start:end]
+                distance = editdistance.eval(window, entity_tokens)
+                if distance <= max_dist:
+                    next_start = end
+                    window_text = " ".join(window)
+                    search = re.search(re.escape(entity), window_text)
+                    if search:
+                        matched_entity = entity
+                        next_start -= len(window_text[search.end() :].strip().split())
+                    else:
+                        matched_entity = window_text
+                    match_positions.append((start, matched_entity))
+                    break
+
+    match_positions.sort(key=lambda x: (x[0], len(x[1].split())))
+    seen = set()
+    ordered = []
+    for pos, entity in match_positions:
+        if (pos, entity) not in seen:
+            seen.add((pos, entity))
+            ordered.append(entity)
+    return ordered
+
+
+def calculate_wer(hyp_tokens, ref_tokens):
+    """Word-level edit distance. Returns (wer, insertions, deletions, substitutions)."""
+    n_hyp = len(hyp_tokens)
+    n_ref = len(ref_tokens)
+
+    if n_ref == 0:
+        return (0.0, 0, 0, 0) if n_hyp == 0 else (float(n_hyp), n_hyp, 0, 0)
+
+    dp = [[0] * (n_ref + 1) for _ in range(n_hyp + 1)]
+    ins = [[0] * (n_ref + 1) for _ in range(n_hyp + 1)]
+    dels = [[0] * (n_ref + 1) for _ in range(n_hyp + 1)]
+    subs = [[0] * (n_ref + 1) for _ in range(n_hyp + 1)]
+
+    for i in range(1, n_hyp + 1):
+        dp[i][0] = i
+        ins[i][0] = i
+    for j in range(1, n_ref + 1):
+        dp[0][j] = j
+        dels[0][j] = j
+
+    for i in range(1, n_hyp + 1):
+        for j in range(1, n_ref + 1):
+            if hyp_tokens[i - 1] == ref_tokens[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1]
+                ins[i][j] = ins[i - 1][j - 1]
+                dels[i][j] = dels[i - 1][j - 1]
+                subs[i][j] = subs[i - 1][j - 1]
+            else:
+                insertion = dp[i - 1][j] + 1
+                deletion = dp[i][j - 1] + 1
+                substitution = dp[i - 1][j - 1] + 1
+                dp[i][j] = min(insertion, deletion, substitution)
+                if dp[i][j] == substitution:
+                    ins[i][j] = ins[i - 1][j - 1]
+                    dels[i][j] = dels[i - 1][j - 1]
+                    subs[i][j] = subs[i - 1][j - 1] + 1
+                elif dp[i][j] == deletion:
+                    ins[i][j] = ins[i][j - 1]
+                    dels[i][j] = dels[i][j - 1] + 1
+                    subs[i][j] = subs[i][j - 1]
+                else:
+                    ins[i][j] = ins[i - 1][j] + 1
+                    dels[i][j] = dels[i - 1][j]
+                    subs[i][j] = subs[i - 1][j]
+
+    wer = dp[n_hyp][n_ref] / n_ref
+    return (wer, ins[n_hyp][n_ref], dels[n_hyp][n_ref], subs[n_hyp][n_ref])
+
+
+def evaluate_contextasr_sample(data_point):
+    """Evaluate a single ContextASR-Bench sample.
+
+    Returns per-sample metrics dict with raw counts for corpus-level aggregation.
+    """
+    reference = data_point["expected_answer"]
+    generation = data_point["generation"].strip()
+    entity_list = data_point.get("entity_list", [])
+
+    norm_ref = simple_tokenize(reference)
+    norm_hyp = simple_tokenize(generation)
+
+    ref_tokens = norm_ref.split()
+    hyp_tokens = norm_hyp.split()
+
+    # WER
+    wer, wer_i, wer_d, wer_s = calculate_wer(hyp_tokens, ref_tokens)
+    wer_errors = wer_i + wer_d + wer_s
+    wer_ref_words = len(ref_tokens)
+
+    # Entity normalization
+    norm_entities = []
+    for entity in entity_list:
+        norm_entity = simple_tokenize(entity)
+        if norm_entity and norm_entity in norm_ref:
+            norm_entities.append(norm_entity)
+
+    updates = {
+        "wer": wer,
+        "wer_errors": wer_errors,
+        "wer_ref_words": wer_ref_words,
+        "is_correct": wer < 0.5,
+        "text": norm_ref,
+        "pred_text": norm_hyp,
+    }
+
+    if norm_entities:
+        ref_entities = extract_entities(norm_ref, norm_entities)
+        entity2count = defaultdict(int)
+        for e in ref_entities:
+            entity2count[e] += 1
+
+        hyp_exact_entities = extract_entities(norm_hyp, norm_entities, entity2count)
+        hyp_fuzzy_entities = extract_entities_fuzzy(norm_hyp, norm_entities)
+
+        # NE-WER: WER on fuzzy entity token sequences
+        ref_entity_text = " ".join(ref_entities)
+        hyp_fuzzy_text = " ".join(hyp_fuzzy_entities)
+        ne_ref_tokens = ref_entity_text.split()
+        ne_hyp_tokens = hyp_fuzzy_text.split()
+
+        if ne_ref_tokens:
+            ne_wer, ne_i, ne_d, ne_s = calculate_wer(ne_hyp_tokens, ne_ref_tokens)
+            ne_wer_errors = ne_i + ne_d + ne_s
+            ne_wer_ref_words = len(ne_ref_tokens)
+        else:
+            ne_wer = 0.0
+            ne_wer_errors = 0
+            ne_wer_ref_words = 0
+
+        # NE-FNR: 1 - exact_hits / total_entities
+        ne_total = len(ref_entities)
+        ne_hits = len(hyp_exact_entities)
+        ne_fnr = 1.0 - (ne_hits / ne_total) if ne_total > 0 else 0.0
+
+        updates.update(
+            {
+                "ne_wer": ne_wer,
+                "ne_wer_errors": ne_wer_errors,
+                "ne_wer_ref_words": ne_wer_ref_words,
+                "ne_fnr": ne_fnr,
+                "ne_fnr_hits": ne_hits,
+                "ne_fnr_total": ne_total,
+            }
+        )
+    else:
+        updates.update(
+            {
+                "ne_wer": 0.0,
+                "ne_wer_errors": 0,
+                "ne_wer_ref_words": 0,
+                "ne_fnr": 0.0,
+                "ne_fnr_hits": 0,
+                "ne_fnr_total": 0,
+            }
+        )
+
+    return updates
+
+
+@nested_dataclass(kw_only=True)
+class ContextASREvaluatorConfig(BaseEvaluatorConfig):
+    """Configuration for ContextASR-Bench evaluation."""
+
+    pass
+
+
+class ContextASREvaluator(BaseEvaluator):
+    """Evaluator for ContextASR-Bench: WER, NE-WER, NE-FNR."""
+
+    def __init__(self, config: dict, num_parallel_requests=10):
+        """Initialize with evaluator config and parallelism settings."""
+        super().__init__(config, num_parallel_requests)
+
+    async def eval_single(self, data_point: dict) -> dict:
+        """Evaluate a single sample, returning WER/NE-WER/NE-FNR metrics."""
+        return evaluate_contextasr_sample(data_point)

--- a/nemo_skills/evaluation/metrics/contextasr_metrics.py
+++ b/nemo_skills/evaluation/metrics/contextasr_metrics.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Metrics aggregation for ContextASR-Bench evaluation.
+
+Computes corpus-level:
+- WER: total word errors / total reference words
+- NE-WER: total entity word errors / total entity reference words
+- NE-FNR: 1 - (total entity hits / total entities)
+"""
+
+from nemo_skills.evaluation.metrics.base import BaseMetrics, as_int, as_percentage
+
+
+class ContextASRMetrics(BaseMetrics):
+    """Metrics class for ContextASR-Bench with corpus-level WER, NE-WER, NE-FNR."""
+
+    def __init__(self, compute_no_answer: bool = True, max_k: int = 1):
+        """Initialize accumulators for corpus-level WER, NE-WER, and NE-FNR."""
+        super().__init__(compute_no_answer=compute_no_answer)
+        self.max_k = max_k
+
+        self.wer_total_errors = 0
+        self.wer_total_ref_words = 0
+
+        self.ne_wer_total_errors = 0
+        self.ne_wer_total_ref_words = 0
+
+        self.ne_fnr_total_hits = 0
+        self.ne_fnr_total_entities = 0
+
+    def _get_score_dict(self, prediction):
+        """Extract the binary correctness score from a prediction (WER < 0.5)."""
+        return {"is_correct": prediction.get("is_correct", False)}
+
+    def get_incorrect_sample(self, prediction):
+        """Return a copy of the prediction marked as incorrect (for no-answer handling)."""
+        prediction = prediction.copy()
+        prediction["is_correct"] = False
+        return prediction
+
+    def update_common_metrics(self, agg_dict):
+        """Populate num_entries, avg_tokens, and gen_seconds into the aggregation dict."""
+        agg_dict["num_entries"] = self.total
+        agg_dict["avg_tokens"] = int(self.avg_tokens / self.total) if self.total > 0 else 0
+        if self.max_end_time > float("-inf") and self.min_start_time < float("inf"):
+            agg_dict["gen_seconds"] = int(self.max_end_time - self.min_start_time)
+
+    def update(self, predictions):
+        """Accumulate per-sample error counts for corpus-level metric computation."""
+        super().update(predictions)
+
+        predicted_answers = [pred.get("generation", "").strip() or None for pred in predictions]
+
+        for pred in predictions:
+            self.wer_total_errors += pred.get("wer_errors", 0)
+            self.wer_total_ref_words += pred.get("wer_ref_words", 0)
+            self.ne_wer_total_errors += pred.get("ne_wer_errors", 0)
+            self.ne_wer_total_ref_words += pred.get("ne_wer_ref_words", 0)
+            self.ne_fnr_total_hits += pred.get("ne_fnr_hits", 0)
+            self.ne_fnr_total_entities += pred.get("ne_fnr_total", 0)
+
+        self._compute_pass_at_k(predictions=predictions, predicted_answers=predicted_answers)
+        self._compute_majority_at_k(predictions=predictions, predicted_answers=predicted_answers)
+
+    def get_metrics(self):
+        """Compute corpus-level WER, NE-WER, NE-FNR percentages from accumulated counts."""
+        metrics_dict = super().get_metrics()
+
+        for _agg_mode, agg_metrics in metrics_dict.items():
+            if "correct" in agg_metrics:
+                agg_metrics["success_rate"] = agg_metrics["correct"]
+
+            if self.wer_total_ref_words > 0:
+                agg_metrics["wer"] = round(100.0 * self.wer_total_errors / self.wer_total_ref_words, 2)
+
+            if self.ne_wer_total_ref_words > 0:
+                agg_metrics["ne_wer"] = round(100.0 * self.ne_wer_total_errors / self.ne_wer_total_ref_words, 2)
+
+            if self.ne_fnr_total_entities > 0:
+                agg_metrics["ne_fnr"] = round(100.0 * (1.0 - self.ne_fnr_total_hits / self.ne_fnr_total_entities), 2)
+
+        return metrics_dict
+
+    def evaluations_to_print(self):
+        """Return the list of evaluation mode names to display."""
+        evals = [f"pass@{self.max_k}"]
+        if self.max_k > 1:
+            evals.extend([f"majority@{self.max_k}", f"pass@1[avg-of-{self.max_k}]"])
+        return evals
+
+    def metrics_to_print(self):
+        """Return ordered dict of metric names to formatters for display."""
+        base_metrics = {
+            "avg_tokens": as_int,
+            "gen_seconds": as_int,
+            "success_rate": as_percentage,
+        }
+
+        if self.compute_no_answer:
+            base_metrics["no_answer"] = as_percentage
+
+        if self.wer_total_ref_words > 0:
+            base_metrics["wer"] = as_percentage
+        if self.ne_wer_total_ref_words > 0:
+            base_metrics["ne_wer"] = as_percentage
+        if self.ne_fnr_total_entities > 0:
+            base_metrics["ne_fnr"] = as_percentage
+
+        base_metrics["num_entries"] = as_int
+        return base_metrics

--- a/nemo_skills/evaluation/metrics/contextasr_metrics.py
+++ b/nemo_skills/evaluation/metrics/contextasr_metrics.py
@@ -42,7 +42,7 @@ class ContextASRMetrics(BaseMetrics):
 
     def _get_score_dict(self, prediction):
         """Extract the binary correctness score from a prediction (WER < 0.5)."""
-        return {"is_correct": prediction.get("is_correct", False)}
+        return {"is_correct": prediction["is_correct"]}
 
     def get_incorrect_sample(self, prediction):
         """Return a copy of the prediction marked as incorrect (for no-answer handling)."""
@@ -61,15 +61,15 @@ class ContextASRMetrics(BaseMetrics):
         """Accumulate per-sample error counts for corpus-level metric computation."""
         super().update(predictions)
 
-        predicted_answers = [pred.get("generation", "").strip() or None for pred in predictions]
+        predicted_answers = [pred["generation"].strip() or None for pred in predictions]
 
         for pred in predictions:
-            self.wer_total_errors += pred.get("wer_errors", 0)
-            self.wer_total_ref_words += pred.get("wer_ref_words", 0)
-            self.ne_wer_total_errors += pred.get("ne_wer_errors", 0)
-            self.ne_wer_total_ref_words += pred.get("ne_wer_ref_words", 0)
-            self.ne_fnr_total_hits += pred.get("ne_fnr_hits", 0)
-            self.ne_fnr_total_entities += pred.get("ne_fnr_total", 0)
+            self.wer_total_errors += pred["wer_errors"]
+            self.wer_total_ref_words += pred["wer_ref_words"]
+            self.ne_wer_total_errors += pred["ne_wer_errors"]
+            self.ne_wer_total_ref_words += pred["ne_wer_ref_words"]
+            self.ne_fnr_total_hits += pred["ne_fnr_hits"]
+            self.ne_fnr_total_entities += pred["ne_fnr_total"]
 
         self._compute_pass_at_k(predictions=predictions, predicted_answers=predicted_answers)
         self._compute_majority_at_k(predictions=predictions, predicted_answers=predicted_answers)

--- a/nemo_skills/evaluation/metrics/contextasr_metrics.py
+++ b/nemo_skills/evaluation/metrics/contextasr_metrics.py
@@ -41,8 +41,13 @@ class ContextASRMetrics(BaseMetrics):
         self.ne_fnr_total_entities = 0
 
     def _get_score_dict(self, prediction):
-        """Extract the binary correctness score from a prediction (WER < 0.5)."""
-        return {"is_correct": prediction["is_correct"]}
+        """Extract the binary correctness score from a prediction (WER < 0.5).
+
+        Uses the standard ``correct`` key so the base class populates
+        ``pass@k["correct"]``, which ``get_metrics`` then surfaces as
+        ``success_rate``.
+        """
+        return {"correct": prediction["is_correct"]}
 
     def get_incorrect_sample(self, prediction):
         """Return a copy of the prediction marked as incorrect (for no-answer handling)."""
@@ -58,18 +63,32 @@ class ContextASRMetrics(BaseMetrics):
             agg_dict["gen_seconds"] = int(self.max_end_time - self.min_start_time)
 
     def update(self, predictions):
-        """Accumulate per-sample error counts for corpus-level metric computation."""
+        """Accumulate per-sample error counts for corpus-level metric computation.
+
+        ContextASR-Bench corpus-level WER/NE-WER/NE-FNR are defined per single
+        hypothesis: there is no canonical way to combine WER across k
+        hypotheses without reference comparison (which would defeat pass@k).
+        Multi-generation aggregation is therefore not supported here -- run
+        with a single greedy generation.
+        """
         super().update(predictions)
 
-        predicted_answers = [pred["generation"].strip() or None for pred in predictions]
+        if len(predictions) != 1:
+            raise ValueError(
+                f"ContextASRMetrics expects exactly 1 generation per sample, "
+                f"got {len(predictions)}. Run with a single greedy generation "
+                f"(num_random_seeds=1) for ContextASR-Bench."
+            )
 
-        for pred in predictions:
-            self.wer_total_errors += pred["wer_errors"]
-            self.wer_total_ref_words += pred["wer_ref_words"]
-            self.ne_wer_total_errors += pred["ne_wer_errors"]
-            self.ne_wer_total_ref_words += pred["ne_wer_ref_words"]
-            self.ne_fnr_total_hits += pred["ne_fnr_hits"]
-            self.ne_fnr_total_entities += pred["ne_fnr_total"]
+        pred = predictions[0]
+        predicted_answers = [pred["generation"].strip() or None]
+
+        self.wer_total_errors += pred["wer_errors"]
+        self.wer_total_ref_words += pred["wer_ref_words"]
+        self.ne_wer_total_errors += pred["ne_wer_errors"]
+        self.ne_wer_total_ref_words += pred["ne_wer_ref_words"]
+        self.ne_fnr_total_hits += pred["ne_fnr_hits"]
+        self.ne_fnr_total_entities += pred["ne_fnr_total"]
 
         self._compute_pass_at_k(predictions=predictions, predicted_answers=predicted_answers)
         self._compute_majority_at_k(predictions=predictions, predicted_answers=predicted_answers)

--- a/nemo_skills/evaluation/metrics/map_metrics.py
+++ b/nemo_skills/evaluation/metrics/map_metrics.py
@@ -30,8 +30,8 @@ from nemo_skills.evaluation.metrics.code_metrics import (
     SciCodeMetrics,
     SweBenchMetrics,
 )
-from nemo_skills.evaluation.metrics.critpt_metrics import CritPtMetrics
 from nemo_skills.evaluation.metrics.contextasr_metrics import ContextASRMetrics
+from nemo_skills.evaluation.metrics.critpt_metrics import CritPtMetrics
 from nemo_skills.evaluation.metrics.gradingbench_metrics import GradingBenchMetrics
 from nemo_skills.evaluation.metrics.hleaa_metrics import HLEAAMetrics
 from nemo_skills.evaluation.metrics.hotpotqa_metrics import HotpotQAMetrics

--- a/nemo_skills/evaluation/metrics/map_metrics.py
+++ b/nemo_skills/evaluation/metrics/map_metrics.py
@@ -31,6 +31,7 @@ from nemo_skills.evaluation.metrics.code_metrics import (
     SweBenchMetrics,
 )
 from nemo_skills.evaluation.metrics.critpt_metrics import CritPtMetrics
+from nemo_skills.evaluation.metrics.contextasr_metrics import ContextASRMetrics
 from nemo_skills.evaluation.metrics.gradingbench_metrics import GradingBenchMetrics
 from nemo_skills.evaluation.metrics.hleaa_metrics import HLEAAMetrics
 from nemo_skills.evaluation.metrics.hotpotqa_metrics import HotpotQAMetrics
@@ -98,6 +99,7 @@ METRICS_MAP = {
     "gradingbench": GradingBenchMetrics,
     "critpt": CritPtMetrics,
     "specdec": SpecdecMetrics,
+    "contextasr": ContextASRMetrics,
     "hotpotqa": HotpotQAMetrics,
     "hotpotqa_closedbook": functools.partial(HotpotQAMetrics, closed_book=True),
     "weighted-math": WeightedMathMetrics,

--- a/tests/gpu-tests/test_eval.py
+++ b/tests/gpu-tests/test_eval.py
@@ -18,10 +18,9 @@ from importlib import import_module
 from pathlib import Path
 
 import pytest
-from utils import require_env_var
-
 from nemo_skills.pipeline.cli import eval, prepare_data, run_cmd, wrap_arguments
 from tests.conftest import docker_rm
+from utils import require_env_var
 
 # Datasets excluded from test_aaa_prepare_and_eval_all_datasets
 # These don't support max_samples, require explicit parameters, or are very heavy to prepare
@@ -55,6 +54,7 @@ EXCLUDED_DATASETS = {
     "librispeech-pc",
     "musan",
     "numb3rs",
+    "contextasr-bench",  # audio benchmark, requires ~22 GB download
     # Excluded for the time being as compute eval requires either a CTK or local docker engine to run
     "compute-eval",
     # CritPt requires exactly 70 submissions and external API key (ARTIFICIAL_ANALYSIS_API_KEY)

--- a/tests/gpu-tests/test_eval.py
+++ b/tests/gpu-tests/test_eval.py
@@ -18,9 +18,10 @@ from importlib import import_module
 from pathlib import Path
 
 import pytest
+from utils import require_env_var
+
 from nemo_skills.pipeline.cli import eval, prepare_data, run_cmd, wrap_arguments
 from tests.conftest import docker_rm
-from utils import require_env_var
 
 # Datasets excluded from test_aaa_prepare_and_eval_all_datasets
 # These don't support max_samples, require explicit parameters, or are very heavy to prepare

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -55,6 +55,7 @@ DATASETS = [
     ("college_math", ["test"]),
     ("comp-math-24-25", ["test"]),
     ("mmau-pro", ["test"]),
+    ("contextasr-bench", ["test"]),
     ("audiobench", ["test"]),
     ("librispeech-pc", ["test"]),
     ("musan", ["test"]),


### PR DESCRIPTION
Follow-up PR to https://github.com/NVIDIA-NeMo/Skills/pull/1365

## Summary

- Adds [ContextASR-Bench](https://huggingface.co/datasets/MrSupW/ContextASR-Bench) as a benchmark group with three evaluation modes: `contextless`, `coarse` (domain context), and `fine` (domain + entity list context), evaluating how contextual information improves ASR transcription quality.
- Introduces a custom evaluator (`ContextASREvaluator`) and metrics class (`ContextASRMetrics`) that compute WER, Named Entity WER (NE-WER via fuzzy matching), and Named Entity False Negative Rate (NE-FNR) following the paper's evaluation methodology.
- The `prepare.py` script is self-contained — it auto-downloads ~22 GB of audio data from HuggingFace when not already present, with `--data_dir` serving as both "use existing data" and "download here".

### New files
| File | Purpose |
|------|---------|
| `nemo_skills/dataset/contextasr-bench/__init__.py` | Benchmark group config |
| `nemo_skills/dataset/contextasr-bench/prepare.py` | Data download + JSONL formatting |
| `nemo_skills/dataset/contextasr-bench/contextasr_score.py` | Cross-mode score aggregation |
| `nemo_skills/dataset/contextasr-bench/{contextless,coarse,fine}/__init__.py` | Per-mode config |
| `nemo_skills/evaluation/evaluator/contextasr.py` | Custom evaluator (WER, NE-WER, NE-FNR) |
| `nemo_skills/evaluation/metrics/contextasr_metrics.py` | Custom corpus-level metrics |

### Modified files
| File | Change |
|------|--------|
| `nemo_skills/evaluation/evaluator/__init__.py` | Register `contextasr` evaluator |
| `nemo_skills/evaluation/metrics/map_metrics.py` | Register `contextasr` metrics |
| `core/requirements.txt` | Add `contractions` dependency |
| `docs/evaluation/speech-audio.md` | Add ContextASR-Bench documentation |
| `tests/test_datasets.py` | Add benchmark discovery test |

### Verified against
Qwen3-Omni baseline (ad-hoc evaluation): exact match on WER, NE-WER, and NE-FNR across all three modes.

## Test plan
- [ ] `pytest tests/test_datasets.py` passes (benchmark is discoverable)
- [ ] `ns prepare_data contextasr-bench --data_dir=<path>` works with pre-downloaded data
- [ ] `ns prepare_data contextasr-bench --data_dir=<empty_dir>` downloads data to that directory
- [ ] Evaluator produces correct WER/NE-WER/NE-FNR on a known sample set
- [ ] GPU CI tests (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ContextASR‑Bench with three evaluation modes (contextless, coarse, fine), reporting WER, NE‑WER, NE‑FNR and per‑domain summaries; end‑to‑end support for dataset prep, evaluation runner, evaluator, and metrics.

* **Documentation**
  * Added full ContextASR‑Bench docs with dataset reference, modes, metrics, CLI data‑prep and eval workflows, and example result outputs.

* **Chores**
  * Added a new runtime dependency for text normalization.

* **Tests**
  * Registered the new dataset split and excluded it from broad preparer tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->