### PR TITLE
Add explicit sandbox mounts option

### DIFF
--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -65,6 +65,7 @@ def _create_llm_judge_tasks(
     sandbox_container,
     with_sandbox,
     keep_mounts_for_sandbox,
+    sandbox_mounts,
     run_after,
     reuse_code_exp,
     reuse_code,
@@ -108,6 +109,7 @@ def _create_llm_judge_tasks(
         sandbox_container=sandbox_container,
         with_sandbox=with_sandbox,
         keep_mounts_for_sandbox=keep_mounts_for_sandbox,
+        sandbox_mounts=sandbox_mounts,
         run_after=run_after,
         reuse_code_exp=reuse_code_exp,
         reuse_code=reuse_code,
@@ -289,6 +291,10 @@ def eval(
     keep_mounts_for_sandbox: bool = typer.Option(
         False,
         help="If True, will keep the mounts for the sandbox container. Note that, it is risky given that sandbox executes LLM commands and could potentially lead to data loss. So, we advise not to use this unless absolutely necessary.",
+    ),
+    sandbox_mounts: List[str] = typer.Option(
+        None,
+        help="Mounts to pass only to the sandbox container. Supports src:dst[:ro|rw].",
     ),
     check_mounted_paths: bool = typer.Option(False, help="Check if mounted paths are available on the remote machine"),
     log_samples: bool = typer.Option(
@@ -590,6 +596,7 @@ def eval(
                         script=sandbox_script,
                         container=sandbox_container or cluster_config["containers"]["sandbox"],
                         name=f"{task_name}_sandbox",
+                        mounts=sandbox_mounts,
                     )
                 )
 
@@ -770,6 +777,7 @@ def eval(
                     sandbox_container=sandbox_container,
                     with_sandbox=with_sandbox,
                     keep_mounts_for_sandbox=keep_mounts_for_sandbox,
+                    sandbox_mounts=sandbox_mounts,
                     run_after=run_after,
                     reuse_code_exp=reuse_code_exp,
                     reuse_code=reuse_code,

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -57,9 +57,9 @@ def _create_job_unified(
     partition: Optional[str],
     account: Optional[str],
     keep_mounts_for_sandbox: bool,
-    sandbox_mounts: Optional[List[str]],
     task_name: str,
     log_dir: str,
+    sandbox_mounts: Optional[List[str]] = None,
     sbatch_kwargs: Optional[Dict] = None,
     sandbox_env_overrides: Optional[List[str]] = None,
     main_container: Optional[str] = None,
@@ -85,9 +85,9 @@ def _create_job_unified(
         with_sandbox: Whether to include sandbox
         partition: Slurm partition
         keep_mounts_for_sandbox: Whether to keep mounts for sandbox
-        sandbox_mounts: Mounts to pass only to the sandbox container
         task_name: Name for the task
         log_dir: Directory for logs
+        sandbox_mounts: Mounts to pass only to the sandbox container
         sbatch_kwargs: Additional sbatch kwargs
 
     Returns:

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -57,6 +57,7 @@ def _create_job_unified(
     partition: Optional[str],
     account: Optional[str],
     keep_mounts_for_sandbox: bool,
+    sandbox_mounts: Optional[List[str]],
     task_name: str,
     log_dir: str,
     sbatch_kwargs: Optional[Dict] = None,
@@ -84,6 +85,7 @@ def _create_job_unified(
         with_sandbox: Whether to include sandbox
         partition: Slurm partition
         keep_mounts_for_sandbox: Whether to keep mounts for sandbox
+        sandbox_mounts: Mounts to pass only to the sandbox container
         task_name: Name for the task
         log_dir: Directory for logs
         sbatch_kwargs: Additional sbatch kwargs
@@ -152,6 +154,7 @@ def _create_job_unified(
                     script=sandbox_script,
                     container=sandbox_container or cluster_config["containers"]["sandbox"],
                     name=f"{task_name}_sandbox",
+                    mounts=sandbox_mounts,
                 )
                 components.append(sandbox_cmd)
 
@@ -336,6 +339,10 @@ def generate(
     keep_mounts_for_sandbox: bool = typer.Option(
         False,
         help="If True, will keep the mounts for the sandbox container. Note that, it is risky given that sandbox executes LLM commands and could potentially lead to data loss. So, we advise not to use this unless absolutely necessary.",
+    ),
+    sandbox_mounts: List[str] = typer.Option(
+        None,
+        help="Mounts to pass only to the sandbox container. Supports src:dst[:ro|rw].",
     ),
     check_mounted_paths: bool = typer.Option(False, help="Check if mounted paths are available on the remote machine"),
     log_samples: bool = typer.Option(
@@ -598,6 +605,7 @@ def generate(
                     partition=partition,
                     account=account,
                     keep_mounts_for_sandbox=keep_mounts_for_sandbox,
+                    sandbox_mounts=sandbox_mounts,
                     task_name=task_name,
                     log_dir=log_dir,
                     sbatch_kwargs=sbatch_kwargs,

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -215,15 +215,15 @@ def _create_job_unified(
 @typer_unpacker
 def generate(
     ctx: typer.Context,
-    cluster: str = typer.Option(
+    cluster: str | None = typer.Option(
         None,
         help="One of the configs inside config_dir or NEMO_SKILLS_CONFIG_DIR or ./cluster_configs. "
         "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
     ),
-    input_file: str = typer.Option(
+    input_file: str | None = typer.Option(
         None, help="Path to the input data file. Can either specify input_file or input_dir, but not both. "
     ),
-    input_dir: str = typer.Option(
+    input_dir: str | None = typer.Option(
         None,
         help="Path to the input data directory. Can either specify input_file or input_dir, but not both. "
         "If input_file is not provided, will use output-rs{{seed}}.jsonl inside input_dir as input_files. "
@@ -233,18 +233,18 @@ def generate(
     output_dir: str = typer.Option(..., help="Where to put results"),
     expname: str = typer.Option("generate", help="Nemo run experiment name"),
     generation_type: GenerationType | None = typer.Option(None, help="Type of generation to perform"),
-    generation_module: str = typer.Option(
+    generation_module: str | None = typer.Option(
         None,
         help="Path to the generation module to use. "
         "If not specified, will use the registered generation module for the "
         "generation type (which is required in this case).",
     ),
-    model: List[str] = typer.Option(
+    model: List[str] | None = typer.Option(
         None,
         help="Path to the model(s). CLI: space-separated. Python API: string or list. "
         "Single value broadcasts to all models for multi-model generation.",
     ),
-    server_address: List[str] = typer.Option(
+    server_address: List[str] | None = typer.Option(
         None,
         help="Server address(es). CLI: space-separated. Python API: string or list. "
         "Single value broadcasts to all models.",
@@ -254,7 +254,7 @@ def generate(
         help="Server type(s). CLI: space-separated. Python API: string or list. "
         "Single value broadcasts to all models.",
     ),
-    server_gpus: List[int] = typer.Option(
+    server_gpus: List[int] | None = typer.Option(
         None,
         help="Number of GPUs per model. CLI: space-separated ints. Python API: int or list. "
         "Single value broadcasts to all models.",
@@ -269,47 +269,47 @@ def generate(
         help="Server arguments per model. CLI: space-separated. Python API: string or list. "
         "Single value broadcasts to all models.",
     ),
-    server_entrypoint: List[str] = typer.Option(
+    server_entrypoint: List[str] | None = typer.Option(
         None,
         help="Server entrypoint(s). CLI: space-separated. Python API: string or list. "
         "Single value broadcasts to all models.",
     ),
-    server_container: List[str] = typer.Option(
+    server_container: List[str] | None = typer.Option(
         None,
         help="Container image(s). CLI: space-separated. Python API: string or list. "
         "Single value broadcasts to all models.",
     ),
-    main_container: str = typer.Option(None, help="Override container image for the main generation client"),
-    sandbox_container: str = typer.Option(None, help="Override container image for the sandbox"),
+    main_container: str | None = typer.Option(None, help="Override container image for the main generation client"),
+    sandbox_container: str | None = typer.Option(None, help="Override container image for the sandbox"),
     dependent_jobs: int = typer.Option(0, help="Specify this to launch that number of dependent jobs"),
-    mount_paths: str = typer.Option(None, help="Comma separated list of paths to mount on the remote machine"),
-    num_random_seeds: int = typer.Option(
+    mount_paths: str | None = typer.Option(None, help="Comma separated list of paths to mount on the remote machine"),
+    num_random_seeds: int | None = typer.Option(
         None, help="Specify if want to run many generations with high temperature for the same input"
     ),
-    random_seeds: str = typer.Option(
+    random_seeds: str | None = typer.Option(
         None,
         help="List of random seeds to use for generation. Separate with , or .. to specify range. "
         "Can provide a list directly when using through Python",
     ),
     starting_seed: int = typer.Option(0, help="Starting seed for random sampling"),
-    num_chunks: int = typer.Option(
+    num_chunks: int | None = typer.Option(
         None,
         help="Number of chunks to split the dataset into. If None, will not chunk the dataset.",
     ),
-    chunk_ids: str = typer.Option(
+    chunk_ids: str | None = typer.Option(
         None,
         help="List of explicit chunk ids to run. Separate with , or .. to specify range. "
         "Can provide a list directly when using through Python",
     ),
-    preprocess_cmd: str = typer.Option(None, help="Command to run before generation"),
-    postprocess_cmd: str = typer.Option(None, help="Command to run after generation"),
-    partition: str = typer.Option(
+    preprocess_cmd: str | None = typer.Option(None, help="Command to run before generation"),
+    postprocess_cmd: str | None = typer.Option(None, help="Command to run after generation"),
+    partition: str | None = typer.Option(
         None, help="Can specify if need interactive jobs or a specific non-default partition"
     ),
-    account: str = typer.Option(None, help="Can specify a non-default Slurm account"),
-    qos: str = typer.Option(None, help="Specify Slurm QoS, e.g. to request interactive nodes"),
-    time_min: str = typer.Option(None, help="If specified, will use as a time-min slurm parameter"),
-    run_after: List[str] = typer.Option(
+    account: str | None = typer.Option(None, help="Can specify a non-default Slurm account"),
+    qos: str | None = typer.Option(None, help="Specify Slurm QoS, e.g. to request interactive nodes"),
+    time_min: str | None = typer.Option(None, help="If specified, will use as a time-min slurm parameter"),
+    run_after: List[str] | None = typer.Option(
         None, help="Can specify a list of expnames that need to be completed before this one starts"
     ),
     reuse_code: bool = typer.Option(
@@ -319,19 +319,19 @@ def generate(
         "the last submitted experiment in the current Python session, so set to False to disable "
         "(or provide reuse_code_exp to override).",
     ),
-    reuse_code_exp: str = typer.Option(
+    reuse_code_exp: str | None = typer.Option(
         None,
         help="If specified, will reuse the code from this experiment. "
         "Can provide an experiment name or an experiment object if running from code.",
     ),
-    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
-    log_dir: str = typer.Option(None, help="Can specify a custom location for slurm logs."),
+    config_dir: str | None = typer.Option(None, help="Can customize where we search for cluster configs"),
+    log_dir: str | None = typer.Option(None, help="Can specify a custom location for slurm logs."),
     exclusive: bool | None = typer.Option(None, help="If set will add exclusive flag to the slurm job."),
-    rerun_done: bool = typer.Option(
+    rerun_done: bool | None = typer.Option(
         False, help="If True, will re-run jobs even if a corresponding '.done' file already exists"
     ),
     with_sandbox: bool = typer.Option(False, help="If True, will start a sandbox container alongside this job"),
-    sandbox_env_overrides: List[str] = typer.Option(
+    sandbox_env_overrides: List[str] | None = typer.Option(
         None,
         help="Extra environment variables for the sandbox container in KEY=VALUE format. "
         "E.g., --sandbox-env-overrides NEMO_SKILLS_SANDBOX_BLOCK_NETWORK=1 to enable network blocking.",
@@ -340,7 +340,7 @@ def generate(
         False,
         help="If True, will keep the mounts for the sandbox container. Note that, it is risky given that sandbox executes LLM commands and could potentially lead to data loss. So, we advise not to use this unless absolutely necessary.",
     ),
-    sandbox_mounts: List[str] = typer.Option(
+    sandbox_mounts: List[str] | None = typer.Option(
         None,
         help="Mounts to pass only to the sandbox container. Supports src:dst[:ro|rw].",
     ),
@@ -351,11 +351,11 @@ def generate(
         "Requires WANDB_API_KEY to be set in the environment. "
         "Use wandb_name/wandb_group/wandb_project to specify where to log.",
     ),
-    wandb_name: str = typer.Option(
+    wandb_name: str | None = typer.Option(
         None,
         help="Name of the wandb group to sync samples to. If not specified, but log_samples=True, will use expname.",
     ),
-    wandb_group: str = typer.Option(None, help="Name of the wandb group to sync samples to."),
+    wandb_group: str | None = typer.Option(None, help="Name of the wandb group to sync samples to."),
     wandb_project: str = typer.Option(
         "nemo-skills",
         help="Name of the wandb project to sync samples to.",
@@ -375,8 +375,8 @@ def generate(
         "",
         help="Additional sbatch kwargs to pass to the job scheduler. Values should be provided as a JSON string or as a `dict` if invoking from code.",
     ),
-    _reuse_exp: str = typer.Option(None, help="Internal option to reuse an experiment object.", hidden=True),
-    _task_dependencies: List[str] = typer.Option(
+    _reuse_exp: str | None = typer.Option(None, help="Internal option to reuse an experiment object.", hidden=True),
+    _task_dependencies: List[str] | None = typer.Option(
         None, help="Internal option to specify task dependencies.", hidden=True
     ),
 ):
@@ -400,7 +400,8 @@ def generate(
     extra_arguments = f"{' '.join(ctx.args)}"
     LOG.info("Starting generation job")
     LOG.info("Extra arguments that will be passed to the underlying script: %s", extra_arguments)
-
+    if (sandbox_mounts or keep_mounts_for_sandbox) and not with_sandbox:
+        raise ValueError("`sandbox_mounts` or `keep_mounts_for_sandbox` requires `with_sandbox=True`.")
     # Normalize model configuration to list
     models_list = pipeline_utils.normalize_models_config(model)
     num_models = len(models_list)

--- a/nemo_skills/pipeline/nemo_gym_rollouts.py
+++ b/nemo_skills/pipeline/nemo_gym_rollouts.py
@@ -48,6 +48,7 @@ Example usage:
 """
 
 import logging
+from typing import List
 
 import typer
 
@@ -107,6 +108,10 @@ def nemo_gym_rollouts(
         "If not specified, uses cluster_config['containers'][server_type].",
     ),
     with_sandbox: bool = typer.Option(False, help="If True, start a sandbox container for code execution"),
+    sandbox_mounts: List[str] = typer.Option(
+        None,
+        help="Mounts to pass only to the sandbox container. Supports src:dst[:ro|rw].",
+    ),
     gym_container: str = typer.Option(
         None,
         help="Container image path/ref (e.g. a .sqsh file or docker:// reference) for the "
@@ -346,6 +351,7 @@ def nemo_gym_rollouts(
                 script=sandbox_script,
                 container=cluster_config["containers"]["sandbox"],
                 name=f"{expname}_sandbox{job_suffix}",
+                mounts=sandbox_mounts,
             )
             components.append(sandbox_cmd)
             LOG.info(f"Job{job_suffix}: sandbox on port {sandbox_script.port}")

--- a/nemo_skills/pipeline/nemo_gym_rollouts.py
+++ b/nemo_skills/pipeline/nemo_gym_rollouts.py
@@ -89,8 +89,8 @@ def nemo_gym_rollouts(
     input_file: str = typer.Option(..., help="Path to input JSONL file for rollout collection"),
     output_dir: str = typer.Option(..., help="Directory for rollout outputs. Output file will be rollouts.jsonl"),
     expname: str = typer.Option("nemo_gym_rollouts", help="NeMo Run experiment name"),
-    model: str = typer.Option(None, help="Path to model or model name for the policy server"),
-    server_address: str = typer.Option(
+    model: str | None = typer.Option(None, help="Path to model or model name for the policy server"),
+    server_address: str | None = typer.Option(
         None,
         help="Address of pre-hosted server (e.g., http://localhost:8000/v1). "
         "If provided, skips self-hosted server setup.",
@@ -108,11 +108,11 @@ def nemo_gym_rollouts(
         "If not specified, uses cluster_config['containers'][server_type].",
     ),
     with_sandbox: bool = typer.Option(False, help="If True, start a sandbox container for code execution"),
-    sandbox_mounts: List[str] = typer.Option(
+    sandbox_mounts: List[str] | None = typer.Option(
         None,
         help="Mounts to pass only to the sandbox container. Supports src:dst[:ro|rw].",
     ),
-    gym_container: str = typer.Option(
+    gym_container: str | None = typer.Option(
         None,
         help="Container image path/ref (e.g. a .sqsh file or docker:// reference) for the "
         "NeMo Gym rollouts step. If not specified, uses "
@@ -127,23 +127,23 @@ def nemo_gym_rollouts(
         "dummy",
         help="API key for policy server. Use 'dummy' for local vLLM servers.",
     ),
-    policy_model_name: str = typer.Option(
+    policy_model_name: str | None = typer.Option(
         None,
         help="Model name for policy server. Required for pre-hosted servers. "
         "For self-hosted, defaults to the model path if not specified.",
     ),
-    partition: str = typer.Option(None, help="Cluster partition to use"),
-    qos: str = typer.Option(None, help="Specify Slurm QoS"),
-    time_min: str = typer.Option(None, help="Slurm time-min parameter"),
-    config_dir: str = typer.Option(None, help="Custom directory for cluster configs"),
-    log_dir: str = typer.Option(None, help="Custom location for logs"),
+    partition: str | None = typer.Option(None, help="Cluster partition to use"),
+    qos: str | None = typer.Option(None, help="Specify Slurm QoS"),
+    time_min: str | None = typer.Option(None, help="Slurm time-min parameter"),
+    config_dir: str | None = typer.Option(None, help="Custom directory for cluster configs"),
+    log_dir: str | None = typer.Option(None, help="Custom location for logs"),
     exclusive: bool | None = typer.Option(None, help="Add exclusive flag to slurm job"),
-    num_random_seeds: int = typer.Option(
+    num_random_seeds: int | None = typer.Option(
         None,
         help="Number of parallel rollout jobs to run. Each job writes to rollouts-rs{i}.jsonl. "
         "Use this to scale rollout collection across multiple nodes.",
     ),
-    random_seeds: str = typer.Option(
+    random_seeds: str | None = typer.Option(
         None,
         help="Explicit list of seed indices to run (comma-separated, e.g., '0,2,5,7'). "
         "Overrides num_random_seeds. Can provide a list directly when using through Python.",
@@ -193,6 +193,8 @@ def nemo_gym_rollouts(
     extra_arguments = " ".join(ctx.args)
     LOG.info("Starting NeMo Gym rollouts pipeline")
     LOG.info(f"Extra arguments: {extra_arguments}")
+    # if sandbox_mounts and not with_sandbox:
+    #     raise ValueError("--sandbox-mounts requires --with-sandbox")
 
     # Parse config paths
     config_paths_list = [p.strip() for p in config_paths.split(",") if p.strip()]

--- a/nemo_skills/pipeline/nemo_gym_rollouts.py
+++ b/nemo_skills/pipeline/nemo_gym_rollouts.py
@@ -193,8 +193,8 @@ def nemo_gym_rollouts(
     extra_arguments = " ".join(ctx.args)
     LOG.info("Starting NeMo Gym rollouts pipeline")
     LOG.info(f"Extra arguments: {extra_arguments}")
-    # if sandbox_mounts and not with_sandbox:
-    #     raise ValueError("--sandbox-mounts requires --with-sandbox")
+    if sandbox_mounts and not with_sandbox:
+        raise ValueError("--sandbox-mounts requires --with-sandbox")
 
     # Parse config paths
     config_paths_list = [p.strip() for p in config_paths.split(",") if p.strip()]

--- a/nemo_skills/pipeline/nemo_rl/grpo.py
+++ b/nemo_skills/pipeline/nemo_rl/grpo.py
@@ -320,6 +320,10 @@ def grpo_nemo_rl(
         "Can provide an experiment name or an experiment object if running from code.",
     ),
     with_sandbox: bool = typer.Option(False, help="If True, will start a sandbox container alongside this job"),
+    sandbox_mounts: List[str] = typer.Option(
+        None,
+        help="Mounts to pass only to the sandbox container. Supports src:dst[:ro|rw].",
+    ),
     config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
     log_dir: str = typer.Option(
         None,
@@ -483,6 +487,7 @@ def grpo_nemo_rl(
                     sbatch_kwargs=sbatch_kwargs,
                     heterogeneous=True if server_config is not None else False,
                     with_sandbox=with_sandbox,
+                    sandbox_mounts=sandbox_mounts,
                     with_ray=True,
                     installation_command=installation_command,
                     skip_hf_home_check=skip_hf_home_check,

--- a/nemo_skills/pipeline/prepare_data.py
+++ b/nemo_skills/pipeline/prepare_data.py
@@ -138,6 +138,10 @@ def prepare_data(
         "sandbox executes LLM commands and could potentially lead to data loss. "
         "So, we advise not to use this unless absolutely necessary.",
     ),
+    sandbox_mounts: List[str] = typer.Option(
+        None,
+        help="Mounts to pass only to the sandbox container. Supports src:dst[:ro|rw].",
+    ),
     log_dir: str = typer.Option(None, help="Custom location for slurm logs"),
     exclusive: bool | None = typer.Option(None, help="If set will add exclusive flag to the slurm job."),
     check_mounted_paths: bool = typer.Option(False, help="Check mounted paths availability"),
@@ -253,6 +257,7 @@ def prepare_data(
         config_dir=config_dir,
         with_sandbox=with_sandbox,
         keep_mounts_for_sandbox=keep_mounts_for_sandbox,
+        sandbox_mounts=sandbox_mounts,
         log_dir=log_dir,
         exclusive=exclusive,
         check_mounted_paths=check_mounted_paths,

--- a/nemo_skills/pipeline/run_cmd.py
+++ b/nemo_skills/pipeline/run_cmd.py
@@ -102,6 +102,10 @@ def run_cmd(
         False,
         help="If True, will keep the mounts for the sandbox container. Note that, it is risky given that sandbox executes LLM commands and could potentially lead to data loss. So, we advise not to use this unless absolutely necessary.",
     ),
+    sandbox_mounts: List[str] = typer.Option(
+        None,
+        help="Mounts to pass only to the sandbox container. Supports src:dst[:ro|rw].",
+    ),
     log_dir: str = typer.Option(
         None,
         help="Can specify a custom location for slurm logs. "
@@ -203,6 +207,7 @@ def run_cmd(
                 server_config=server_config,
                 with_sandbox=with_sandbox,
                 keep_mounts_for_sandbox=keep_mounts_for_sandbox,
+                sandbox_mounts=sandbox_mounts,
                 sandbox_port=None if get_random_port else 6000,
                 sandbox_container=sandbox_container,
                 run_after=run_after,

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -15,6 +15,7 @@ import logging
 import signal
 import subprocess
 import time
+from typing import List
 
 import typer
 from nemo_run import SSHTunnel
@@ -128,6 +129,7 @@ def launch_server(
     account=None,
     with_sandbox=False,
     keep_mounts_for_sandbox=False,
+    sandbox_mounts=None,
     server_port=None,
     sandbox_port=None,
     main_container=None,
@@ -184,6 +186,7 @@ def launch_server(
         server_config=server_config,
         with_sandbox=with_sandbox,
         keep_mounts_for_sandbox=keep_mounts_for_sandbox,
+        sandbox_mounts=sandbox_mounts,
         sandbox_port=sandbox_port,
         sandbox_container=sandbox_container,
         sbatch_kwargs=sbatch_kwargs,
@@ -231,6 +234,10 @@ def start_server(
     keep_mounts_for_sandbox: bool = typer.Option(
         False,
         help="If True, will keep the mounts for the sandbox container. Note that, it is risky given that sandbox executes LLM commands and could potentially lead to data loss. So, we advise not to use this unless absolutely necessary.",
+    ),
+    sandbox_mounts: List[str] = typer.Option(
+        None,
+        help="Mounts to pass only to the sandbox container. Supports src:dst[:ro|rw].",
     ),
     launch_chat_interface: bool = typer.Option(
         False, help="If True, will launch a gradio app that provides chat with the model"
@@ -285,6 +292,7 @@ def start_server(
         account=account,
         with_sandbox=with_sandbox,
         keep_mounts_for_sandbox=keep_mounts_for_sandbox,
+        sandbox_mounts=sandbox_mounts,
         server_port=server_port,
         sandbox_port=sandbox_port,
         main_container=main_container,

--- a/nemo_skills/pipeline/utils/__init__.py
+++ b/nemo_skills/pipeline/utils/__init__.py
@@ -63,6 +63,7 @@ from nemo_skills.pipeline.utils.mounts import (
     get_mounts_from_config,
     get_unmounted_path,
     is_mounted_filepath,
+    normalize_mounts_list,
     resolve_mount_paths,
 )
 from nemo_skills.pipeline.utils.packager import (

--- a/nemo_skills/pipeline/utils/declarative.py
+++ b/nemo_skills/pipeline/utils/declarative.py
@@ -36,7 +36,7 @@ from nemo_skills.pipeline.utils.exp import (
     get_packaging_job_key,
     tunnel_hash,
 )
-from nemo_skills.pipeline.utils.mounts import get_mounts_from_config, is_mounted_filepath
+from nemo_skills.pipeline.utils.mounts import get_mounts_from_config, is_mounted_filepath, normalize_mounts_list
 from nemo_skills.pipeline.utils.scripts import SandboxScript
 from nemo_skills.pipeline.utils.server import wrap_python_path
 from nemo_skills.utils import get_logger_name
@@ -303,7 +303,11 @@ class Command:
         # (in which case Stage A's resolved_mounts alone loses that signal).
         keep_mounts = getattr(self.script, "keep_mounts", True)
         if self.mounts is not None:
-            resolved_mounts = self.mounts
+            if isinstance(self.script, SandboxScript):
+                resolved_mounts = normalize_mounts_list(self.mounts, allow_rw_mode=True)
+                keep_mounts = False
+            else:
+                resolved_mounts = self.mounts
         else:
             resolved_mounts = None if keep_mounts else []
 

--- a/nemo_skills/pipeline/utils/exp.py
+++ b/nemo_skills/pipeline/utils/exp.py
@@ -707,7 +707,9 @@ def add_task(
             het_group_indices.append(het_group)
         het_group += 1
         LOG.info("Sandbox command: %s", commands[-1])
-
+    else:
+        if sandbox_mounts or keep_mounts_for_sandbox:
+            raise ValueError("`sandbox_mounts` or `keep_mounts_for_sandbox` requires `with_sandbox=True`.")
     # If server wasn't added first (because client needs GPUs or server doesn't need GPUs), add it now
     if server_config is not None and not server_goes_first:
         add_server_tasks()

--- a/nemo_skills/pipeline/utils/exp.py
+++ b/nemo_skills/pipeline/utils/exp.py
@@ -41,6 +41,7 @@ from nemo_skills.pipeline.utils.mounts import (
     get_mounts_from_config,
     get_unmounted_path,
     is_mounted_filepath,
+    normalize_mounts_list,
 )
 from nemo_skills.pipeline.utils.packager import (
     get_packager,
@@ -446,6 +447,7 @@ def add_task(
     with_sandbox=False,
     sandbox_container=None,
     keep_mounts_for_sandbox=False,
+    sandbox_mounts: list[str] | None = None,
     sandbox_port: int | None = None,
     server_config=None,
     n_servers: int = 1,
@@ -663,6 +665,10 @@ def add_task(
 
         with temporary_env_update(cluster_config, sandbox_env_updates):
             commands.append(get_sandbox_command(cluster_config))
+            if sandbox_mounts is not None:
+                sandbox_exec_mounts = normalize_mounts_list(sandbox_mounts, allow_rw_mode=True)
+            else:
+                sandbox_exec_mounts = None if keep_mounts_for_sandbox else []
             sandbox_executor = get_executor(
                 cluster_config=cluster_config,
                 container=sandbox_container or cluster_config["containers"]["sandbox"],
@@ -671,7 +677,7 @@ def add_task(
                 gpus_per_node=0,
                 partition=partition,
                 account=account,
-                mounts=None if keep_mounts_for_sandbox else [],
+                mounts=sandbox_exec_mounts,
                 dependencies=dependencies,
                 job_name=task_name,
                 log_dir=log_dir,

--- a/nemo_skills/pipeline/utils/mounts.py
+++ b/nemo_skills/pipeline/utils/mounts.py
@@ -396,20 +396,20 @@ def check_remote_mount_directories(directories: list, cluster_config: dict, exit
         raise ValueError(f"Unsupported executor: {cluster_config.get('executor')}")
 
 
-def get_mounts_from_config(cluster_config: dict):
+def normalize_mounts_list(mounts: list[str], allow_rw_mode: bool = False):
     """
     Determines if there are mount paths that are being passed via environment variables.
-    Selects the key in the cluster config called `mounts` which is a list of strings.
-    Each string is in the format of `<str | {env_var}>:<str | {env_var}>` where `env_var`
+    Each string is in the format of `<str | {env_var} | ${env_var}>:<str | {env_var} | ${env_var}>` where `env_var`
     is the name of the environment variable.
 
     Args:
-        cluster_config (dict): cluster config dictionary
+        mounts (list[str]): mounts to resolve.
+        allow_rw_mode (bool): whether to allow `src:dst:ro` and `src:dst:rw` mounts.
 
     Returns:
         list: updated list of mounts
     """
-    mounts = cluster_config.get("mounts", [])
+    mounts = list(mounts)
 
     # if there are env_mounts, we will add the mounts from the env_mounts
     for mount_id in range(len(mounts)):
@@ -423,7 +423,19 @@ def get_mounts_from_config(cluster_config: dict):
         if "$" in mount:
             mount = os.path.expandvars(mount)
 
-        mount_source, mount_target = mount.split(":")
+        parts = mount.split(":")
+        if len(parts) != 2 and not (allow_rw_mode and len(parts) == 3):
+            raise ValueError(
+                f"Invalid mount format: {mount}. "
+                "Expected src:dst" + (" or src:dst:mode." if allow_rw_mode else ".")
+            )
+
+        mount_source, mount_target = parts[0], parts[1]
+        mount_mode = parts[2] if len(parts) == 3 else None
+        if not mount_source or not mount_target:
+            raise ValueError(f"Invalid mount format: {mount}. Source and target paths must not be empty.")
+        if mount_mode is not None and mount_mode not in {"ro", "rw"}:
+            raise ValueError(f"Invalid mount mode: {mount_mode} in `{mount}`. Supported mount modes are `ro` and `rw`.")
 
         # Then handle {VAR} style for full path replacement (legacy support)
         if mount_source[0] == "{" and mount_source[-1] == "}":
@@ -450,6 +462,24 @@ def get_mounts_from_config(cluster_config: dict):
 
         # add the mount to the list of mounts
         resolved_mount = f"{mount_source}:{mount_target}"
+        if mount_mode is not None:
+            resolved_mount = f"{resolved_mount}:{mount_mode}"
         mounts[mount_id] = resolved_mount
 
     return mounts
+
+
+def get_mounts_from_config(cluster_config: dict):
+    """
+    Selects the key in the cluster config called `mounts` which is a list of strings.
+    Normalizes the mount paths to resolve environment variables.
+    Each string is in the format of `<str | {env_var} | ${env_var}>:<str | {env_var} | ${env_var}>` where `env_var`
+    is the name of the environment variable.
+
+    Args:
+        cluster_config (dict): cluster config dictionary
+
+    Returns:
+        list: updated list of mounts
+    """
+    return normalize_mounts_list(cluster_config.get("mounts", []))

--- a/nemo_skills/pipeline/utils/mounts.py
+++ b/nemo_skills/pipeline/utils/mounts.py
@@ -426,8 +426,7 @@ def normalize_mounts_list(mounts: list[str], allow_rw_mode: bool = False):
         parts = mount.split(":")
         if len(parts) != 2 and not (allow_rw_mode and len(parts) == 3):
             raise ValueError(
-                f"Invalid mount format: {mount}. "
-                "Expected src:dst" + (" or src:dst:mode." if allow_rw_mode else ".")
+                f"Invalid mount format: {mount}. Expected src:dst" + (" or src:dst:mode." if allow_rw_mode else ".")
             )
 
         mount_source, mount_target = parts[0], parts[1]
@@ -435,7 +434,9 @@ def normalize_mounts_list(mounts: list[str], allow_rw_mode: bool = False):
         if not mount_source or not mount_target:
             raise ValueError(f"Invalid mount format: {mount}. Source and target paths must not be empty.")
         if mount_mode is not None and mount_mode not in {"ro", "rw"}:
-            raise ValueError(f"Invalid mount mode: {mount_mode} in `{mount}`. Supported mount modes are `ro` and `rw`.")
+            raise ValueError(
+                f"Invalid mount mode: {mount_mode} in `{mount}`. Supported mount modes are `ro` and `rw`."
+            )
 
         # Then handle {VAR} style for full path replacement (legacy support)
         if mount_source[0] == "{" and mount_source[-1] == "}":

--- a/nemo_skills/pipeline/verl/ppo.py
+++ b/nemo_skills/pipeline/verl/ppo.py
@@ -296,6 +296,10 @@ def ppo_verl(
         False,
         help="If True, will use the sandbox to run the training job",
     ),
+    sandbox_mounts: List[str] = typer.Option(
+        None,
+        help="Mounts to pass only to the sandbox container. Supports src:dst[:ro|rw].",
+    ),
     script_module: str = typer.Option("verl.trainer.main_ppo", help="The script module to run. "),
     verl_config_dir: str = typer.Option(None, help="The directory containing the Verl config files. "),
     verl_config_name: str = typer.Option(None, help="The name of the Verl config file to use. "),
@@ -430,6 +434,7 @@ def ppo_verl(
                 sbatch_kwargs=parse_kwargs(sbatch_kwargs, exclusive=exclusive, qos=qos, time_min=time_min),
                 heterogeneous=True if server_config is not None else False,
                 with_sandbox=with_sandbox,
+                sandbox_mounts=sandbox_mounts,
                 installation_command=installation_command,
                 skip_hf_home_check=skip_hf_home_check,
             )

--- a/tests/gpu-tests/test_sandbox_mounts.py
+++ b/tests/gpu-tests/test_sandbox_mounts.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nemo_skills.pipeline.cli import run_cmd, wrap_arguments
+from tests.conftest import docker_rm
+
+
+@pytest.mark.gpu
+def test_sandbox_mounts_read_only_functional():
+    base_dir = Path("/tmp/nemo-skills-tests/sandbox-mounts-read-only")
+    sandbox_source = base_dir / "source"
+    output_file = base_dir / "result.json"
+    script_file = base_dir / "check_sandbox_mount.py"
+
+    docker_rm([str(base_dir)])
+    sandbox_source.mkdir(parents=True)
+    sandbox_source.joinpath("input.txt").write_text("sandbox-mount-data\n")
+
+    script_file.write_text(
+        f"""
+import asyncio
+import json
+from pathlib import Path
+
+from nemo_skills.code_execution.sandbox import get_sandbox
+
+
+async def main():
+    sandbox = get_sandbox("local")
+    try:
+        read_result, _ = await sandbox.execute_code(
+            "cat /sandbox-ro/input.txt",
+            language="shell",
+            timeout=10,
+        )
+        write_result, _ = await sandbox.execute_code(
+            "touch /sandbox-ro/should-not-exist",
+            language="shell",
+            timeout=10,
+        )
+    finally:
+        await sandbox.close()
+
+    Path({str(output_file)!r}).write_text(
+        json.dumps({{"read": read_result, "write": write_result}}, sort_keys=True)
+    )
+
+
+asyncio.run(main())
+""".lstrip()
+    )
+
+    run_cmd(
+        cluster="test-local",
+        config_dir=Path(__file__).parent,
+        log_dir=str(base_dir / "logs"),
+        with_sandbox=True,
+        sandbox_mounts=[f"{sandbox_source}:/sandbox-ro:ro"],
+        ctx=wrap_arguments(f"python {script_file}"),
+    )
+
+    result = json.loads(output_file.read_text())
+
+    assert result["read"]["process_status"] == "completed"
+    assert result["read"]["stdout"] == "sandbox-mount-data\n"
+    assert result["write"]["process_status"] == "error"
+    assert not sandbox_source.joinpath("should-not-exist").exists()

--- a/tests/test_declarative_pipeline.py
+++ b/tests/test_declarative_pipeline.py
@@ -1055,6 +1055,45 @@ class TestMountsResolution:
         mounts = self._run_pipeline_and_capture_mounts(command_mounts=["/a:/b"], keep_mounts_attr=True)
         assert mounts == self.CLUSTER_MOUNTS + ["/a:/b"]
 
+    @patch("nemo_skills.pipeline.utils.scripts.server.sandbox_command", return_value=("echo sandbox", {}))
+    @patch("nemo_skills.pipeline.utils.scripts.server.get_free_port", return_value=12345)
+    def test_sandbox_script_mounts_override_keep_mounts_true(self, _mock_port, _mock_command):
+        """Explicit SandboxScript mounts are exact, even when keep_mounts=True."""
+        from nemo_skills.pipeline.utils.scripts import SandboxScript
+
+        cluster_config = {
+            "executor": "local",
+            "containers": {"sandbox": "sandbox:latest"},
+            "mounts": self.CLUSTER_MOUNTS,
+        }
+        command_mounts = ["/host/data:/sandbox/data:ro"]
+        sandbox = SandboxScript(cluster_config=cluster_config, keep_mounts=True)
+        cmd = Command(script=sandbox, container="sandbox:latest", name="sandbox", mounts=command_mounts)
+
+        _, exec_config = cmd.prepare_for_execution(cluster_config)
+
+        assert exec_config["mounts"] == command_mounts
+        assert exec_config["keep_mounts"] is False
+
+        pipeline = object.__new__(Pipeline)
+        pipeline.with_ray = False
+        hardware = HardwareConfig(num_gpus=0, num_nodes=1, num_tasks=1)
+        with patch("nemo_skills.pipeline.utils.declarative.get_executor") as mock_get_executor:
+            pipeline._create_executor(
+                cmd,
+                exec_config,
+                "sandbox:latest",
+                cluster_config,
+                "/tmp/logs",
+                hardware,
+                heterogeneous=False,
+                het_group=0,
+                total_het_groups=1,
+                overlap=True,
+            )
+
+        assert mock_get_executor.call_args.kwargs["mounts"] == command_mounts
+
     # ---- Bug rows: keep_mounts=False must isolate from cluster mounts ----
 
     def test_bug_row_1_mounts_none_keep_mounts_false_no_cluster_leak(self):

--- a/tests/test_pipeline_utils.py
+++ b/tests/test_pipeline_utils.py
@@ -16,6 +16,8 @@ import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from nemo_skills.pipeline.utils.declarative import Command
 from nemo_skills.pipeline.utils.generation import (
     get_chunked_rs_filename,
@@ -404,3 +406,54 @@ def test_non_sandbox_command_mounts_unchanged():
     cmd = Command(script=script, container="nemo-skills:latest", name="client")
     _, exec_config = cmd.prepare_for_execution({"executor": "slurm"})
     assert exec_config["mounts"] is None, "Non-sandbox commands should inherit cluster mounts (mounts=None)"
+
+
+def test_normalize_mounts_list_supports_sandbox_modes(monkeypatch):
+    from nemo_skills.pipeline.utils.mounts import normalize_mounts_list
+
+    monkeypatch.setenv("SANDBOX_DATA", "/cluster/sandbox-data")
+
+    assert normalize_mounts_list(
+        ["${SANDBOX_DATA}:/sandbox/data:ro", "/host/scratch:/sandbox/scratch:rw"],
+        allow_rw_mode=True,
+    ) == ["/cluster/sandbox-data:/sandbox/data:ro", "/host/scratch:/sandbox/scratch:rw"]
+
+
+@pytest.mark.parametrize("mount", ["/host/data:/sandbox/data:rw", ":/sandbox/data", "/host/data:"])
+def test_normalize_mounts_list_rejects_invalid_regular_mounts(mount):
+    from nemo_skills.pipeline.utils.mounts import normalize_mounts_list
+
+    with pytest.raises(ValueError):
+        normalize_mounts_list([mount])
+
+
+@patch("nemo_skills.pipeline.utils.exp.get_executor")
+@patch("nemo_skills.pipeline.utils.exp.get_free_port", return_value=12345)
+def test_add_task_sandbox_mounts_override_keep_mounts_true(mock_port, mock_get_executor):
+    """Legacy add_task sandbox sidecars should also use sandbox_mounts exactly."""
+    from types import SimpleNamespace
+
+    from nemo_skills.pipeline.utils.exp import add_task
+
+    mock_get_executor.return_value = MagicMock()
+    exp = SimpleNamespace(add=MagicMock(return_value="task_handle"))
+    cluster_config = {
+        "executor": "local",
+        "containers": {"sandbox": "sandbox:latest"},
+    }
+
+    add_task(
+        exp=exp,
+        cmd="echo hello",
+        task_name="test-task",
+        cluster_config=cluster_config,
+        container="main:latest",
+        log_dir="/tmp/logs",
+        with_sandbox=True,
+        keep_mounts_for_sandbox=True,
+        sandbox_mounts=["/host/data:/sandbox/data:ro"],
+        skip_hf_home_check=True,
+        reuse_code=False,
+    )
+
+    assert mock_get_executor.call_args_list[-1].kwargs["mounts"] == ["/host/data:/sandbox/data:ro"]


### PR DESCRIPTION
## Summary
- add `--sandbox-mounts` for existing pipelines that create sandbox sidecars: `generate`, `eval`, `run_cmd`, `prepare_data`, `start_server`, `nemo_gym_rollouts`, `nemo_rl/grpo`, and `verl/ppo`
- pass explicit sandbox mounts through both declarative `SandboxScript` and legacy `add_task` paths
- split mount parsing into `normalize_mounts_list()` and `get_mounts_from_config()`
- add unit coverage plus a functional read-only sandbox mount test
- **note**: this is a redoing of previous stale PR [#1350](https://github.com/NVIDIA-NeMo/Skills/pull/1350) and is compatible with updated declarative path. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --sandbox-mounts to multiple pipeline commands to specify sandbox-only filesystem mounts (src:dst[:ro|rw]); CLI inputs validated and applied only when sandbox mode is enabled.

* **Refactor**
  * Centralized mount normalization and validation; sandbox mounts are handled consistently, isolated from cluster mounts and re-exported for reuse.
  * Several CLI options updated to accept nullable values with runtime checks for sandbox usage.

* **Tests**
  * Added unit and GPU functional tests covering mount normalization and sandbox read-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->