### PR TITLE
Add LibriSpeechMix SOT benchmark

### DIFF
--- a/docs/evaluation/speech-audio.md
+++ b/docs/evaluation/speech-audio.md
@@ -408,6 +408,54 @@ or
 ns prepare_data librispeech-pc --split test-other --data_dir=/path/to/data
 ```
 
+## LibriSpeechMix SOT
+
+LibriSpeechMix SOT evaluates multispeaker ASR with serialized speaker tags. It uses the official [LibriSpeechMix](https://github.com/NaoyukiKanda/LibriSpeechMix) JSONL lists and LibriSpeech/OpenSLR audio, then writes NeMo SOT manifests with `[s0]`, `[s1]`, etc. reference text, RTTM supervision, and reference SegLST files.
+
+Supported benchmark variants:
+
+- `librispeechmix-sot.under20s-test-clean-1mix`
+- `librispeechmix-sot.under20s-test-clean-2mix`
+- `librispeechmix-sot.under20s-test-clean-3mix`
+- `librispeechmix-sot.over20s-test-clean-1mix`
+- `librispeechmix-sot.over20s-test-clean-2mix`
+- `librispeechmix-sot.over20s-test-clean-3mix`
+
+Dev smoke variants are also available with `dev-clean` in place of `test-clean`. The duration split is explicit: `under20s` contains records with mixed duration `<= 20.0` seconds, and `over20s` contains records with duration `> 20.0` seconds.
+
+Prepare the required test-clean variants:
+
+```bash
+ns prepare_data librispeechmix-sot --cluster=local --data_dir=/path/to/ns-data --splits test-clean --mixes 1mix 2mix 3mix
+```
+
+For a tiny local smoke using a pre-cloned LibriSpeechMix checkout:
+
+```bash
+python -m nemo_skills.dataset.prepare librispeechmix-sot \
+    --data_dir=/path/to/lsm-sot-data \
+    --librispeechmix-dir=/path/to/LibriSpeechMix \
+    --splits test-clean \
+    --mixes 1mix \
+    --max-samples 2 \
+    --no-audio
+```
+
+The primary metric is corpus-level no-PnC cpWER. The scorer reads reference SOT text from `text`, reads hypotheses from `pred_text` when available and otherwise `generation`, splits both by `[sN]` tags, removes punctuation/case, and applies minimum speaker permutation matching. It also writes `*_ref.seglst.json` and `*_hyp.seglst.json`; when `meeteval-wer` is installed it additionally runs MeetEval cpWER with `--normalizer chime8 --partial`.
+
+True speaker-attributed baselines should use a SOT-capable generation module, for example:
+
+```bash
+ns eval \
+    --benchmarks=librispeechmix-sot.under20s-test-clean-1mix \
+    --generation_module=nemo_skills.inference.librispeechmix_rtmtasr \
+    --server_type=none \
+    --server_gpus=0 \
+    --extra_arguments="++model_path=/path/to/MSCanary-v2.nemo ++spk_supervision=rttm ++nemo_root=/path/to/NeMo"
+```
+
+`nemo_skills.inference.librispeechmix_multitalker_parakeet` wraps the streaming Multitalker Parakeet path. The generic SALM backend can run `nvidia/canary-qwen-2.5b`, but the public model card documents generic ASR output, not SOT speaker-tagged output, so treat it as a generic ASR baseline unless a run proves it emits `[sN]` speaker-attributed text.
+
 ## Numb3rs
 
 Numb3rs is a speech benchmark for evaluating text normalization (TN) and inverse text normalization (ITN) capabilities of audio-language models. It contains paired written/spoken forms with corresponding synthetic audio, allowing evaluation of whether a model transcribes numbers in written form (e.g., `$100`, `3.14`) or spoken form (e.g., `one hundred dollars`, `three point one four`).

--- a/nemo_skills/dataset/librispeechmix-sot/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+"""LibriSpeechMix SOT benchmark group."""
+
+IS_BENCHMARK_GROUP = True
+REQUIRES_DATA_DIR = True
+SCORE_MODULE = "nemo_skills.dataset.librispeechmix-sot.librispeechmix_sot_score"
+
+_DURATION_SPLITS = ("under20s", "over20s")
+_LSM_SPLITS = ("test-clean", "dev-clean")
+_MIXES = ("1mix", "2mix", "3mix")
+
+BENCHMARKS = {
+    f"librispeechmix-sot.{duration_split}-{lsm_split}-{mix}": {}
+    for duration_split in _DURATION_SPLITS
+    for lsm_split in _LSM_SPLITS
+    for mix in _MIXES
+}

--- a/nemo_skills/dataset/librispeechmix-sot/librispeechmix_sot_score.py
+++ b/nemo_skills/dataset/librispeechmix-sot/librispeechmix_sot_score.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+"""Group score aggregation for LibriSpeechMix SOT."""
+
+from __future__ import annotations
+
+
+def _aggregate(benchmarks: dict, eval_mode: str) -> dict:
+    total_entries = 0
+    errors = 0
+    substitutions = 0
+    insertions = 0
+    deletions = 0
+    ref_words = 0
+
+    for benchmark_metrics in benchmarks.values():
+        metrics = benchmark_metrics.get(eval_mode)
+        if not metrics:
+            continue
+        total_entries += metrics.get("num_entries", 0)
+        errors += metrics.get("cpwer_errors", 0)
+        substitutions += metrics.get("cpwer_substitutions", 0)
+        insertions += metrics.get("cpwer_insertions", 0)
+        deletions += metrics.get("cpwer_deletions", 0)
+        ref_words += metrics.get("cpwer_ref_words", 0)
+
+    if total_entries == 0:
+        return {}
+
+    output = {
+        "num_entries": total_entries,
+        "cpwer_errors": errors,
+        "cpwer_substitutions": substitutions,
+        "cpwer_insertions": insertions,
+        "cpwer_deletions": deletions,
+        "cpwer_ref_words": ref_words,
+    }
+    if ref_words > 0:
+        output["cpwer"] = round(100.0 * errors / ref_words, 2)
+    return output
+
+
+def compute_score(combined_metrics: dict) -> dict:
+    """Aggregate cpWER overall and by duration split."""
+    if not combined_metrics:
+        return {}
+
+    first_benchmark = next(iter(combined_metrics.values()))
+    eval_modes = list(first_benchmark.keys())
+    groups = {
+        "all": combined_metrics,
+        "under20s": {k: v for k, v in combined_metrics.items() if ".under20s-" in k},
+        "over20s": {k: v for k, v in combined_metrics.items() if ".over20s-" in k},
+        "test_clean": {k: v for k, v in combined_metrics.items() if "-test-clean-" in k},
+        "dev_clean": {k: v for k, v in combined_metrics.items() if "-dev-clean-" in k},
+    }
+
+    output = {}
+    for eval_mode in eval_modes:
+        mode_output = {}
+        for group_name, group_metrics in groups.items():
+            aggregate = _aggregate(group_metrics, eval_mode)
+            if aggregate:
+                mode_output[group_name] = aggregate
+        if mode_output:
+            output[eval_mode] = mode_output
+    return output

--- a/nemo_skills/dataset/librispeechmix-sot/over20s-dev-clean-1mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/over20s-dev-clean-1mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/librispeechmix-sot/over20s-dev-clean-2mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/over20s-dev-clean-2mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/librispeechmix-sot/over20s-dev-clean-3mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/over20s-dev-clean-3mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/librispeechmix-sot/over20s-test-clean-1mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/over20s-test-clean-1mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/librispeechmix-sot/over20s-test-clean-2mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/over20s-test-clean-2mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/librispeechmix-sot/over20s-test-clean-3mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/over20s-test-clean-3mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/librispeechmix-sot/prepare.py
+++ b/nemo_skills/dataset/librispeechmix-sot/prepare.py
@@ -1,0 +1,410 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+"""Prepare LibriSpeechMix SOT manifests for NeMo Skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tarfile
+import urllib.request
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+BENCHMARK_NAME = "librispeechmix-sot"
+DURATION_THRESHOLD_SECONDS = 20.0
+DEFAULT_PROMPT = "Transcribe the mixed audio with speaker tags like [s0] hello [s1] yes."
+SPLITS = ("test-clean", "dev-clean")
+MIXES = ("1mix", "2mix", "3mix")
+
+LIST_URL = "https://raw.githubusercontent.com/NaoyukiKanda/LibriSpeechMix/master/list/{name}.jsonl"
+OPENSLR_ARCHIVES = {
+    "dev-clean": "https://www.openslr.org/resources/12/dev-clean.tar.gz",
+    "test-clean": "https://www.openslr.org/resources/12/test-clean.tar.gz",
+}
+
+
+def _default_data_dir() -> Path:
+    """Return a repo-sibling data directory, never an in-repo path."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent.parent / f"{parent.name}-data" / BENCHMARK_NAME
+    return Path.home() / ".cache" / "nemo-skills-data" / BENCHMARK_NAME
+
+
+def _resolve_values(values: list[str] | None, allowed: tuple[str, ...]) -> tuple[str, ...]:
+    if values is None:
+        return allowed
+    out = []
+    for value in values:
+        for part in value.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            if part == "all":
+                out.extend(allowed)
+            elif part not in allowed:
+                raise ValueError(f"Unsupported value {part!r}; expected one of {allowed}")
+            else:
+                out.append(part)
+    return tuple(dict.fromkeys(out))
+
+
+def _safe_extract_archive(archive_path: Path, output_dir: Path) -> None:
+    output_dir = output_dir.resolve()
+    with tarfile.open(archive_path, "r:gz") as tar:
+        for member in tar.getmembers():
+            member_path = (output_dir / member.name).resolve()
+            if member_path != output_dir and output_dir not in member_path.parents:
+                raise RuntimeError(f"Refusing to extract archive member outside target: {member.name}")
+        tar.extractall(output_dir)
+
+
+def ensure_librispeech_audio(split: str, data_dir: Path, no_audio: bool) -> Path:
+    """Ensure the OpenSLR LibriSpeech split exists and return the LibriSpeech root."""
+    librispeech_root = data_dir / "LibriSpeech"
+    if (librispeech_root / split).exists():
+        return librispeech_root
+    if no_audio:
+        return librispeech_root
+
+    data_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = data_dir / f"{split}.tar.gz"
+    print("=" * 72)
+    print(f"Downloading LibriSpeech {split} from OpenSLR into {data_dir}")
+    print("This archive is large; pass --no-audio to prepare manifests without audio.")
+    print("=" * 72)
+    urllib.request.urlretrieve(OPENSLR_ARCHIVES[split], archive_path)
+    _safe_extract_archive(archive_path, data_dir)
+    archive_path.unlink(missing_ok=True)
+    return librispeech_root
+
+
+def ensure_librispeechmix_list(name: str, data_dir: Path, librispeechmix_dir: Path | None) -> Path:
+    """Find or download an official LibriSpeechMix JSONL list file."""
+    if librispeechmix_dir is not None:
+        candidates = [librispeechmix_dir / "list" / f"{name}.jsonl", librispeechmix_dir / f"{name}.jsonl"]
+        for candidate in candidates:
+            if candidate.exists():
+                return candidate
+        raise FileNotFoundError(f"Could not find {name}.jsonl under {librispeechmix_dir}")
+
+    env_dir = os.getenv("LIBRISPEECHMIX_DIR")
+    if env_dir:
+        return ensure_librispeechmix_list(name, data_dir, Path(env_dir).expanduser())
+
+    list_dir = data_dir / "LibriSpeechMix" / "list"
+    list_dir.mkdir(parents=True, exist_ok=True)
+    list_path = list_dir / f"{name}.jsonl"
+    if list_path.exists():
+        return list_path
+
+    print(f"Downloading official LibriSpeechMix list {name}.jsonl")
+    urllib.request.urlretrieve(LIST_URL.format(name=name), list_path)
+    return list_path
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    """Load a JSONL file."""
+    rows = []
+    with open(path, "rt", encoding="utf-8") as fin:
+        for line in fin:
+            if line.strip():
+                rows.append(json.loads(line))
+    return rows
+
+
+def mixed_duration(row: dict) -> float:
+    """Return mixed utterance duration from source delays and durations."""
+    return float(max(delay + duration for delay, duration in zip(row["delays"], row["durations"])))
+
+
+def duration_bucket(duration: float) -> str:
+    """Map a duration to the explicit under/over-20 second benchmark split."""
+    return "under20s" if duration <= DURATION_THRESHOLD_SECONDS else "over20s"
+
+
+def speaker_tag_map(row: dict) -> dict[str, str]:
+    """Assign stable [sN] tags in first-start order."""
+    ordered = sorted(enumerate(row["speakers"]), key=lambda item: (row["delays"][item[0]], item[1], item[0]))
+    mapping = {}
+    for _orig_idx, speaker in ordered:
+        if speaker not in mapping:
+            mapping[speaker] = f"s{len(mapping)}"
+    return mapping
+
+
+def sot_text(row: dict) -> str:
+    """Create SOT reference text with bracket speaker tags."""
+    tag_by_speaker = speaker_tag_map(row)
+    ordered = sorted(range(len(row["speakers"])), key=lambda idx: (row["delays"][idx], row["speakers"][idx], idx))
+    chunks = []
+    for idx in ordered:
+        tag = tag_by_speaker[row["speakers"][idx]]
+        chunks.append(f"[{tag}] {row['texts'][idx].lower()}")
+    return " ".join(chunks)
+
+
+def num_speaker_changes(row: dict) -> int:
+    """Count speaker changes in chronological segment order."""
+    ordered_speakers = [
+        row["speakers"][idx]
+        for idx in sorted(range(len(row["speakers"])), key=lambda i: (row["delays"][i], row["speakers"][i], i))
+    ]
+    return sum(1 for prev, cur in zip(ordered_speakers, ordered_speakers[1:]) if prev != cur)
+
+
+def rttm_lines(row: dict, session_id: str) -> list[str]:
+    """Render RTTM speaker supervision for one mixed recording."""
+    lines = []
+    for delay, duration, speaker in zip(row["delays"], row["durations"], row["speakers"]):
+        lines.append(f"SPEAKER {session_id} 1 {delay:.3f} {duration:.3f} <NA> <NA> {speaker} <NA> <NA>\n")
+    return lines
+
+
+def seglst_entries(row: dict, session_id: str) -> list[dict]:
+    """Render reference SegLST entries for one mixed recording."""
+    entries = []
+    for delay, duration, speaker, text in zip(row["delays"], row["durations"], row["speakers"], row["texts"]):
+        entries.append(
+            {
+                "session_id": session_id,
+                "words": text.lower(),
+                "speaker": speaker,
+                "start_time": round(float(delay), 3),
+                "end_time": round(float(delay + duration), 3),
+            }
+        )
+    return entries
+
+
+def _read_audio(path: Path) -> tuple[np.ndarray, int]:
+    import soundfile as sf
+
+    audio, sample_rate = sf.read(path)
+    if audio.ndim > 1:
+        audio = np.mean(audio, axis=1)
+    return np.asarray(audio, dtype=np.float32), int(sample_rate)
+
+
+def _write_audio(path: Path, audio: np.ndarray, sample_rate: int) -> None:
+    import soundfile as sf
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(path, audio, sample_rate)
+
+
+def source_audio_path(relative_wav: str, librispeech_root: Path) -> Path:
+    """Resolve a LibriSpeechMix relative source path to existing WAV/FLAC audio."""
+    rel = Path(relative_wav)
+    wav_path = librispeech_root / rel
+    flac_path = librispeech_root / rel.with_suffix(".flac")
+    if wav_path.exists():
+        return wav_path
+    if flac_path.exists():
+        return flac_path
+    raise FileNotFoundError(f"Missing LibriSpeech source audio for {relative_wav} under {librispeech_root}")
+
+
+def materialize_mixed_wav(row: dict, output_path: Path, librispeech_root: Path) -> Path:
+    """Create a mixed WAV from source utterances and official LibriSpeechMix delays."""
+    if output_path.exists():
+        return output_path
+
+    tracks = []
+    sample_rate = None
+    target_len = 0
+    for relative_wav, delay in zip(row["wavs"], row["delays"]):
+        audio, current_rate = _read_audio(source_audio_path(relative_wav, librispeech_root))
+        if sample_rate is None:
+            sample_rate = current_rate
+        elif current_rate != sample_rate:
+            raise RuntimeError(f"Sample-rate mismatch while mixing {row['id']}: {sample_rate} vs {current_rate}")
+        delay_frames = int(round(float(delay) * current_rate))
+        tracks.append((audio, delay_frames))
+        target_len = max(target_len, delay_frames + len(audio))
+
+    mixed = np.zeros(target_len, dtype=np.float32)
+    for audio, delay_frames in tracks:
+        mixed[delay_frames : delay_frames + len(audio)] += audio
+    _write_audio(output_path, mixed, sample_rate or 16000)
+    return output_path
+
+
+def _public_audio_path(local_audio_path: Path, local_audio_root: Path, audio_prefix: Path) -> str:
+    relative = local_audio_path.relative_to(local_audio_root)
+    return str(audio_prefix / relative)
+
+
+def build_record(
+    row: dict,
+    *,
+    split: str,
+    mix: str,
+    data_dir: Path,
+    audio_prefix: Path,
+    no_audio: bool,
+    librispeech_root: Path,
+) -> dict:
+    """Build one NeMo SOT manifest record and write its RTTM/SegLST sidecars."""
+    duration = mixed_duration(row)
+    session_id = Path(row["mixed_wav"]).stem
+    local_audio_root = data_dir / "audio"
+    local_audio_path = local_audio_root / row["mixed_wav"]
+    rttm_path = data_dir / "rttm" / split / mix / f"{session_id}.rttm"
+    seglst_path = data_dir / "seglst" / split / mix / f"{session_id}_ref.seglst.json"
+
+    if not no_audio:
+        materialize_mixed_wav(row, local_audio_path, librispeech_root)
+
+    rttm_path.parent.mkdir(parents=True, exist_ok=True)
+    rttm_path.write_text("".join(rttm_lines(row, session_id)), encoding="utf-8")
+    seglst_path.parent.mkdir(parents=True, exist_ok=True)
+    seglst_path.write_text(json.dumps(seglst_entries(row, session_id), indent=2) + "\n", encoding="utf-8")
+
+    tag_by_speaker = speaker_tag_map(row)
+    ordered_global_speakers = [speaker for speaker, _tag in sorted(tag_by_speaker.items(), key=lambda item: item[1])]
+    audio_filepath = _public_audio_path(local_audio_path, local_audio_root, audio_prefix)
+    text = sot_text(row)
+
+    return {
+        "audio_filepath": audio_filepath,
+        "rttm_filepath": str(rttm_path),
+        "reference_seglst_filepath": str(seglst_path),
+        "offset": 0.0,
+        "duration": round(duration, 4),
+        "text": text,
+        "expected_answer": text,
+        "source_lang": "en",
+        "target_lang": "en",
+        "taskname": "asr",
+        "pnc": "no",
+        "num_speakers": len(tag_by_speaker),
+        "num_changes": num_speaker_changes(row),
+        "dataset_id": f"{BENCHMARK_NAME}:{split}-{mix}",
+        "global_speaker_ids": ordered_global_speakers,
+        "speaker_tag_map": tag_by_speaker,
+        "librispeechmix_id": row["id"],
+        "sample_id": session_id,
+        "delays": row["delays"],
+        "source_wavs": row["wavs"],
+        "subset_for_metrics": f"{duration_bucket(duration)}-{split}-{mix}",
+        "messages": [
+            {
+                "role": "user",
+                "content": DEFAULT_PROMPT,
+                "audio": {"path": audio_filepath, "duration": round(duration, 4)},
+            }
+        ],
+    }
+
+
+def write_jsonl(path: Path, rows: Iterable[dict]) -> int:
+    """Write JSONL rows and return the number written."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with open(path, "wt", encoding="utf-8") as fout:
+        for row in rows:
+            fout.write(json.dumps(row) + "\n")
+            count += 1
+    return count
+
+
+def prepare_split_mix(
+    *,
+    split: str,
+    mix: str,
+    rows: list[dict],
+    output_dir: Path,
+    data_dir: Path,
+    audio_prefix: Path,
+    no_audio: bool,
+    max_samples: int | None,
+    librispeech_root: Path,
+) -> dict[str, int]:
+    """Prepare under/over-20s variants for one LibriSpeechMix list."""
+    buckets = {"under20s": [], "over20s": []}
+    for row in rows:
+        bucket = duration_bucket(mixed_duration(row))
+        if max_samples is not None and len(buckets[bucket]) >= max_samples:
+            continue
+        buckets[bucket].append(
+            build_record(
+                row,
+                split=split,
+                mix=mix,
+                data_dir=data_dir,
+                audio_prefix=audio_prefix,
+                no_audio=no_audio,
+                librispeech_root=librispeech_root,
+            )
+        )
+        if max_samples is not None and all(len(items) >= max_samples for items in buckets.values()):
+            break
+
+    counts = {}
+    for bucket, records in buckets.items():
+        out_file = output_dir / f"{bucket}-{split}-{mix}" / "test.jsonl"
+        counts[f"{bucket}-{split}-{mix}"] = write_jsonl(out_file, records)
+    return counts
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare LibriSpeechMix SOT benchmark manifests.")
+    parser.add_argument("--data_dir", type=str, default=None, help="External data/artifact root.")
+    parser.add_argument("--audio-prefix", type=str, default=None, help="Audio path prefix embedded in manifests.")
+    parser.add_argument("--no-audio", action="store_true", help="Do not download or materialize audio.")
+    parser.add_argument("--splits", nargs="+", default=["test-clean"], help="LibriSpeechMix splits or 'all'.")
+    parser.add_argument("--mixes", nargs="+", default=list(MIXES), help="Mixtures to prepare or 'all'.")
+    parser.add_argument("--max-samples", type=int, default=None, help="Maximum records per under/over bucket.")
+    parser.add_argument("--librispeechmix-dir", type=str, default=None, help="Local LibriSpeechMix checkout/list dir.")
+    parser.add_argument("--librispeech-root", type=str, default=None, help="Existing LibriSpeech root override.")
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir).expanduser().resolve() if args.data_dir else _default_data_dir()
+    audio_prefix = Path(args.audio_prefix).expanduser() if args.audio_prefix else data_dir / "audio"
+    lsm_dir = Path(args.librispeechmix_dir).expanduser().resolve() if args.librispeechmix_dir else None
+    output_dir = Path(__file__).parent
+    splits = _resolve_values(args.splits, SPLITS)
+    mixes = _resolve_values(args.mixes, MIXES)
+
+    data_dir.mkdir(parents=True, exist_ok=True)
+    all_counts = {}
+    for split in splits:
+        librispeech_root = (
+            Path(args.librispeech_root).expanduser().resolve()
+            if args.librispeech_root
+            else ensure_librispeech_audio(split, data_dir, args.no_audio)
+        )
+        for mix in mixes:
+            name = f"{split}-{mix}"
+            list_path = ensure_librispeechmix_list(name, data_dir, lsm_dir)
+            rows = load_jsonl(list_path)
+            counts = prepare_split_mix(
+                split=split,
+                mix=mix,
+                rows=rows,
+                output_dir=output_dir,
+                data_dir=data_dir,
+                audio_prefix=audio_prefix,
+                no_audio=args.no_audio,
+                max_samples=args.max_samples,
+                librispeech_root=librispeech_root,
+            )
+            all_counts.update(counts)
+
+    print("Prepared LibriSpeechMix SOT manifests:")
+    for name, count in sorted(all_counts.items()):
+        print(f"  {name}: {count}")
+    print(f"Data/artifacts root: {data_dir}")
+    print(f"Duration split threshold: {DURATION_THRESHOLD_SECONDS:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_skills/dataset/librispeechmix-sot/under20s-dev-clean-1mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/under20s-dev-clean-1mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/librispeechmix-sot/under20s-dev-clean-2mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/under20s-dev-clean-2mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/librispeechmix-sot/under20s-dev-clean-3mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/under20s-dev-clean-3mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/librispeechmix-sot/under20s-test-clean-1mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/under20s-test-clean-1mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/librispeechmix-sot/under20s-test-clean-2mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/under20s-test-clean-2mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/dataset/librispeechmix-sot/under20s-test-clean-3mix/__init__.py
+++ b/nemo_skills/dataset/librispeechmix-sot/under20s-test-clean-3mix/__init__.py
@@ -1,0 +1,5 @@
+METRICS_TYPE = "librispeechmix_sot"
+EVAL_ARGS = "++eval_type=librispeechmix_sot"
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
+GENERATION_MODULE = "nemo_skills.inference.generate"
+EVAL_SPLIT = "test"

--- a/nemo_skills/evaluation/evaluator/__init__.py
+++ b/nemo_skills/evaluation/evaluator/__init__.py
@@ -53,6 +53,7 @@ _EVALUATOR_CLASS_MAP_PATHS = {
     "icpc": "nemo_skills.evaluation.evaluator.icpc:ICPCEvaluator",
     "ccc": "nemo_skills.evaluation.evaluator.ccc:CCCEvaluator",
     "audio": "nemo_skills.evaluation.evaluator.audio:AudioEvaluator",
+    "librispeechmix_sot": "nemo_skills.evaluation.evaluator.librispeechmix_sot:LibriSpeechMixSOTEvaluator",
     "bird": "nemo_skills.evaluation.evaluator.bird:BirdEvaluator",
     "compute-eval": "nemo_skills.evaluation.evaluator.compute_eval:ComputeEvalEvaluator",
     "contextasr": "nemo_skills.evaluation.evaluator.contextasr:ContextASREvaluator",

--- a/nemo_skills/evaluation/evaluator/librispeechmix_sot.py
+++ b/nemo_skills/evaluation/evaluator/librispeechmix_sot.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+"""Evaluator for LibriSpeechMix SOT cpWER."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+import tqdm
+
+from nemo_skills.evaluation.evaluator.base import BaseEvaluator, BaseEvaluatorConfig
+from nemo_skills.evaluation.metrics.librispeechmix_sot_utils import cpwer, write_meeteval_artifacts
+from nemo_skills.utils import nested_dataclass
+
+
+@nested_dataclass(kw_only=True)
+class LibriSpeechMixSOTEvaluatorConfig(BaseEvaluatorConfig):
+    """Configuration for LibriSpeechMix SOT evaluation."""
+
+    prediction_keys: list[str] | None = None
+    write_meeteval: bool = True
+
+
+class LibriSpeechMixSOTEvaluator(BaseEvaluator):
+    """Compute per-record cpWER and optional MeetEval artifacts."""
+
+    def __init__(self, config: Dict[str, Any], num_parallel_requests=10):
+        super().__init__(LibriSpeechMixSOTEvaluatorConfig(_init_nested=True, **config), num_parallel_requests)
+
+    def _get_hypothesis(self, data_point: dict[str, Any]) -> str:
+        keys = self.config.prediction_keys or ["pred_text", "generation"]
+        for key in keys:
+            value = data_point.get(key)
+            if value is not None:
+                return str(value)
+        return ""
+
+    async def eval_single(self, data_point: dict[str, Any]) -> dict[str, Any]:
+        hypothesis = self._get_hypothesis(data_point)
+        result = cpwer(data_point["text"], hypothesis)
+        return {
+            "pred_text": hypothesis,
+            "cpwer": result["cpwer"],
+            "cpwer_errors": result["errors"],
+            "cpwer_substitutions": result["substitutions"],
+            "cpwer_insertions": result["insertions"],
+            "cpwer_deletions": result["deletions"],
+            "cpwer_ref_words": result["ref_words"],
+            "speaker_assignment": result["assignment"],
+            "is_correct": result["errors"] == 0,
+        }
+
+    async def eval_full(self) -> None:
+        records = []
+        with open(self.config.input_file, "rt", encoding="utf-8") as fin:
+            for line in tqdm.tqdm(fin, desc=f"Evaluating {os.path.basename(self.config.input_file)}"):
+                record = json.loads(line)
+                record.update(await self.eval_single(record))
+                if "generation" not in record:
+                    record["generation"] = record["pred_text"]
+                records.append(record)
+
+        temp_file = self.config.input_file + "-tmp"
+        with open(temp_file, "wt", encoding="utf-8") as fout:
+            for record in records:
+                fout.write(json.dumps(record) + "\n")
+        os.replace(temp_file, self.config.input_file)
+
+        if self.config.write_meeteval:
+            artifacts = write_meeteval_artifacts(records, self.config.input_file)
+            sidecar = self.config.input_file + ".meeteval_artifacts.json"
+            with open(sidecar, "wt", encoding="utf-8") as fout:
+                json.dump(artifacts, fout, indent=2)

--- a/nemo_skills/evaluation/metrics/librispeechmix_sot_metrics.py
+++ b/nemo_skills/evaluation/metrics/librispeechmix_sot_metrics.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+"""Metrics aggregation for LibriSpeechMix SOT cpWER."""
+
+from __future__ import annotations
+
+from nemo_skills.evaluation.metrics.base import BaseMetrics, as_float, as_int, as_percentage
+
+
+class LibriSpeechMixSOTMetrics(BaseMetrics):
+    """Aggregate LibriSpeechMix SOT cpWER from raw corpus counts."""
+
+    def __init__(self, compute_no_answer: bool = True, max_k: int = 1):
+        super().__init__(compute_no_answer=compute_no_answer)
+        self.max_k = max_k
+
+    def _get_score_dict(self, prediction: dict) -> dict[str, bool]:
+        return {"correct": bool(prediction.get("is_correct", False))}
+
+    def get_incorrect_sample(self, prediction: dict) -> dict:
+        prediction = prediction.copy()
+        prediction["is_correct"] = False
+        prediction["cpwer_errors"] = prediction.get("cpwer_ref_words", 0)
+        prediction["cpwer_deletions"] = prediction.get("cpwer_ref_words", 0)
+        prediction["cpwer_insertions"] = 0
+        prediction["cpwer_substitutions"] = 0
+        return prediction
+
+    def update(self, predictions: list[dict]) -> None:
+        super().update(predictions)
+        predicted_answers = [p.get("generation") or p.get("pred_text") or None for p in predictions]
+        self._compute_pass_at_k(predictions=predictions, predicted_answers=predicted_answers)
+        if len(predictions) > 1:
+            self._compute_majority_at_k(predictions=predictions, predicted_answers=predicted_answers)
+
+        first = predictions[0]
+        for mode in ["pass@1", "pass@1[avg-of-1]"]:
+            self.eval_dict[mode]["cpwer_errors"] += first.get("cpwer_errors", 0)
+            self.eval_dict[mode]["cpwer_substitutions"] += first.get("cpwer_substitutions", 0)
+            self.eval_dict[mode]["cpwer_insertions"] += first.get("cpwer_insertions", 0)
+            self.eval_dict[mode]["cpwer_deletions"] += first.get("cpwer_deletions", 0)
+            self.eval_dict[mode]["cpwer_ref_words"] += first.get("cpwer_ref_words", 0)
+
+    def get_metrics(self) -> dict:
+        metrics_dict = super().get_metrics()
+        raw_count_keys = [
+            "cpwer_errors",
+            "cpwer_substitutions",
+            "cpwer_insertions",
+            "cpwer_deletions",
+            "cpwer_ref_words",
+        ]
+        for mode, metrics in metrics_dict.items():
+            raw_metrics = self.eval_dict.get(mode, {})
+            for key in raw_count_keys:
+                metrics[key] = int(raw_metrics.get(key, 0))
+            ref_words = metrics.get("cpwer_ref_words", 0)
+            errors = metrics.get("cpwer_errors", 0)
+            if ref_words > 0:
+                metrics["cpwer"] = round(100.0 * errors / ref_words, 2)
+        return metrics_dict
+
+    def evaluations_to_print(self) -> list[str]:
+        return [f"pass@{self.max_k}"]
+
+    def metrics_to_print(self) -> dict:
+        metrics = {
+            "correct": as_percentage,
+            "cpwer": as_float,
+            "cpwer_errors": as_int,
+            "cpwer_substitutions": as_int,
+            "cpwer_insertions": as_int,
+            "cpwer_deletions": as_int,
+            "cpwer_ref_words": as_int,
+            "num_entries": as_int,
+        }
+        if self.compute_no_answer:
+            metrics["no_answer"] = as_percentage
+        return metrics

--- a/nemo_skills/evaluation/metrics/librispeechmix_sot_utils.py
+++ b/nemo_skills/evaluation/metrics/librispeechmix_sot_utils.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Utilities for LibriSpeechMix SOT cpWER evaluation."""
+
+from __future__ import annotations
+
+import itertools
+import json
+import logging
+import re
+import string
+import subprocess
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+LOG = logging.getLogger(__name__)
+
+SPEAKER_TAG_RE = re.compile(r"\[(s\d+)\]", re.IGNORECASE)
+PUNCT_TRANSLATION = str.maketrans({char: " " for char in string.punctuation})
+
+
+def normalize_no_pnc(text: str) -> str:
+    """Lowercase text and remove punctuation for no-PnC cpWER."""
+    text = text.lower().translate(PUNCT_TRANSLATION)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def parse_sot_speaker_streams(text: str, *, default_speaker: str = "s0") -> OrderedDict[str, str]:
+    """Parse SOT text into speaker streams keyed by speaker token without brackets."""
+    streams: OrderedDict[str, list[str]] = OrderedDict()
+    current_speaker: str | None = None
+    cursor = 0
+
+    for match in SPEAKER_TAG_RE.finditer(text or ""):
+        chunk = text[cursor : match.start()].strip()
+        if chunk:
+            speaker = current_speaker or default_speaker
+            streams.setdefault(speaker, []).append(chunk)
+        current_speaker = match.group(1).lower()
+        streams.setdefault(current_speaker, [])
+        cursor = match.end()
+
+    tail = (text or "")[cursor:].strip()
+    if tail:
+        speaker = current_speaker or default_speaker
+        streams.setdefault(speaker, []).append(tail)
+
+    return OrderedDict((speaker, normalize_no_pnc(" ".join(chunks))) for speaker, chunks in streams.items())
+
+
+def edit_counts(reference: list[str], hypothesis: list[str]) -> dict[str, int]:
+    """Return Levenshtein substitutions, insertions, and deletions."""
+    rows = len(reference) + 1
+    cols = len(hypothesis) + 1
+    dp: list[list[tuple[int, int, int, int]]] = [[(0, 0, 0, 0) for _ in range(cols)] for _ in range(rows)]
+
+    for row in range(1, rows):
+        prev = dp[row - 1][0]
+        dp[row][0] = (prev[0] + 1, prev[1], prev[2], prev[3] + 1)
+    for col in range(1, cols):
+        prev = dp[0][col - 1]
+        dp[0][col] = (prev[0] + 1, prev[1], prev[2] + 1, prev[3])
+
+    for row in range(1, rows):
+        for col in range(1, cols):
+            if reference[row - 1] == hypothesis[col - 1]:
+                hit_prev = dp[row - 1][col - 1]
+                hit = (hit_prev[0], hit_prev[1], hit_prev[2], hit_prev[3])
+                dp[row][col] = hit
+                continue
+
+            sub_prev = dp[row - 1][col - 1]
+            ins_prev = dp[row][col - 1]
+            del_prev = dp[row - 1][col]
+            candidates = [
+                (sub_prev[0] + 1, sub_prev[1] + 1, sub_prev[2], sub_prev[3]),
+                (ins_prev[0] + 1, ins_prev[1], ins_prev[2] + 1, ins_prev[3]),
+                (del_prev[0] + 1, del_prev[1], del_prev[2], del_prev[3] + 1),
+            ]
+            dp[row][col] = min(candidates, key=lambda item: (item[0], item[1], item[3], item[2]))
+
+    errors, substitutions, insertions, deletions = dp[-1][-1]
+    return {
+        "errors": errors,
+        "substitutions": substitutions,
+        "insertions": insertions,
+        "deletions": deletions,
+        "ref_words": len(reference),
+    }
+
+
+def _counts_for_text(reference: str, hypothesis: str) -> dict[str, int]:
+    return edit_counts(reference.split(), hypothesis.split())
+
+
+def cpwer(reference_text: str, hypothesis_text: str) -> dict[str, Any]:
+    """Compute cpWER using minimum speaker permutation matching."""
+    ref_streams = parse_sot_speaker_streams(reference_text)
+    hyp_streams = parse_sot_speaker_streams(hypothesis_text)
+
+    ref_items = list(ref_streams.items())
+    hyp_items = list(hyp_streams.items())
+    size = max(len(ref_items), len(hyp_items), 1)
+    padded_refs = ref_items + [(f"__empty_ref_{idx}", "") for idx in range(size - len(ref_items))]
+    padded_hyps = hyp_items + [(f"__empty_hyp_{idx}", "") for idx in range(size - len(hyp_items))]
+
+    best: dict[str, Any] | None = None
+    for permutation in itertools.permutations(range(size)):
+        totals = {"errors": 0, "substitutions": 0, "insertions": 0, "deletions": 0, "ref_words": 0}
+        assignment = []
+        for ref_idx, hyp_idx in enumerate(permutation):
+            ref_speaker, ref_words = padded_refs[ref_idx]
+            hyp_speaker, hyp_words = padded_hyps[hyp_idx]
+            counts = _counts_for_text(ref_words, hyp_words)
+            for key in totals:
+                totals[key] += counts[key]
+            assignment.append({"reference": ref_speaker, "hypothesis": hyp_speaker})
+
+        candidate = {
+            **totals,
+            "cpwer": totals["errors"] / totals["ref_words"] if totals["ref_words"] else 0.0,
+            "assignment": assignment,
+            "reference_streams": dict(ref_streams),
+            "hypothesis_streams": dict(hyp_streams),
+        }
+        key = (candidate["errors"], candidate["substitutions"], candidate["deletions"], candidate["insertions"])
+        if best is None:
+            best = candidate
+            best_key = key
+        elif key < best_key:
+            best = candidate
+            best_key = key
+
+    return best or {
+        "cpwer": 0.0,
+        "errors": 0,
+        "substitutions": 0,
+        "insertions": 0,
+        "deletions": 0,
+        "ref_words": 0,
+        "assignment": [],
+        "reference_streams": {},
+        "hypothesis_streams": {},
+    }
+
+
+def sot_to_seglst(record: dict[str, Any], text_key: str) -> list[dict[str, Any]]:
+    """Convert a SOT transcript into coarse SegLST entries for MeetEval cpWER."""
+    text = record.get(text_key, "") or ""
+    streams = parse_sot_speaker_streams(text)
+    session_id = record.get("sample_id") or record.get("id") or Path(record.get("audio_filepath", "sample")).stem
+    offset = float(record.get("offset", 0.0) or 0.0)
+    duration = max(float(record.get("duration", 0.0) or 0.0), 0.01)
+    step = duration / max(len(streams), 1)
+
+    entries = []
+    for idx, (speaker, words) in enumerate(streams.items()):
+        start = offset + idx * step
+        end = offset + (idx + 1) * step
+        entries.append(
+            {
+                "session_id": str(session_id),
+                "words": words,
+                "speaker": speaker,
+                "start_time": round(start, 2),
+                "end_time": round(end, 2),
+            }
+        )
+    return entries
+
+
+def write_meeteval_artifacts(records: list[dict[str, Any]], output_file: str | Path) -> dict[str, str]:
+    """Write reference and hypothesis SegLST JSON files next to an evaluated output file."""
+    output_path = Path(output_file)
+    stem = output_path.with_suffix("")
+    ref_path = stem.parent / f"{stem.name}_ref.seglst.json"
+    hyp_path = stem.parent / f"{stem.name}_hyp.seglst.json"
+    avg_path = stem.parent / f"{stem.name}_meeteval_average.json"
+    per_path = stem.parent / f"{stem.name}_meeteval_per_reco.json"
+
+    ref_entries: list[dict[str, Any]] = []
+    hyp_entries: list[dict[str, Any]] = []
+    for record in records:
+        ref_entries.extend(sot_to_seglst(record, "text"))
+        hyp_record = dict(record)
+        hyp_record["pred_text"] = record.get("pred_text") or record.get("generation", "")
+        hyp_entries.extend(sot_to_seglst(hyp_record, "pred_text"))
+
+    ref_path.write_text(json.dumps(ref_entries, indent=2) + "\n", encoding="utf-8")
+    hyp_path.write_text(json.dumps(hyp_entries, indent=2) + "\n", encoding="utf-8")
+
+    artifacts = {"ref": str(ref_path), "hyp": str(hyp_path)}
+    command = [
+        "meeteval-wer",
+        "cpwer",
+        "-r",
+        str(ref_path),
+        "-h",
+        str(hyp_path),
+        "--normalizer",
+        "chime8",
+        "--average-out",
+        str(avg_path),
+        "--per-reco-out",
+        str(per_path),
+        "--partial",
+    ]
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError:
+        LOG.warning("meeteval-wer is not installed; wrote SegLST artifacts but skipped MeetEval cpWER.")
+    except subprocess.CalledProcessError as exc:
+        LOG.warning("meeteval-wer cpwer failed: %s", exc.stderr.strip() or exc.stdout.strip())
+    else:
+        artifacts["average"] = str(avg_path)
+        artifacts["per_reco"] = str(per_path)
+    return artifacts

--- a/nemo_skills/evaluation/metrics/map_metrics.py
+++ b/nemo_skills/evaluation/metrics/map_metrics.py
@@ -39,6 +39,7 @@ from nemo_skills.evaluation.metrics.icpc_metrics import ICPCMetrics
 from nemo_skills.evaluation.metrics.if_metrics import IFMetrics
 from nemo_skills.evaluation.metrics.ioi_metrics import IOIMetrics
 from nemo_skills.evaluation.metrics.lean4_metrics import Lean4Metrics
+from nemo_skills.evaluation.metrics.librispeechmix_sot_metrics import LibriSpeechMixSOTMetrics
 from nemo_skills.evaluation.metrics.math_metrics import MathMetrics
 from nemo_skills.evaluation.metrics.mcq_multilingual_metrics import MCQMultilingualMetrics
 from nemo_skills.evaluation.metrics.mmau_pro_metrics import MMAUProMetrics
@@ -68,6 +69,7 @@ METRICS_MAP = {
     "answer-judgement": AnswerJudgementMetrics,
     "arena": ArenaMetrics,
     "audio": AudioMetrics,
+    "librispeechmix_sot": LibriSpeechMixSOTMetrics,
     "speechlm": AudioMetrics,  # Alias for backward compatibility
     "bfcl": BFCLMetrics,
     "bird": BirdMetrics,

--- a/nemo_skills/inference/librispeechmix_multitalker_parakeet.py
+++ b/nemo_skills/inference/librispeechmix_multitalker_parakeet.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+"""NeMo-Skills generation wrapper for Multitalker Parakeet streaming inference."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import field
+from pathlib import Path
+from typing import Any
+
+import hydra
+
+from nemo_skills.utils import get_help_message, nested_dataclass, setup_logging
+
+DEFAULT_ASR_MODEL = "nvidia/multitalker-parakeet-streaming-0.6b-v1"
+DEFAULT_DIAR_MODEL = "nvidia/diar_streaming_sortformer_4spk-v2.1"
+
+
+@nested_dataclass(kw_only=True)
+class MultitalkerParakeetGenerationConfig:
+    """Configuration for Multitalker Parakeet script-backed generation."""
+
+    input_file: str
+    output_file: str
+    prompt_config: Any = None
+    prompt_format: str = "openai"
+    server: dict = field(default_factory=dict)
+    eval_type: str | None = None
+    eval_config: dict = field(default_factory=dict)
+    skip_filled: bool = False
+    num_chunks: int | None = None
+    chunk_id: int | None = None
+    nemo_root: str = ""
+    script_path: str = ""
+    asr_model: str = DEFAULT_ASR_MODEL
+    diar_model: str = DEFAULT_DIAR_MODEL
+    spk_supervision: str = "rttm"
+    max_num_of_spks: int = 4
+    masked_asr: bool = False
+    parallel_speaker_strategy: bool = True
+    binary_diar_preds: bool = True
+    batch_size: int = 125
+    att_context_size: str = "[70,13]"
+    spkcache_len: int = 188
+    spkcache_refresh_rate: int = 144
+    fifo_len: int = 188
+    chunk_len: int = 13
+    chunk_left_context: int = 1
+    chunk_right_context: int = 0
+    cache_gating: bool = False
+    calculate_cpwer: bool = False
+    remove_pnc_for_cpwer: bool = True
+
+    def __post_init__(self):
+        pass
+
+
+cs = hydra.core.config_store.ConfigStore.instance()
+cs.store(name="multitalker_parakeet_generation_config", node=MultitalkerParakeetGenerationConfig)
+
+
+def resolve_script_path(cfg: MultitalkerParakeetGenerationConfig) -> Path:
+    """Resolve the streaming multitalker inference script."""
+    if cfg.script_path:
+        return Path(cfg.script_path)
+    root = Path(cfg.nemo_root or os.environ.get("NEMO_ROOT", "."))
+    return root / "examples/asr/asr_cache_aware_streaming/speech_to_text_multitalker_streaming_infer.py"
+
+
+def build_multitalker_parakeet_command(cfg: MultitalkerParakeetGenerationConfig) -> list[str]:
+    """Build the Multitalker Parakeet command from config."""
+    return [
+        sys.executable,
+        str(resolve_script_path(cfg)),
+        "log=False",
+        f"binary_diar_preds={str(cfg.binary_diar_preds)}",
+        f"spk_supervision={cfg.spk_supervision}",
+        f"max_num_of_spks={cfg.max_num_of_spks}",
+        f"masked_asr={str(cfg.masked_asr)}",
+        f"asr_model={cfg.asr_model}",
+        f"diar_model={cfg.diar_model}",
+        f"parallel_speaker_strategy={str(cfg.parallel_speaker_strategy)}",
+        f"att_context_size={cfg.att_context_size}",
+        "generate_realtime_scripts=False",
+        f"batch_size={cfg.batch_size}",
+        f"manifest_file={cfg.input_file}",
+        f"output_path={cfg.output_file}",
+        f"calculate_cpwer={str(cfg.calculate_cpwer)}",
+        f"remove_pnc_for_cpwer={str(cfg.remove_pnc_for_cpwer)}",
+        f"cache_gating={str(cfg.cache_gating)}",
+        f"spkcache_len={cfg.spkcache_len}",
+        f"spkcache_refresh_rate={cfg.spkcache_refresh_rate}",
+        f"fifo_len={cfg.fifo_len}",
+        f"chunk_len={cfg.chunk_len}",
+        f"chunk_left_context={cfg.chunk_left_context}",
+        f"chunk_right_context={cfg.chunk_right_context}",
+    ]
+
+
+def _load_jsonl(path: str | Path) -> list[dict]:
+    rows = []
+    with open(path, "rt", encoding="utf-8") as fin:
+        for line in fin:
+            if line.strip():
+                rows.append(json.loads(line))
+    return rows
+
+
+def _session_id(record: dict) -> str:
+    return str(record.get("sample_id") or record.get("id") or Path(record.get("audio_filepath", "sample")).stem)
+
+
+def _seglst_to_sot(entries: list[dict]) -> str:
+    tag_by_speaker = {}
+    chunks = []
+    for entry in sorted(
+        entries,
+        key=lambda item: (
+            float(item.get("start_time", 0.0) or 0.0),
+            float(item.get("end_time", 0.0) or 0.0),
+            str(item.get("speaker", "")),
+        ),
+    ):
+        words = str(entry.get("words") or entry.get("text") or "").strip()
+        if not words:
+            continue
+        speaker = str(entry.get("speaker") or "speaker")
+        if speaker not in tag_by_speaker:
+            tag_by_speaker[speaker] = f"s{len(tag_by_speaker)}"
+        chunks.append(f"[{tag_by_speaker[speaker]}] {words}")
+    return " ".join(chunks)
+
+
+def _normalize_seglst_output(output_path: Path, input_file: str | Path | None, entries: list[dict]) -> None:
+    by_session: dict[str, list[dict]] = defaultdict(list)
+    for entry in entries:
+        session_id = str(entry.get("session_id") or entry.get("recording_id") or entry.get("audio_id") or "sample")
+        by_session[session_id].append(entry)
+
+    if input_file and Path(input_file).exists():
+        rows = _load_jsonl(input_file)
+        for row in rows:
+            session_id = _session_id(row)
+            session_entries = by_session.get(session_id, [])
+            pred_text = _seglst_to_sot(session_entries)
+            row["pred_text"] = pred_text
+            row["generation"] = row.get("generation") or pred_text
+            row["hypothesis_seglst"] = session_entries
+    else:
+        rows = []
+        for session_id, session_entries in sorted(by_session.items()):
+            pred_text = _seglst_to_sot(session_entries)
+            rows.append(
+                {
+                    "sample_id": session_id,
+                    "pred_text": pred_text,
+                    "generation": pred_text,
+                    "hypothesis_seglst": session_entries,
+                }
+            )
+
+    with open(output_path, "wt", encoding="utf-8") as fout:
+        for row in rows:
+            fout.write(json.dumps(row) + "\n")
+
+
+def normalize_prediction_file(path: str | Path, input_file: str | Path | None = None) -> None:
+    """Ensure Multitalker outputs contain both pred_text and generation."""
+    output_path = Path(path)
+    raw = output_path.read_text(encoding="utf-8").strip()
+    if not raw:
+        output_path.write_text("", encoding="utf-8")
+        return
+
+    parsed = json.loads(raw.splitlines()[0] if raw[0] != "[" else raw)
+    if isinstance(parsed, list):
+        _normalize_seglst_output(output_path, input_file, parsed)
+        return
+
+    rows = []
+    with open(output_path, "rt", encoding="utf-8") as fin:
+        for line_idx, line in enumerate(fin):
+            if not line.strip():
+                continue
+            row = parsed if line_idx == 0 else json.loads(line)
+            pred_text = row.get("pred_text") or row.get("generation") or row.get("text_pred") or ""
+            row["pred_text"] = pred_text
+            row["generation"] = row.get("generation") or pred_text
+            rows.append(row)
+    with open(output_path, "wt", encoding="utf-8") as fout:
+        for row in rows:
+            fout.write(json.dumps(row) + "\n")
+
+
+class MultitalkerParakeetGenerationTask:
+    """GenerationTask-compatible adapter for the streaming multitalker script."""
+
+    def __init__(self, cfg: MultitalkerParakeetGenerationConfig):
+        self.cfg = cfg
+
+    @classmethod
+    def get_generation_default_args(cls) -> str:
+        return "++prompt_format=openai"
+
+    @classmethod
+    def get_generation_requirements(cls) -> list[str] | None:
+        return None
+
+    def generate(self) -> None:
+        Path(self.cfg.output_file).parent.mkdir(parents=True, exist_ok=True)
+        env = os.environ.copy()
+        if self.cfg.nemo_root:
+            env["PYTHONPATH"] = f"{self.cfg.nemo_root}:{env.get('PYTHONPATH', '')}"
+        subprocess.run(build_multitalker_parakeet_command(self.cfg), check=True, env=env)
+        normalize_prediction_file(self.cfg.output_file, self.cfg.input_file)
+        if self.cfg.eval_type:
+            from nemo_skills.evaluation.evaluator import evaluate
+
+            eval_config = dict(self.cfg.eval_config)
+            eval_config["input_file"] = self.cfg.output_file
+            evaluate(self.cfg.eval_type, eval_config)
+
+
+GENERATION_TASK_CLASS = MultitalkerParakeetGenerationTask
+
+
+@hydra.main(version_base=None, config_name="multitalker_parakeet_generation_config")
+def generate(cfg: MultitalkerParakeetGenerationConfig) -> None:
+    cfg = MultitalkerParakeetGenerationConfig(_init_nested=True, **cfg)
+    task = MultitalkerParakeetGenerationTask(cfg)
+    task.generate()
+
+
+if __name__ == "__main__":
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print(get_help_message(MultitalkerParakeetGenerationConfig))
+    else:
+        setup_logging()
+        generate()

--- a/nemo_skills/inference/librispeechmix_rtmtasr.py
+++ b/nemo_skills/inference/librispeechmix_rtmtasr.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+"""NeMo-Skills generation wrapper for RTMT-ASR multispeaker SOT inference."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import field
+from pathlib import Path
+from typing import Any
+
+import hydra
+
+from nemo_skills.utils import get_help_message, nested_dataclass, setup_logging
+
+@nested_dataclass(kw_only=True)
+class RTMTASRGenerationConfig:
+    """Configuration for RTMT-ASR script-backed generation."""
+
+    input_file: str
+    output_file: str
+    prompt_config: Any = None
+    prompt_format: str = "openai"
+    server: dict = field(default_factory=dict)
+    eval_type: str | None = None
+    eval_config: dict = field(default_factory=dict)
+    skip_filled: bool = False
+    num_chunks: int | None = None
+    chunk_id: int | None = None
+    model_path: str = ""
+    nemo_root: str = ""
+    script_path: str = ""
+    spk_supervision: str = "rttm"
+    batch_size: int = 200
+    cuda: int = 0
+    amp: bool = True
+    clean_groundtruth_text: bool = True
+    calculate_cpwer: bool = False
+    source_lang: str = "en"
+    target_lang: str = "en"
+    task: str = "asr"
+    pnc: str = "no"
+
+    def __post_init__(self):
+        pass
+
+
+cs = hydra.core.config_store.ConfigStore.instance()
+cs.store(name="rtmtasr_generation_config", node=RTMTASRGenerationConfig)
+
+
+def resolve_script_path(cfg: RTMTASRGenerationConfig) -> Path:
+    """Resolve the RTMT-ASR transcribe script path."""
+    if cfg.script_path:
+        return Path(cfg.script_path)
+    root = Path(cfg.nemo_root or os.environ.get("NEMO_ROOT", "."))
+    return root / "examples/asr/transcribe_speech_rtmtasr.py"
+
+
+def build_rtmtasr_command(cfg: RTMTASRGenerationConfig) -> list[str]:
+    """Build the RTMT-ASR command from config."""
+    if not cfg.model_path:
+        raise ValueError("RTMT-ASR generation requires ++model_path=/path/to/model.nemo")
+    return [
+        sys.executable,
+        "-u",
+        str(resolve_script_path(cfg)),
+        f"model_path={cfg.model_path}",
+        "pretrained_name=null",
+        "audio_dir=null",
+        f"dataset_manifest={cfg.input_file}",
+        f"output_filename={cfg.output_file}",
+        f"clean_groundtruth_text={str(cfg.clean_groundtruth_text)}",
+        "langid=en",
+        "gt_lang_attr_name=target_lang",
+        f"batch_size={cfg.batch_size}",
+        "timestamps=False",
+        "compute_langs=False",
+        f"cuda={cfg.cuda}",
+        f"amp={str(cfg.amp)}",
+        "append_pred=False",
+        "calculate_wer=False",
+        f"calculate_cpwer={str(cfg.calculate_cpwer)}",
+        f"spk_supervision={cfg.spk_supervision}",
+        f"+prompt.source_lang={cfg.source_lang}",
+        f"+prompt.target_lang={cfg.target_lang}",
+        f"+prompt.task={cfg.task}",
+        f"+prompt.pnc={cfg.pnc}",
+    ]
+
+
+def normalize_prediction_file(path: str | Path) -> None:
+    """Ensure RTMT-ASR outputs contain both pred_text and generation."""
+    output_path = Path(path)
+    rows = []
+    with open(output_path, "rt", encoding="utf-8") as fin:
+        for line in fin:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            pred_text = row.get("pred_text") or row.get("generation") or ""
+            row["pred_text"] = pred_text
+            row["generation"] = row.get("generation") or pred_text
+            rows.append(row)
+    with open(output_path, "wt", encoding="utf-8") as fout:
+        for row in rows:
+            fout.write(json.dumps(row) + "\n")
+
+
+class RTMTASRGenerationTask:
+    """GenerationTask-compatible adapter that runs NeMo's RTMT-ASR script."""
+
+    def __init__(self, cfg: RTMTASRGenerationConfig):
+        self.cfg = cfg
+
+    @classmethod
+    def get_generation_default_args(cls) -> str:
+        return "++prompt_format=openai"
+
+    @classmethod
+    def get_generation_requirements(cls) -> list[str] | None:
+        return None
+
+    def generate(self) -> None:
+        Path(self.cfg.output_file).parent.mkdir(parents=True, exist_ok=True)
+        env = os.environ.copy()
+        if self.cfg.nemo_root:
+            env["PYTHONPATH"] = f"{self.cfg.nemo_root}:{env.get('PYTHONPATH', '')}"
+        subprocess.run(build_rtmtasr_command(self.cfg), check=True, env=env)
+        normalize_prediction_file(self.cfg.output_file)
+        if self.cfg.eval_type:
+            from nemo_skills.evaluation.evaluator import evaluate
+
+            eval_config = dict(self.cfg.eval_config)
+            eval_config["input_file"] = self.cfg.output_file
+            evaluate(self.cfg.eval_type, eval_config)
+
+
+GENERATION_TASK_CLASS = RTMTASRGenerationTask
+
+
+@hydra.main(version_base=None, config_name="rtmtasr_generation_config")
+def generate(cfg: RTMTASRGenerationConfig) -> None:
+    cfg = RTMTASRGenerationConfig(_init_nested=True, **cfg)
+    task = RTMTASRGenerationTask(cfg)
+    task.generate()
+
+
+if __name__ == "__main__":
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print(get_help_message(RTMTASRGenerationConfig))
+    else:
+        setup_logging()
+        generate()

--- a/recipes/multimodal/server/backends/__init__.py
+++ b/recipes/multimodal/server/backends/__init__.py
@@ -18,6 +18,8 @@ Backend implementations for the Unified NeMo Inference Server.
 Available backends:
 - magpie_tts: MagpieTTS text-to-speech (audio output from text input)
 - nemo_asr: NeMo ASR speech-to-text (text output from audio input)
+- salm: SALM speech-to-text using NeMo speechlm2 generate()
+- multitalker_parakeet: Multitalker Parakeet streaming speaker-attributed ASR
 
 Backends are lazily loaded to avoid importing heavy dependencies upfront.
 """
@@ -40,6 +42,8 @@ __all__ = [
 BACKEND_REGISTRY = {
     "magpie_tts": ("magpie_tts_backend", "MagpieTTSBackend"),
     "nemo_asr": ("nemo_asr_backend", "NeMoASRBackend"),
+    "salm": ("salm_backend", "SALMBackend"),
+    "multitalker_parakeet": ("multitalker_parakeet_backend", "MultitalkerParakeetBackend"),
 }
 
 

--- a/recipes/multimodal/server/backends/multitalker_parakeet_backend.py
+++ b/recipes/multimodal/server/backends/multitalker_parakeet_backend.py
@@ -1,0 +1,655 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# Licensed under the Apache License, Version 2.0
+
+"""Unified-server backend for persistent Multitalker Parakeet streaming ASR.
+
+This backend exposes the official NeMo multitalker streaming path through the
+OpenAI-compatible ``serve_unified`` server.  Model weights are loaded once in
+``load_model()`` and each request batch is run in-process against those model
+instances.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import os
+import sys
+import tempfile
+import threading
+import time
+import wave
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from .base import BackendConfig, GenerationRequest, GenerationResult, InferenceBackend, Modality
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ASR_MODEL = "nvidia/multitalker-parakeet-streaming-0.6b-v1"
+DEFAULT_DIAR_MODEL = "nvidia/diar_streaming_sortformer_4spk-v2.1"
+DEFAULT_NEMO_ROOT = "/opt/NeMo"
+
+
+@dataclass
+class _RuntimeModules:
+    torch: Any
+    pl: Any
+    nemo_asr: Any
+    SortformerEncLabelModel: Any
+    CacheAwareStreamingAudioBuffer: Any
+    get_multi_talker_samples_from_manifest: Any
+    OmegaConf: Any
+
+
+@dataclass
+class MultitalkerParakeetConfig(BackendConfig):
+    """Configuration for the Multitalker Parakeet unified backend."""
+
+    model_name: Optional[str] = None
+    asr_model: Optional[str] = None
+    diar_model: str = DEFAULT_DIAR_MODEL
+    nemo_root: str = DEFAULT_NEMO_ROOT
+    script_path: str = ""
+    model_cache_dir: Optional[str] = None
+    resolve_hf_models: bool = True
+    spk_supervision: str = "diar"
+    max_num_of_spks: int = 4
+    masked_asr: bool = False
+    parallel_speaker_strategy: bool = True
+    binary_diar_preds: bool = True
+    batch_size: int = 16
+    mt_batch_size: Optional[int] = None
+    num_workers: int = 0
+    att_context_size: Any = "[70,13]"
+    spkcache_len: int = 188
+    spkcache_refresh_rate: int = 144
+    fifo_len: int = 188
+    chunk_len: int = 13
+    chunk_left_context: int = 1
+    chunk_right_context: int = 0
+    cache_gating: bool = False
+    request_timeout_s: int = 7200
+    log: bool = False
+    session_len_sec: float = -1.0
+    streaming_mode: bool = True
+    use_amp: bool = True
+    online_normalization: bool = False
+    pad_and_drop_preencoded: bool = False
+    chunk_size: int = -1
+    shift_size: int = -1
+    left_chunks: int = 2
+    matmul_precision: str = "highest"
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "MultitalkerParakeetConfig":
+        if d.get("model_name") and not d.get("model_path"):
+            d = {**d, "model_path": d["model_name"]}
+        if d.get("asr_model") and not d.get("model_path"):
+            d = {**d, "model_path": d["asr_model"]}
+        if d.get("model_path") and not d.get("asr_model"):
+            d = {**d, "asr_model": d["model_path"]}
+        if d.get("mt_batch_size"):
+            d = {**d, "batch_size": d["mt_batch_size"]}
+
+        known = {field.name for field in cls.__dataclass_fields__.values()}
+        return cls(
+            **{k: v for k, v in d.items() if k in known and k != "extra_config"},
+            extra_config={k: v for k, v in d.items() if k not in known},
+        )
+
+
+def _resolve_script_path(cfg: MultitalkerParakeetConfig) -> Path:
+    if cfg.script_path:
+        return Path(cfg.script_path)
+    return Path(cfg.nemo_root) / "examples/asr/asr_cache_aware_streaming/speech_to_text_multitalker_streaming_infer.py"
+
+
+def _session_id_from_audio_path(path: str) -> str:
+    return Path(path).stem
+
+
+def _duration_seconds(path: Path) -> float:
+    try:
+        import soundfile as sf
+
+        info = sf.info(str(path))
+        return float(info.frames) / float(info.samplerate)
+    except Exception:
+        with wave.open(str(path), "rb") as wavf:
+            return float(wavf.getnframes()) / float(wavf.getframerate())
+
+
+def _get_request_audio_bytes(request: GenerationRequest) -> bytes:
+    if request.audio_bytes:
+        return request.audio_bytes
+    if request.audio_bytes_list:
+        if len(request.audio_bytes_list) > 1:
+            raise ValueError("multitalker_parakeet backend supports one mixed audio input per request.")
+        return request.audio_bytes_list[0]
+    raise ValueError("Request must contain audio_bytes or audio_bytes_list.")
+
+
+def _seglst_to_sot(entries: list[dict]) -> str:
+    tag_by_speaker: dict[str, str] = {}
+    chunks: list[str] = []
+    for entry in sorted(
+        entries,
+        key=lambda item: (
+            float(item.get("start_time", 0.0) or 0.0),
+            float(item.get("end_time", 0.0) or 0.0),
+            str(item.get("speaker", "")),
+        ),
+    ):
+        words = str(entry.get("words") or entry.get("text") or "").strip()
+        if not words:
+            continue
+        speaker = str(entry.get("speaker") or "speaker")
+        if speaker not in tag_by_speaker:
+            tag_by_speaker[speaker] = f"s{len(tag_by_speaker)}"
+        chunks.append(f"[{tag_by_speaker[speaker]}] {words}")
+    return " ".join(chunks)
+
+
+def _group_seglst_by_session(entries: list[dict]) -> dict[str, list[dict]]:
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for entry in entries:
+        session_id = str(entry.get("session_id") or entry.get("recording_id") or entry.get("audio_id") or "")
+        if not session_id and entry.get("audio_filepath"):
+            session_id = _session_id_from_audio_path(str(entry["audio_filepath"]))
+        grouped[session_id].append(entry)
+    return grouped
+
+
+def _choose_nemo_file(repo_id: str, files: list[str], preferred_name: str | None) -> str | None:
+    nemo_files = [name for name in files if name.endswith(".nemo")]
+    if not nemo_files:
+        return None
+    if preferred_name:
+        preferred = [name for name in nemo_files if Path(name).name == preferred_name]
+        if preferred:
+            return preferred[0]
+    repo_basename = repo_id.rsplit("/", 1)[-1]
+    for name in nemo_files:
+        if Path(name).stem == repo_basename:
+            return name
+    return nemo_files[0]
+
+
+def _resolve_hf_nemo_file(model_ref: str, *, cache_dir: str | None = None, required: bool = False) -> str:
+    model_path = Path(model_ref)
+    if model_path.exists():
+        return str(model_path)
+    if model_ref.endswith((".nemo", ".ckpt")) and os.sep in model_ref:
+        return model_ref
+    if "/" not in model_ref:
+        return model_ref
+
+    try:
+        from huggingface_hub import hf_hub_download, list_repo_files
+
+        files = list_repo_files(model_ref, repo_type="model")
+        chosen = _choose_nemo_file(model_ref, files, preferred_name=f"{model_ref.rsplit('/', 1)[-1]}.nemo")
+        if chosen is None:
+            if required:
+                raise FileNotFoundError(f"No .nemo file found in Hugging Face repo {model_ref}")
+            return model_ref
+        return hf_hub_download(repo_id=model_ref, filename=chosen, cache_dir=cache_dir)
+    except Exception as exc:
+        if required:
+            raise RuntimeError(f"Could not resolve required Hugging Face .nemo file for {model_ref}: {exc}") from exc
+        logger.warning("Could not resolve Hugging Face model %s to a .nemo file: %s", model_ref, exc)
+        return model_ref
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
+def _as_int(value: Any) -> int:
+    return int(value)
+
+
+def _parse_att_context_size(value: Any) -> list[int] | None:
+    if value in (None, "", "None"):
+        return None
+    if isinstance(value, (list, tuple)):
+        return [int(item) for item in value]
+    if isinstance(value, str):
+        text = value.strip()
+        if text.startswith("["):
+            return [int(item) for item in json.loads(text)]
+        return [int(item.strip()) for item in text.split(",") if item.strip()]
+    raise TypeError(f"Unsupported att_context_size value: {value!r}")
+
+
+def _import_script_module(script_path: Path) -> Any:
+    module_name = "_nemo_multitalker_streaming_infer"
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not import Multitalker Parakeet script from {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _import_runtime_modules() -> _RuntimeModules:
+    import pytorch_lightning as pl
+    import torch
+    from omegaconf import OmegaConf
+
+    import nemo.collections.asr as nemo_asr
+    from nemo.collections.asr.models.sortformer_diar_models import SortformerEncLabelModel
+    from nemo.collections.asr.parts.utils.multispk_transcribe_utils import get_multi_talker_samples_from_manifest
+    from nemo.collections.asr.parts.utils.streaming_utils import CacheAwareStreamingAudioBuffer
+
+    return _RuntimeModules(
+        torch=torch,
+        pl=pl,
+        nemo_asr=nemo_asr,
+        SortformerEncLabelModel=SortformerEncLabelModel,
+        CacheAwareStreamingAudioBuffer=CacheAwareStreamingAudioBuffer,
+        get_multi_talker_samples_from_manifest=get_multi_talker_samples_from_manifest,
+        OmegaConf=OmegaConf,
+    )
+
+
+def _configure_cpu_thread_env() -> None:
+    for name in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS", "NUMEXPR_NUM_THREADS"):
+        os.environ.setdefault(name, "1")
+
+
+class MultitalkerParakeetBackend(InferenceBackend):
+    """Unified-server backend for persistent NeMo Multitalker Parakeet inference."""
+
+    @classmethod
+    def get_config_class(cls) -> type:
+        return MultitalkerParakeetConfig
+
+    @property
+    def name(self) -> str:
+        return "multitalker_parakeet"
+
+    @property
+    def supported_modalities(self) -> Set[Modality]:
+        return {Modality.AUDIO_IN, Modality.TEXT}
+
+    def __init__(self, config: BackendConfig):
+        self.mt_config = (
+            config if isinstance(config, MultitalkerParakeetConfig) else MultitalkerParakeetConfig.from_dict(config.extra_config)
+        )
+        super().__init__(self.mt_config)
+        self._script_path: Path | None = None
+        self._script_module: Any = None
+        self._runtime: _RuntimeModules | None = None
+        self._runtime_cfg_template: Any = None
+        self._asr_model_ref = self.mt_config.asr_model or self.mt_config.model_path or DEFAULT_ASR_MODEL
+        self._diar_model_ref = self.mt_config.diar_model
+        self._asr_model = None
+        self._diar_model = None
+        self._device = self.mt_config.device
+        self._pl_devices: Any = 1
+        self._accelerator = "cpu"
+        self._inference_lock = threading.Lock()
+
+    def load_model(self) -> None:
+        _configure_cpu_thread_env()
+        script_path = _resolve_script_path(self.mt_config)
+        if not script_path.exists():
+            raise FileNotFoundError(f"Multitalker Parakeet script not found: {script_path}")
+        self._script_path = script_path
+        self._script_module = _import_script_module(script_path)
+        self._runtime = _import_runtime_modules()
+        try:
+            self._runtime.torch.set_num_threads(max(1, int(os.environ.get("OMP_NUM_THREADS", "1"))))
+        except Exception as exc:
+            logger.warning("Could not set torch CPU thread count: %s", exc)
+
+        if self.mt_config.resolve_hf_models:
+            self._asr_model_ref = _resolve_hf_nemo_file(
+                self._asr_model_ref,
+                cache_dir=self.mt_config.model_cache_dir,
+            )
+            self._diar_model_ref = _resolve_hf_nemo_file(
+                self._diar_model_ref,
+                cache_dir=self.mt_config.model_cache_dir,
+                required=not str(self._diar_model_ref).endswith((".nemo", ".ckpt")),
+            )
+
+        self._runtime_cfg_template = self._build_runtime_cfg()
+        self._device, self._pl_devices, self._accelerator, map_location = self._select_device()
+        self._runtime.torch.set_float32_matmul_precision(str(self._runtime_cfg_template.matmul_precision))
+
+        self._diar_model = self._load_diar_model(map_location)
+        trainer = self._runtime.pl.Trainer(devices=self._pl_devices, accelerator=self._accelerator)
+        self._diar_model.set_trainer(trainer)
+        self._configure_diar_model(self._runtime_cfg_template)
+        self._diar_model = self._diar_model.eval()
+
+        self._asr_model = self._load_asr_model(map_location)
+        self._asr_model = self._asr_model.to(self._device)
+        self._asr_model.eval()
+        self._configure_asr_model(self._runtime_cfg_template)
+        self._set_script_autocast(self._runtime_cfg_template)
+
+        self._model = self._asr_model
+        self._is_loaded = True
+        logger.info(
+            "Loaded Multitalker Parakeet backend with asr_model=%s diar_model=%s script=%s device=%s",
+            self._asr_model_ref,
+            self._diar_model_ref,
+            self._script_path,
+            self._device,
+        )
+
+    def _build_runtime_cfg(self) -> Any:
+        cfg = self._runtime.OmegaConf.structured(self._script_module.MultitalkerTranscriptionConfig())
+        cfg.asr_model = str(self._asr_model_ref)
+        cfg.diar_model = str(self._diar_model_ref)
+        cfg.diar_pretrained_name = None
+        cfg.device = str(self.mt_config.device)
+        cfg.manifest_file = None
+        cfg.audio_file = None
+        cfg.log = _as_bool(self.mt_config.log)
+        cfg.binary_diar_preds = _as_bool(self.mt_config.binary_diar_preds)
+        cfg.spk_supervision = str(self.mt_config.spk_supervision)
+        cfg.max_num_of_spks = _as_int(self.mt_config.max_num_of_spks)
+        cfg.masked_asr = _as_bool(self.mt_config.masked_asr)
+        cfg.parallel_speaker_strategy = _as_bool(self.mt_config.parallel_speaker_strategy)
+        cfg.att_context_size = _parse_att_context_size(self.mt_config.att_context_size)
+        cfg.generate_realtime_scripts = False
+        cfg.batch_size = max(1, _as_int(self.mt_config.batch_size))
+        cfg.num_workers = max(0, _as_int(self.mt_config.num_workers))
+        cfg.cache_gating = _as_bool(self.mt_config.cache_gating)
+        cfg.spkcache_len = _as_int(self.mt_config.spkcache_len)
+        cfg.spkcache_refresh_rate = _as_int(self.mt_config.spkcache_refresh_rate)
+        cfg.fifo_len = _as_int(self.mt_config.fifo_len)
+        cfg.chunk_len = _as_int(self.mt_config.chunk_len)
+        cfg.chunk_left_context = _as_int(self.mt_config.chunk_left_context)
+        cfg.chunk_right_context = _as_int(self.mt_config.chunk_right_context)
+        cfg.session_len_sec = float(self.mt_config.session_len_sec)
+        cfg.streaming_mode = _as_bool(self.mt_config.streaming_mode)
+        cfg.use_amp = _as_bool(self.mt_config.use_amp)
+        cfg.online_normalization = _as_bool(self.mt_config.online_normalization)
+        cfg.pad_and_drop_preencoded = _as_bool(self.mt_config.pad_and_drop_preencoded)
+        cfg.chunk_size = _as_int(self.mt_config.chunk_size)
+        cfg.shift_size = _as_int(self.mt_config.shift_size)
+        cfg.left_chunks = _as_int(self.mt_config.left_chunks)
+        cfg.matmul_precision = str(self.mt_config.matmul_precision)
+        return cfg
+
+    def _select_device(self) -> tuple[str, Any, str, Any]:
+        requested = str(self.mt_config.device or "cuda")
+        torch = self._runtime.torch
+        if requested.startswith("cuda") and torch.cuda.is_available():
+            if ":" in requested:
+                device_idx = int(requested.split(":", 1)[1])
+            else:
+                device_idx = 0
+            device = f"cuda:{device_idx}"
+            return device, [device_idx], "gpu", torch.device(device)
+        return "cpu", 1, "cpu", torch.device("cpu")
+
+    def _load_diar_model(self, map_location: Any) -> Any:
+        model_ref = str(self._diar_model_ref)
+        if model_ref.endswith(".ckpt"):
+            return self._runtime.SortformerEncLabelModel.load_from_checkpoint(
+                checkpoint_path=model_ref,
+                map_location=map_location,
+                strict=False,
+            )
+        if model_ref.endswith(".nemo") or Path(model_ref).exists():
+            return self._runtime.SortformerEncLabelModel.restore_from(restore_path=model_ref, map_location=map_location)
+        return self._runtime.SortformerEncLabelModel.from_pretrained(model_ref)
+
+    def _load_asr_model(self, map_location: Any) -> Any:
+        model_ref = str(self._asr_model_ref)
+        if model_ref.endswith(".nemo") or Path(model_ref).exists():
+            try:
+                return self._runtime.nemo_asr.models.ASRModel.restore_from(
+                    restore_path=model_ref,
+                    map_location=map_location,
+                )
+            except TypeError:
+                return self._runtime.nemo_asr.models.ASRModel.restore_from(restore_path=model_ref)
+        try:
+            return self._runtime.nemo_asr.models.ASRModel.from_pretrained(
+                model_name=model_ref,
+                map_location=map_location,
+            )
+        except TypeError:
+            return self._runtime.nemo_asr.models.ASRModel.from_pretrained(model_name=model_ref)
+
+    def _configure_diar_model(self, cfg: Any) -> None:
+        test_ds = self._diar_model._cfg.test_ds
+        test_ds.session_len_sec = cfg.session_len_sec
+        test_ds.batch_size = cfg.batch_size
+        test_ds.num_workers = cfg.num_workers
+
+        self._diar_model.streaming_mode = cfg.streaming_mode
+        modules = getattr(self._diar_model, "sortformer_modules", None)
+        if modules is not None:
+            modules.chunk_len = cfg.chunk_len
+            modules.spkcache_len = cfg.spkcache_len
+            modules.chunk_left_context = cfg.chunk_left_context
+            modules.chunk_right_context = cfg.chunk_right_context
+            modules.fifo_len = cfg.fifo_len
+            modules.log = cfg.log
+            modules.spkcache_refresh_rate = cfg.spkcache_refresh_rate
+
+    def _configure_asr_model(self, cfg: Any) -> None:
+        if cfg.att_context_size is not None:
+            if hasattr(self._asr_model.encoder, "set_default_att_context_size"):
+                self._asr_model.encoder.set_default_att_context_size(att_context_size=cfg.att_context_size)
+            else:
+                raise ValueError("Model does not support multiple lookaheads.")
+
+        if cfg.chunk_size > 0:
+            shift_size = cfg.chunk_size if cfg.shift_size < 0 else cfg.shift_size
+            self._asr_model.encoder.setup_streaming_params(
+                chunk_size=cfg.chunk_size,
+                left_chunks=cfg.left_chunks,
+                shift_size=shift_size,
+            )
+
+    def _set_script_autocast(self, cfg: Any) -> None:
+        device = getattr(self._asr_model, "device", None)
+        device_type = getattr(device, "type", None) or str(self._device).split(":", 1)[0]
+        self._script_module.autocast = self._runtime.torch.amp.autocast(device_type, enabled=cfg.use_amp)
+
+    def validate_request(self, request: GenerationRequest) -> Optional[str]:
+        has_audio = request.audio_bytes is not None or (
+            request.audio_bytes_list is not None and len(request.audio_bytes_list) > 0
+        )
+        if not has_audio:
+            return "multitalker_parakeet backend requires audio input"
+        if request.audio_bytes_list is not None and len(request.audio_bytes_list) > 1:
+            return "multitalker_parakeet backend supports one mixed audio input per request"
+        return None
+
+    def _batch_cfg(self, manifest_file: Path, batch_size: int) -> Any:
+        payload = self._runtime.OmegaConf.to_container(self._runtime_cfg_template, resolve=True)
+        cfg = self._runtime.OmegaConf.create(payload)
+        cfg.manifest_file = str(manifest_file)
+        cfg.audio_file = None
+        cfg.batch_size = max(1, min(int(cfg.batch_size), max(1, batch_size)))
+        cfg.device = self._device
+        return cfg
+
+    def _setup_diar_test_data(self, cfg: Any) -> None:
+        test_ds = self._diar_model._cfg.test_ds
+        test_ds.session_len_sec = cfg.session_len_sec
+        test_ds.manifest_filepath = cfg.manifest_file
+        test_ds.batch_size = cfg.batch_size
+        test_ds.num_workers = cfg.num_workers
+        self._diar_model.setup_test_data(test_data_config=test_ds)
+
+    @staticmethod
+    def _json_scalar(value: Any) -> Any:
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        if hasattr(value, "item"):
+            return value.item()
+        return str(value)
+
+    @classmethod
+    def _sanitize_seglst_entry(cls, entry: dict) -> dict:
+        sanitized: dict[str, Any] = {}
+        for key in ("session_id", "recording_id", "audio_id", "audio_filepath", "speaker", "words", "text"):
+            if key in entry:
+                sanitized[key] = str(cls._json_scalar(entry[key]))
+        for key in ("start_time", "end_time"):
+            if key in entry:
+                sanitized[key] = float(cls._json_scalar(entry[key]))
+        return sanitized
+
+    @staticmethod
+    def _coerce_batch_entries(streamer: Any, batch_entries: Any) -> list[dict]:
+        if batch_entries is not None:
+            entries = list(batch_entries)
+        else:
+            instance_manager = getattr(streamer, "instance_manager", None)
+            entries = list(getattr(instance_manager, "seglst_dict_list", None) or [])
+        return [
+            MultitalkerParakeetBackend._sanitize_seglst_entry(entry)
+            for entry in entries
+            if isinstance(entry, dict)
+        ]
+
+    def _run_inprocess_manifest(self, manifest_file: Path, batch_size: int) -> list[dict]:
+        if self._runtime is None or self._script_module is None:
+            raise RuntimeError("Multitalker backend runtime is not initialized.")
+
+        cfg = self._batch_cfg(manifest_file, batch_size)
+        with self._inference_lock:
+            self._setup_diar_test_data(cfg)
+            self._set_script_autocast(cfg)
+
+            feat_per_sec = round(
+                self._asr_model.cfg.preprocessor.window_stride * self._asr_model.cfg.encoder.subsampling_factor,
+                2,
+            )
+            samples, rttms_mask_mats = self._runtime.get_multi_talker_samples_from_manifest(
+                cfg,
+                manifest_file=str(manifest_file),
+                feat_per_sec=feat_per_sec,
+                max_spks=cfg.max_num_of_spks,
+            )
+            if cfg.spk_supervision == "rttm":
+                self._diar_model.add_rttms_mask_mats(rttms_mask_mats, device=self._asr_model.device)
+
+            logger.info("Running persistent Multitalker Parakeet inference for %d samples", len(samples))
+            streaming_buffer = self._runtime.CacheAwareStreamingAudioBuffer(
+                model=self._asr_model,
+                online_normalization=cfg.online_normalization,
+                pad_and_drop_preencoded=cfg.pad_and_drop_preencoded,
+            )
+
+            seglst_entries: list[dict] = []
+            batch_samples: list[dict] = []
+            for sample_idx, sample in enumerate(samples):
+                batch_samples.append(sample)
+                streaming_buffer.append_audio_file(sample["audio_filepath"], stream_id=-1)
+
+                if (sample_idx + 1) % cfg.batch_size == 0 or sample_idx == len(samples) - 1:
+                    if cfg.parallel_speaker_strategy:
+                        streamer = self._script_module.launch_parallel_streaming(
+                            cfg=cfg,
+                            asr_model=self._asr_model,
+                            diar_model=self._diar_model,
+                            streaming_buffer=streaming_buffer,
+                            pad_and_drop_preencoded=cfg.pad_and_drop_preencoded,
+                        )
+                        batch_entries = streamer.generate_seglst_dicts_from_parallel_streaming(samples=batch_samples)
+                    else:
+                        streamer = self._script_module.launch_serial_streaming(
+                            cfg=cfg,
+                            asr_model=self._asr_model,
+                            diar_model=self._diar_model,
+                            streaming_buffer=streaming_buffer,
+                            pad_and_drop_preencoded=cfg.pad_and_drop_preencoded,
+                        )
+                        batch_entries = streamer.generate_seglst_dicts_from_serial_streaming(samples=batch_samples)
+
+                    seglst_entries.extend(self._coerce_batch_entries(streamer, batch_entries))
+                    streaming_buffer.reset_buffer()
+                    batch_samples = []
+
+            return seglst_entries
+
+    def _manifest_record(self, audio_path: Path, request: GenerationRequest) -> dict[str, Any]:
+        extra = request.extra_params or {}
+        record = {
+            "audio_filepath": str(audio_path),
+            "offset": float(extra.get("offset", 0.0) or 0.0),
+            "duration": float(extra.get("duration") or round(_duration_seconds(audio_path), 4)),
+        }
+        if extra.get("rttm_filepath"):
+            record["rttm_filepath"] = str(extra["rttm_filepath"])
+        return record
+
+    def generate(self, requests: List[GenerationRequest]) -> List[GenerationResult]:
+        if not self._is_loaded:
+            return [GenerationResult(error="Model not loaded", request_id=request.request_id) for request in requests]
+        if not requests:
+            return []
+
+        start = time.time()
+        session_ids: list[str] = []
+        results: list[GenerationResult | None] = [None] * len(requests)
+
+        with tempfile.TemporaryDirectory(prefix="multitalker_parakeet_") as temp_name:
+            temp_dir = Path(temp_name)
+            manifest_file = temp_dir / "input.jsonl"
+
+            with open(manifest_file, "wt", encoding="utf-8") as fout:
+                for idx, request in enumerate(requests):
+                    try:
+                        audio_path = temp_dir / f"req_{idx:04d}.wav"
+                        audio_path.write_bytes(_get_request_audio_bytes(request))
+                        session_ids.append(audio_path.stem)
+                        fout.write(json.dumps(self._manifest_record(audio_path, request)) + "\n")
+                    except Exception as exc:
+                        session_ids.append("")
+                        results[idx] = GenerationResult(error=str(exc), request_id=request.request_id)
+
+            runnable_indices = [idx for idx, result in enumerate(results) if result is None]
+            if not runnable_indices:
+                return [result if result is not None else GenerationResult(error="Unknown multitalker backend error") for result in results]
+
+            try:
+                entries = self._run_inprocess_manifest(manifest_file, len(runnable_indices))
+                grouped_entries = _group_seglst_by_session(entries)
+                per_req_ms = (time.time() - start) * 1000.0 / max(len(runnable_indices), 1)
+
+                for idx in runnable_indices:
+                    session_entries = grouped_entries.get(session_ids[idx], [])
+                    text = _seglst_to_sot(session_entries)
+                    results[idx] = GenerationResult(
+                        text=text,
+                        request_id=requests[idx].request_id,
+                        generation_time_ms=per_req_ms,
+                        debug_info={
+                            "backend": self.name,
+                            "model": self._asr_model_ref,
+                            "diar_model": self._diar_model_ref,
+                            "spk_supervision": self.mt_config.spk_supervision,
+                            "hypothesis_seglst": session_entries,
+                            "persistent_inprocess": True,
+                        },
+                    )
+            except Exception as exc:
+                logger.exception("Persistent Multitalker Parakeet inference failed")
+                error = str(exc)
+                for idx in runnable_indices:
+                    results[idx] = GenerationResult(error=error, request_id=requests[idx].request_id)
+
+            return [result if result is not None else GenerationResult(error="Unknown multitalker backend error") for result in results]

--- a/recipes/multimodal/server/backends/salm_backend.py
+++ b/recipes/multimodal/server/backends/salm_backend.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# Licensed under the Apache License, Version 2.0
+
+"""SALM backend for unified_server.
+
+This supports generic Canary-Qwen style ASR through NeMo SALM.generate().
+It is not a LibriSpeechMix SOT-specific backend and does not add speaker
+supervision by itself.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+import time
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from .base import BackendConfig, GenerationRequest, GenerationResult, InferenceBackend, Modality
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ASR_PROMPT = "Transcribe the following:"
+
+
+@dataclass
+class SALMConfig(BackendConfig):
+    """Configuration for SALM backend."""
+
+    model_name: Optional[str] = None
+    batch_size: int = 16
+    warmup: bool = True
+    user_prompt: str = DEFAULT_ASR_PROMPT
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "SALMConfig":
+        if d.get("model_name") and not d.get("model_path"):
+            d = {**d, "model_path": d["model_name"]}
+        known = {
+            "model_path",
+            "model_name",
+            "device",
+            "dtype",
+            "max_new_tokens",
+            "temperature",
+            "top_p",
+            "top_k",
+            "batch_size",
+            "warmup",
+            "user_prompt",
+        }
+        return cls(
+            **{k: v for k, v in d.items() if k in known},
+            extra_config={k: v for k, v in d.items() if k not in known},
+        )
+
+
+class SALMBackend(InferenceBackend):
+    """Unified-server backend for SALM models such as nvidia/canary-qwen-2.5b."""
+
+    @classmethod
+    def get_config_class(cls) -> type:
+        return SALMConfig
+
+    @property
+    def name(self) -> str:
+        return "salm"
+
+    @property
+    def supported_modalities(self) -> Set[Modality]:
+        return {Modality.AUDIO_IN, Modality.TEXT}
+
+    def __init__(self, config: BackendConfig):
+        self.salm_config = config if isinstance(config, SALMConfig) else SALMConfig.from_dict(config.extra_config)
+        super().__init__(self.salm_config)
+        self._model_name = self.salm_config.model_path or self.salm_config.model_name
+        self._model = None
+
+    def load_model(self) -> None:
+        if not self._model_name:
+            raise ValueError("SALM backend requires model_path or model_name.")
+
+        from nemo.collections.speechlm2.models import SALM
+
+        if Path(self._model_name).exists():
+            self._model = SALM.restore_from(self._model_name)
+        else:
+            self._model = SALM.from_pretrained(self._model_name)
+
+        self._model.to(self.config.device)
+        self._model.eval()
+
+        if self.salm_config.warmup:
+            self._run_warmup()
+
+        self._is_loaded = True
+        logger.info("Loaded SALM model=%s on device=%s", self._model_name, self.config.device)
+
+    def _run_warmup(self) -> None:
+        fd, path = tempfile.mkstemp(suffix=".wav", prefix="salm_warmup_")
+        os.close(fd)
+        try:
+            with wave.open(path, "wb") as wavf:
+                wavf.setnchannels(1)
+                wavf.setsampwidth(2)
+                wavf.setframerate(16000)
+                wavf.writeframes(b"\x00\x00" * 16000)
+            prompts = [
+                [
+                    {
+                        "role": "user",
+                        "content": f"{self.salm_config.user_prompt} {self._model.audio_locator_tag}",
+                        "audio": [path],
+                    }
+                ]
+            ]
+            self._model.generate(prompts=prompts, max_new_tokens=8)
+        except Exception as exc:
+            logger.warning("SALM warmup skipped due to error: %s", exc)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def _get_request_audio_bytes(self, request: GenerationRequest) -> bytes:
+        if request.audio_bytes:
+            return request.audio_bytes
+        if request.audio_bytes_list:
+            if len(request.audio_bytes_list) > 1:
+                raise ValueError("SALM backend currently supports one audio input per request.")
+            return request.audio_bytes_list[0]
+        raise ValueError("Request must contain audio_bytes or audio_bytes_list.")
+
+    def validate_request(self, request: GenerationRequest) -> Optional[str]:
+        if request.audio_bytes is None and not request.audio_bytes_list:
+            return "SALM backend requires audio input"
+        if request.audio_bytes_list is not None and len(request.audio_bytes_list) > 1:
+            return "SALM backend currently supports one audio input per request"
+        return None
+
+    def generate(self, requests: List[GenerationRequest]) -> List[GenerationResult]:
+        if not self._is_loaded:
+            return [GenerationResult(error="Model not loaded", request_id=request.request_id) for request in requests]
+        if not requests:
+            return []
+
+        tmp_dir = Path(tempfile.mkdtemp(prefix="salm_batch_"))
+        start = time.time()
+        temp_paths: list[str] = []
+        valid_indices: list[int] = []
+        results: list[GenerationResult | None] = [None] * len(requests)
+
+        try:
+            for idx, request in enumerate(requests):
+                try:
+                    path = tmp_dir / f"req_{idx:04d}.wav"
+                    path.write_bytes(self._get_request_audio_bytes(request))
+                    temp_paths.append(str(path))
+                    valid_indices.append(idx)
+                except Exception as exc:
+                    results[idx] = GenerationResult(error=str(exc), request_id=request.request_id)
+
+            if temp_paths:
+                prompts = []
+                max_new_tokens = self.config.max_new_tokens
+                audio_tag = self._model.audio_locator_tag
+                for out_idx, path in enumerate(temp_paths):
+                    request = requests[valid_indices[out_idx]]
+                    user_prompt = request.user_prompt or request.extra_params.get("user_prompt", self.salm_config.user_prompt)
+                    prompts.append([{"role": "user", "content": f"{user_prompt} {audio_tag}", "audio": [path]}])
+                    if request.max_new_tokens:
+                        max_new_tokens = max(max_new_tokens, request.max_new_tokens)
+
+                output_ids = self._model.generate(prompts=prompts, max_new_tokens=max_new_tokens)
+                if len(output_ids) != len(temp_paths):
+                    raise RuntimeError(f"SALM output size mismatch: got {len(output_ids)} for {len(temp_paths)} inputs.")
+
+                per_req_ms = (time.time() - start) * 1000.0 / max(len(temp_paths), 1)
+                for out_idx, ids in enumerate(output_ids):
+                    req_idx = valid_indices[out_idx]
+                    request = requests[req_idx]
+                    text = self._model.tokenizer.ids_to_text(ids.cpu())
+                    results[req_idx] = GenerationResult(
+                        text=text,
+                        request_id=request.request_id,
+                        num_tokens_generated=len(ids),
+                        generation_time_ms=per_req_ms,
+                        debug_info={"backend": "salm", "model": self._model_name},
+                    )
+            return [result if result is not None else GenerationResult(error="Unknown SALM backend error") for result in results]
+        except Exception as exc:
+            return [GenerationResult(error=str(exc), request_id=request.request_id) for request in requests]
+        finally:
+            for path in temp_paths:
+                Path(path).unlink(missing_ok=True)
+            try:
+                tmp_dir.rmdir()
+            except OSError:
+                pass

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -58,6 +58,7 @@ DATASETS = [
     ("contextasr-bench", ["test"]),
     ("audiobench", ["test"]),
     ("librispeech-pc", ["test"]),
+    ("librispeechmix-sot", ["test"]),
     ("musan", ["test"]),
     ("compute-eval", ["eval"]),
 ]

--- a/tests/test_librispeechmix_sot.py
+++ b/tests/test_librispeechmix_sot.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0
+
+import importlib
+import asyncio
+import inspect
+import json
+import subprocess
+import types
+import wave
+from pathlib import Path
+
+import pytest
+
+from nemo_skills.dataset.utils import get_dataset_module
+from nemo_skills.evaluation.evaluator.librispeechmix_sot import LibriSpeechMixSOTEvaluator
+from nemo_skills.evaluation.metrics.librispeechmix_sot_metrics import LibriSpeechMixSOTMetrics
+from nemo_skills.evaluation.metrics.librispeechmix_sot_utils import cpwer, parse_sot_speaker_streams
+
+
+prepare = importlib.import_module("nemo_skills.dataset.librispeechmix-sot.prepare")
+
+
+def _write_wav(path: Path, duration: float = 0.05, sample_rate: int = 16000) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frames = int(duration * sample_rate)
+    with wave.open(str(path), "wb") as wavf:
+        wavf.setnchannels(1)
+        wavf.setsampwidth(2)
+        wavf.setframerate(sample_rate)
+        wavf.writeframes(b"\x00\x00" * frames)
+
+
+def _row(duration_a=5.0, delay_b=2.0, duration_b=3.0):
+    return {
+        "id": "test-clean-2mix/test-clean-2mix-0000",
+        "mixed_wav": "test-clean-2mix/test-clean-2mix-0000.wav",
+        "texts": ["HELLO, WORLD", "GOOD MORNING"],
+        "wavs": ["test-clean/111/1/111-1-0000.wav", "test-clean/222/2/222-2-0000.wav"],
+        "delays": [0.0, delay_b],
+        "speakers": ["111", "222"],
+        "durations": [duration_a, duration_b],
+        "genders": ["m", "f"],
+        "speaker_profile": [],
+        "speaker_profile_index": [0, 1],
+    }
+
+
+def test_group_registration():
+    group_module, _ = get_dataset_module("librispeechmix-sot")
+    assert group_module.IS_BENCHMARK_GROUP is True
+    assert "librispeechmix-sot.under20s-test-clean-3mix" in group_module.BENCHMARKS
+
+    sub_module, _ = get_dataset_module("librispeechmix-sot.under20s-test-clean-1mix")
+    assert sub_module.METRICS_TYPE == "librispeechmix_sot"
+    assert "++eval_type=librispeechmix_sot" in sub_module.EVAL_ARGS
+
+
+def test_under_over_split_threshold():
+    assert prepare.duration_bucket(20.0) == "under20s"
+    assert prepare.duration_bucket(20.0001) == "over20s"
+
+
+def test_rttm_generation_and_stable_sot_tags():
+    row = {
+        **_row(),
+        "texts": ["SECOND", "FIRST"],
+        "speakers": ["b_spk", "a_spk"],
+        "delays": [1.0, 0.0],
+        "durations": [2.0, 3.0],
+    }
+
+    assert prepare.speaker_tag_map(row) == {"a_spk": "s0", "b_spk": "s1"}
+    assert prepare.sot_text(row) == "[s0] first [s1] second"
+    assert prepare.num_speaker_changes(row) == 1
+
+    lines = prepare.rttm_lines(row, "mix0")
+    assert lines == [
+        "SPEAKER mix0 1 1.000 2.000 <NA> <NA> b_spk <NA> <NA>\n",
+        "SPEAKER mix0 1 0.000 3.000 <NA> <NA> a_spk <NA> <NA>\n",
+    ]
+
+
+def test_prepare_writes_under_and_over_manifests(tmp_path):
+    data_dir = tmp_path / "data"
+    rows = [_row(duration_a=5.0, delay_b=1.0, duration_b=3.0), _row(duration_a=21.0, delay_b=0.0, duration_b=1.0)]
+    counts = prepare.prepare_split_mix(
+        split="test-clean",
+        mix="2mix",
+        rows=rows,
+        output_dir=tmp_path / "benchmark",
+        data_dir=data_dir,
+        audio_prefix=data_dir / "audio",
+        no_audio=True,
+        max_samples=1,
+        librispeech_root=data_dir / "LibriSpeech",
+    )
+
+    assert counts == {"under20s-test-clean-2mix": 1, "over20s-test-clean-2mix": 1}
+    under_record = json.loads((tmp_path / "benchmark/under20s-test-clean-2mix/test.jsonl").read_text().splitlines()[0])
+    over_record = json.loads((tmp_path / "benchmark/over20s-test-clean-2mix/test.jsonl").read_text().splitlines()[0])
+
+    assert under_record["duration"] <= 20.0
+    assert over_record["duration"] > 20.0
+    assert under_record["source_lang"] == "en"
+    assert under_record["taskname"] == "asr"
+    assert under_record["pnc"] == "no"
+    assert Path(under_record["rttm_filepath"]).exists()
+    assert Path(under_record["reference_seglst_filepath"]).exists()
+    assert under_record["messages"][0]["audio"]["path"] == under_record["audio_filepath"]
+
+
+def test_materialize_mixed_wav(tmp_path):
+    data_dir = tmp_path / "data"
+    libri_root = data_dir / "LibriSpeech"
+    _write_wav(libri_root / "test-clean/111/1/111-1-0000.wav")
+    _write_wav(libri_root / "test-clean/222/2/222-2-0000.wav")
+
+    record = prepare.build_record(
+        _row(duration_a=0.05, delay_b=0.01, duration_b=0.05),
+        split="test-clean",
+        mix="2mix",
+        data_dir=data_dir,
+        audio_prefix=data_dir / "audio",
+        no_audio=False,
+        librispeech_root=libri_root,
+    )
+
+    assert Path(record["audio_filepath"]).exists()
+    assert record["num_speakers"] == 2
+
+
+def test_sot_parser_and_cpwer_permutation_invariance():
+    parsed = parse_sot_speaker_streams("[s0] Hello, [s1] YES! [s0] again")
+    assert parsed == {"s0": "hello again", "s1": "yes"}
+
+    result = cpwer("[s0] hello world [s1] good morning", "[s0] good morning [s1] hello world")
+    assert result["errors"] == 0
+    assert result["cpwer"] == 0.0
+
+
+@pytest.mark.parametrize(
+    ("hypothesis", "errors", "ref_words"),
+    [
+        ("[s0] hello", 2, 3),
+        ("[s0] hello [s1] there [s2] extra words", 3, 3),
+        ("", 3, 3),
+    ],
+)
+def test_cpwer_missing_extra_empty_hypothesis(hypothesis, errors, ref_words):
+    result = cpwer("[s0] hello [s1] there now", hypothesis)
+    assert result["errors"] == errors
+    assert result["ref_words"] == ref_words
+
+
+def test_cpwer_punctuation_case_normalization():
+    result = cpwer("[s0] Hello, WORLD!", "[s0] hello world")
+    assert result["errors"] == 0
+
+
+def test_metrics_use_corpus_level_raw_counts():
+    metrics = LibriSpeechMixSOTMetrics(compute_no_answer=False, max_k=1)
+    metrics.update(
+        [
+            {
+                "generation": "wrong",
+                "is_correct": False,
+                "cpwer_errors": 1,
+                "cpwer_substitutions": 1,
+                "cpwer_insertions": 0,
+                "cpwer_deletions": 0,
+                "cpwer_ref_words": 1,
+            }
+        ]
+    )
+    metrics.update(
+        [
+            {
+                "generation": "correct",
+                "is_correct": True,
+                "cpwer_errors": 0,
+                "cpwer_substitutions": 0,
+                "cpwer_insertions": 0,
+                "cpwer_deletions": 0,
+                "cpwer_ref_words": 100,
+            }
+        ]
+    )
+
+    output = metrics.get_metrics()["pass@1"]
+    assert output["cpwer_errors"] == 1
+    assert output["cpwer_ref_words"] == 101
+    assert output["cpwer"] == 0.99
+
+
+def test_evaluator_reads_pred_text_before_generation():
+    evaluator = LibriSpeechMixSOTEvaluator({})
+    result = asyncio.run(
+        evaluator.eval_single({"text": "[s0] hello", "pred_text": "[s0] hello", "generation": "[s0] wrong"})
+    )
+
+    assert result["cpwer_errors"] == 0
+    assert result["is_correct"] is True
+
+
+def test_rtmtasr_command_and_generation_fake(monkeypatch, tmp_path):
+    module = importlib.import_module("nemo_skills.inference.librispeechmix_rtmtasr")
+    output_file = tmp_path / "out.jsonl"
+    cfg = module.RTMTASRGenerationConfig(
+        input_file="input.jsonl",
+        output_file=str(output_file),
+        model_path="model.nemo",
+        nemo_root="/repo/NeMo",
+    )
+
+    command = module.build_rtmtasr_command(cfg)
+    assert "/repo/NeMo/examples/asr/transcribe_speech_rtmtasr.py" in command[2]
+    assert "spk_supervision=rttm" in command
+    assert "model_path=model.nemo" in command
+    assert "+prompt.pnc=no" in command
+
+    def fake_run(cmd, check, env):
+        assert cmd == command
+        output_file.write_text(json.dumps({"text": "[s0] hi", "pred_text": "[s0] hi"}) + "\n")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    module.RTMTASRGenerationTask(cfg).generate()
+    row = json.loads(output_file.read_text())
+    assert row["generation"] == "[s0] hi"
+
+
+def test_multitalker_parakeet_command_and_generation_fake(monkeypatch, tmp_path):
+    module = importlib.import_module("nemo_skills.inference.librispeechmix_multitalker_parakeet")
+    input_file = tmp_path / "input.jsonl"
+    output_file = tmp_path / "out.jsonl"
+    input_file.write_text(
+        json.dumps({"sample_id": "mix0", "audio_filepath": "/audio/mix0.wav", "text": "[s0] hi [s1] there"}) + "\n"
+    )
+    cfg = module.MultitalkerParakeetGenerationConfig(
+        input_file=str(input_file),
+        output_file=str(output_file),
+        nemo_root="/repo/NeMo",
+        asr_model="asr.nemo",
+        diar_model="diar.nemo",
+    )
+
+    command = module.build_multitalker_parakeet_command(cfg)
+    assert "/repo/NeMo/examples/asr/asr_cache_aware_streaming/speech_to_text_multitalker_streaming_infer.py" in command[1]
+    assert "asr_model=asr.nemo" in command
+    assert "diar_model=diar.nemo" in command
+
+    def fake_run(cmd, check, env):
+        assert cmd == command
+        output_file.write_text(
+            json.dumps(
+                [
+                    {"session_id": "mix0", "speaker": "speaker_a", "words": "hi", "start_time": 0.0, "end_time": 0.5},
+                    {
+                        "session_id": "mix0",
+                        "speaker": "speaker_b",
+                        "words": "there",
+                        "start_time": 0.5,
+                        "end_time": 1.0,
+                    },
+                ]
+            )
+            + "\n"
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    module.MultitalkerParakeetGenerationTask(cfg).generate()
+    row = json.loads(output_file.read_text())
+    assert row["text"] == "[s0] hi [s1] there"
+    assert row["generation"] == "[s0] hi [s1] there"
+    assert row["hypothesis_seglst"][0]["speaker"] == "speaker_a"
+
+
+def test_multitalker_parakeet_unified_backend_fake(monkeypatch, tmp_path):
+    backends = importlib.import_module("recipes.multimodal.server.backends")
+    module = importlib.import_module("recipes.multimodal.server.backends.multitalker_parakeet_backend")
+    assert backends.get_backend("multitalker_parakeet").__name__ == "MultitalkerParakeetBackend"
+    assert not hasattr(module, "subprocess")
+    backend_source = inspect.getsource(module.MultitalkerParakeetBackend.generate)
+    backend_source += inspect.getsource(module.MultitalkerParakeetBackend._run_inprocess_manifest)
+    assert "subprocess.run" not in backend_source
+
+    audio_path = tmp_path / "input.wav"
+    _write_wav(audio_path, duration=0.05)
+
+    cfg = module.MultitalkerParakeetConfig(
+        model_path="asr.nemo",
+        diar_model="diar.nemo",
+        nemo_root=str(tmp_path),
+        resolve_hf_models=False,
+        batch_size=2,
+    )
+    backend = module.MultitalkerParakeetBackend(cfg)
+    backend._is_loaded = True
+
+    def fake_run_inprocess(manifest_file, batch_size):
+        assert batch_size == 1
+        manifest_rows = [json.loads(line) for line in Path(manifest_file).read_text().splitlines()]
+        assert len(manifest_rows) == 1
+        assert Path(manifest_rows[0]["audio_filepath"]).exists()
+        assert manifest_rows[0]["duration"] > 0
+        return [
+            {"session_id": "req_0000", "speaker": "speaker_0", "words": "hi", "start_time": 0.0, "end_time": 0.5},
+            {
+                "session_id": "req_0000",
+                "speaker": "speaker_1",
+                "words": "there",
+                "start_time": 0.5,
+                "end_time": 1.0,
+            },
+        ]
+
+    monkeypatch.setattr(backend, "_run_inprocess_manifest", fake_run_inprocess)
+    result = backend.generate([module.GenerationRequest(audio_bytes=audio_path.read_bytes())])[0]
+    assert result.error is None
+    assert result.text == "[s0] hi [s1] there"
+    assert result.debug_info["backend"] == "multitalker_parakeet"
+    assert result.debug_info["persistent_inprocess"] is True
+
+
+def test_multitalker_parakeet_backend_coerces_mutating_seglst_return():
+    module = importlib.import_module("recipes.multimodal.server.backends.multitalker_parakeet_backend")
+    entries = [{"session_id": "req_0000", "speaker": "speaker_0", "words": "hi"}]
+    streamer = types.SimpleNamespace(instance_manager=types.SimpleNamespace(seglst_dict_list=entries))
+    assert module.MultitalkerParakeetBackend._coerce_batch_entries(streamer, None) == entries


### PR DESCRIPTION
## Summary

Adds a LibriSpeechMix SOT benchmark group for evaluating multispeaker ASR models with serialized speaker tags:

- `librispeechmix-sot.{under20s,over20s}-{dev-clean,test-clean}-{1mix,2mix,3mix}`
- dataset preparation from the official LibriSpeechMix JSONL lists plus LibriSpeech/OpenSLR audio
- explicit duration split at 20.0 seconds (`under20s <= 20.0`, `over20s > 20.0`)
- reference SOT text with `[s0]`, `[s1]`, etc., RTTM supervision, and SegLST sidecars
- corpus-level no-PnC cpWER evaluator/metrics with speaker-permutation matching and raw S/I/D counts
- optional MeetEval sidecars when `meeteval-wer` is installed
- RTMT-ASR, Multitalker Parakeet, and SALM/Canary-Qwen generation wiring through NeMo-Skills/`serve_unified`
- persistent in-process `multitalker_parakeet` unified backend that loads Multitalker Parakeet ASR and Sortformer diarization once

The Multitalker baseline defaults to:

- ASR: `nvidia/multitalker-parakeet-streaming-0.6b-v1`
- diarization: `nvidia/diar_streaming_sortformer_4spk-v2.1`

## Testing

Rebased on current `github/main` (`7dcb0a67`).

Local focused tests:

```bash
python -m pytest tests/test_librispeechmix_sot.py tests/test_vllm_audio.py tests/test_unified_server_audio_parser.py tests/test_configs.py
```

Result: `37 passed in 18.54s`.

Compile checks:

```bash
python -m py_compile \
  nemo_skills/dataset/librispeechmix-sot/prepare.py \
  nemo_skills/dataset/librispeechmix-sot/librispeechmix_sot_score.py \
  nemo_skills/evaluation/evaluator/librispeechmix_sot.py \
  nemo_skills/evaluation/metrics/librispeechmix_sot_utils.py \
  nemo_skills/evaluation/metrics/librispeechmix_sot_metrics.py \
  nemo_skills/inference/librispeechmix_rtmtasr.py \
  nemo_skills/inference/librispeechmix_multitalker_parakeet.py \
  recipes/multimodal/server/backends/salm_backend.py \
  recipes/multimodal/server/backends/multitalker_parakeet_backend.py
