### PR TITLE
Add region to WMT24++ language names

### DIFF
--- a/nemo_skills/dataset/wmt24pp/prepare.py
+++ b/nemo_skills/dataset/wmt24pp/prepare.py
@@ -30,7 +30,7 @@ def write_data_to_file(output_file, datasets, tgt_languages):
                     "source_language": "en",
                     "target_language": tgt_lang,
                     "source_lang_name": "English",
-                    "target_lang_name": Language(tgt_lang[:2]).display_name(),
+                    "target_lang_name": Language.get(tgt_lang).display_name(),
                 }
                 json.dump(json_dict, fout)
                 fout.write("\n")


### PR DESCRIPTION
Currently the model will receive the same prompt for regional variances of a language (e.g. `ar_SA` and `ar_EG`) in WMT24++. This PR fixes that.