```

Result: passed.

Also ran:

- `git diff --check`: passed
- prepare/evaluator smoke on a tiny LibriSpeechMix sample: passed
- persistent Multitalker Parakeet tiny DRACO smoke: passed, generated `[s0]` SOT output and `debug_info.persistent_inprocess: true`

## Cluster Results

Full under-20s LibriSpeechMix test-clean runs completed on DRACO OCI via Symphony job:

- job id: `issue81-full-multitalker-20260501-000558`
- status: succeeded, exit code `0`
- full report: Symphony issue 81 artifact `.symphony/artifacts/issue81-final-report.md`
- job log: Symphony issue 81 artifact `.symphony/artifacts/jobs/issue81-full-multitalker-20260501-000558/job.log`

Each run used `--num-chunks 16`, `--server-batch-size 2`, `--mt-batch-size 2`, and `--max-concurrent-requests 2`.

Remote output roots:

- DRACO Lustre issue-specific baseline root: `issue81_librispeechmix_sot/baselines/multitalker-parakeet/`
- split subdirectories: `under20s-test-clean-1mix-full`, `under20s-test-clean-2mix-full`, `under20s-test-clean-3mix-full`

Local copied metrics:

- `.symphony/artifacts/issue81-baselines/multitalker-parakeet/under20s-test-clean-1mix-full/metrics.json`
- `.symphony/artifacts/issue81-baselines/multitalker-parakeet/under20s-test-clean-2mix-full/metrics.json`
- `.symphony/artifacts/issue81-baselines/multitalker-parakeet/under20s-test-clean-3mix-full/metrics.json`

Multitalker Parakeet cpWER:

| Split | Rows | cpWER | Errors | S | I | D | Ref words |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| under20s-test-clean-1mix | 2620 | 3.62 | 1921 | 1007 | 220 | 694 | 53120 |
| under20s-test-clean-2mix | 2620 | 8.19 | 8705 | 2938 | 901 | 4866 | 106240 |
| under20s-test-clean-3mix | 2620 | 15.71 | 25039 | 6392 | 2766 | 15881 | 159360 |
| aggregate | 7860 | 11.19 | 35665 | 10337 | 3887 | 21441 | 318720 |

## Notes

- `meeteval-wer` was not installed in the local scoring venv, so optional MeetEval average/per-record JSON was skipped. The scorer still wrote SegLST sidecars and NeMo cpWER metrics.
- RTMT-ASR En Canary-v2 and Canary-Qwen paths are wired but were not run as full baselines in this PR.
- Over-20s manifests are implemented/preparable, but no over-20s model inference was run.
