### PR TITLE
Add periodictable MCP tool

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
+      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       env:
         GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
@@ -110,6 +111,7 @@ jobs:
           --load \
           .
     - name: Run all tests
+      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       env:
         NV_INFERENCE_API_KEY: ${{ secrets.NV_INFERENCE_API_KEY }}
         NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
@@ -123,3 +125,12 @@ jobs:
         set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         ns prepare_data gsm8k math-500 hle
         python -m pytest tests/ -m "not gpu and not live" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv
+
+    - name: Run fork-safe MCP tests
+      if: ${{ env.HAS_GHCR_PAT != 'true' }}
+      run: |
+        python -m nemo_skills.code_execution.local_sandbox.local_sandbox_server &
+        SANDBOX_PID=$!
+        trap "kill ${SANDBOX_PID}" EXIT
+        sleep 5
+        python -m pytest tests/test_mcp_clients.py -m "not gpu and not live" --junitxml=pytest.xml --durations=30 -rs -s -vvv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,6 +17,8 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    env:
+      HAS_GHCR_PAT: ${{ secrets.GHCR_PAT != '' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -25,11 +26,14 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
+      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       uses: docker/login-action@v3
+      env:
+        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_PAT || github.token }}
+        password: ${{ env.GHCR_PAT }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -55,17 +59,32 @@ jobs:
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-        CACHE_ARGS_NEMO=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
-        CACHE_ARGS_SANDBOX=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
+        CACHE_ARGS_NEMO=()
+        CACHE_ARGS_SANDBOX=()
         if [ -n "${GHCR_PAT:-}" ]; then
+          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
           CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
+          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
           CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
         fi
+
+        retry_docker_build() {
+          for attempt in 1 2 3; do
+            if docker buildx build "$@"; then
+              return 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Docker build failed on attempt ${attempt}; retrying in 30s..."
+              sleep 30
+            fi
+          done
+          return 1
+        }
 
         # Build nemo-skills-image with expected tag
         NEMO_SKILLS_HASH=$(sha256sum dockerfiles/Dockerfile.nemo-skills | cut -d' ' -f1 | cut -c1-12)
         NEMO_SKILLS_TAG="locally-built-dockerfiles-dockerfile-nemo-skills:${NEMO_SKILLS_HASH}"
-        docker buildx build \
+        retry_docker_build \
           --tag nemo-skills-image \
           --tag ${NEMO_SKILLS_TAG} \
           --file dockerfiles/Dockerfile.nemo-skills \
@@ -82,7 +101,7 @@ jobs:
         # Build sandbox-image with expected tag
         SANDBOX_HASH=$(sha256sum dockerfiles/Dockerfile.sandbox | cut -d' ' -f1 | cut -c1-12)
         SANDBOX_TAG="locally-built-dockerfiles-dockerfile-sandbox:${SANDBOX_HASH}"
-        docker buildx build \
+        retry_docker_build \
           --tag nemo-skills-sandbox-image \
           --tag ${SANDBOX_TAG} \
           --file dockerfiles/Dockerfile.sandbox \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
+      if: ${{ secrets.GHCR_PAT != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -44,14 +45,24 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev] --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -e ".[dev,tools]" --extra-index-url https://download.pytorch.org/whl/cpu
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
+      env:
+        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+        CACHE_ARGS_NEMO=()
+        CACHE_ARGS_SANDBOX=()
+        if [ -n "${GHCR_PAT:-}" ]; then
+          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
+          CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
+          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
+          CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
+        fi
 
         # Build nemo-skills-image with expected tag
         NEMO_SKILLS_HASH=$(sha256sum dockerfiles/Dockerfile.nemo-skills | cut -d' ' -f1 | cut -c1-12)
@@ -60,8 +71,7 @@ jobs:
           --tag nemo-skills-image \
           --tag ${NEMO_SKILLS_TAG} \
           --file dockerfiles/Dockerfile.nemo-skills \
-          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache \
-          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min \
+          "${CACHE_ARGS_NEMO[@]}" \
           --load \
           .
 
@@ -79,8 +89,7 @@ jobs:
           --tag ${SANDBOX_TAG} \
           --file dockerfiles/Dockerfile.sandbox \
           --build-arg GITHUB_CI=1 \
-          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache \
-          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min \
+          "${CACHE_ARGS_SANDBOX[@]}" \
           --load \
           .
     - name: Run all tests
@@ -96,4 +105,4 @@ jobs:
         sleep 10
         set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         ns prepare_data gsm8k math-500 hle
-        python -m pytest tests/ -m "not gpu" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv
+        python -m pytest tests/ -m "not gpu and not live" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,6 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    env:
-      GHCR_PAT: ${{ secrets.GHCR_PAT }}
-      GHCR_TOKEN: ${{ secrets.GHCR_PAT || github.token }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -28,12 +25,11 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ env.GHCR_TOKEN != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ env.GHCR_TOKEN }}
+        password: ${{ secrets.GHCR_PAT || github.token }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -53,6 +49,8 @@ jobs:
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
+      env:
+        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,6 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    env:
-      HAS_GHCR_PAT: ${{ secrets.GHCR_PAT != '' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -26,14 +24,11 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       uses: docker/login-action@v3
-      env:
-        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ env.GHCR_PAT }}
+        password: ${{ secrets.GHCR_PAT }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -49,47 +44,24 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev,tools]" --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -e .[dev] --extra-index-url https://download.pytorch.org/whl/cpu
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
-      if: ${{ env.HAS_GHCR_PAT == 'true' }}
-      env:
-        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-        CACHE_ARGS_NEMO=()
-        CACHE_ARGS_SANDBOX=()
-        if [ -n "${GHCR_PAT:-}" ]; then
-          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
-          CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
-          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
-          CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
-        fi
-
-        retry_docker_build() {
-          for attempt in 1 2 3; do
-            if docker buildx build "$@"; then
-              return 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              echo "Docker build failed on attempt ${attempt}; retrying in 30s..."
-              sleep 30
-            fi
-          done
-          return 1
-        }
 
         # Build nemo-skills-image with expected tag
         NEMO_SKILLS_HASH=$(sha256sum dockerfiles/Dockerfile.nemo-skills | cut -d' ' -f1 | cut -c1-12)
         NEMO_SKILLS_TAG="locally-built-dockerfiles-dockerfile-nemo-skills:${NEMO_SKILLS_HASH}"
-        retry_docker_build \
+        docker buildx build \
           --tag nemo-skills-image \
           --tag ${NEMO_SKILLS_TAG} \
           --file dockerfiles/Dockerfile.nemo-skills \
-          "${CACHE_ARGS_NEMO[@]}" \
+          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache \
+          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min \
           --load \
           .
 
@@ -102,16 +74,16 @@ jobs:
         # Build sandbox-image with expected tag
         SANDBOX_HASH=$(sha256sum dockerfiles/Dockerfile.sandbox | cut -d' ' -f1 | cut -c1-12)
         SANDBOX_TAG="locally-built-dockerfiles-dockerfile-sandbox:${SANDBOX_HASH}"
-        retry_docker_build \
+        docker buildx build \
           --tag nemo-skills-sandbox-image \
           --tag ${SANDBOX_TAG} \
           --file dockerfiles/Dockerfile.sandbox \
           --build-arg GITHUB_CI=1 \
-          "${CACHE_ARGS_SANDBOX[@]}" \
+          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache \
+          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min \
           --load \
           .
     - name: Run all tests
-      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       env:
         NV_INFERENCE_API_KEY: ${{ secrets.NV_INFERENCE_API_KEY }}
         NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
@@ -124,13 +96,4 @@ jobs:
         sleep 10
         set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         ns prepare_data gsm8k math-500 hle
-        python -m pytest tests/ -m "not gpu and not live" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv
-
-    - name: Run fork-safe MCP tests
-      if: ${{ env.HAS_GHCR_PAT != 'true' }}
-      run: |
-        python -m nemo_skills.code_execution.local_sandbox.local_sandbox_server &
-        SANDBOX_PID=$!
-        trap "kill ${SANDBOX_PID}" EXIT
-        sleep 5
-        python -m pytest tests/test_mcp_clients.py -m "not gpu and not live" --junitxml=pytest.xml --durations=30 -rs -s -vvv
+        python -m pytest tests/ -m "not gpu" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GHCR_PAT: ${{ secrets.GHCR_PAT }}
+      GHCR_TOKEN: ${{ secrets.GHCR_PAT || github.token }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -26,12 +28,12 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ env.GHCR_PAT != '' }}
+      if: ${{ env.GHCR_TOKEN != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ env.GHCR_PAT }}
+        password: ${{ env.GHCR_TOKEN }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -55,12 +57,10 @@ jobs:
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-        CACHE_ARGS_NEMO=()
-        CACHE_ARGS_SANDBOX=()
+        CACHE_ARGS_NEMO=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
+        CACHE_ARGS_SANDBOX=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
         if [ -n "${GHCR_PAT:-}" ]; then
-          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
           CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
-          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
           CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
         fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    env:
+      GHCR_PAT: ${{ secrets.GHCR_PAT }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -24,12 +26,12 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ secrets.GHCR_PAT != '' }}
+      if: ${{ env.GHCR_PAT != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_PAT }}
+        password: ${{ env.GHCR_PAT }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -49,8 +51,6 @@ jobs:
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
-      env:
-        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}

--- a/docs/agentic_inference/tool_calling.md
+++ b/docs/agentic_inference/tool_calling.md
@@ -372,4 +372,3 @@ For vLLM, you may need to specify tool calling arguments:
 - [`nemo_skills.mcp.servers.python_tool.PythonTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/python_tool.py) - Python code execution
 - [`nemo_skills.mcp.servers.exa_tool.ExaTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/exa_tool.py) - Web search via Exa API
 - [`nemo_skills.mcp.servers.periodictable_tool.PeriodictableTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/periodictable_tool.py) - Direct element, isotope, and neutron scattering lookup via periodictable (requires `periodictable`)
-- [`nemo_skills.mcp.servers.periodictable_tool.PeriodictableTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/periodictable_tool.py) - Element, isotope, and neutron scattering lookup via periodictable (requires `periodictable`)

--- a/docs/agentic_inference/tool_calling.md
+++ b/docs/agentic_inference/tool_calling.md
@@ -371,4 +371,5 @@ For vLLM, you may need to specify tool calling arguments:
 
 - [`nemo_skills.mcp.servers.python_tool.PythonTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/python_tool.py) - Python code execution
 - [`nemo_skills.mcp.servers.exa_tool.ExaTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/exa_tool.py) - Web search via Exa API
+- [`nemo_skills.mcp.servers.periodictable_tool.PeriodictableTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/periodictable_tool.py) - Direct element, isotope, and neutron scattering lookup via periodictable (requires `periodictable`)
 - [`nemo_skills.mcp.servers.periodictable_tool.PeriodictableTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/periodictable_tool.py) - Element, isotope, and neutron scattering lookup via periodictable (requires `periodictable`)

--- a/docs/agentic_inference/tool_calling.md
+++ b/docs/agentic_inference/tool_calling.md
@@ -371,3 +371,4 @@ For vLLM, you may need to specify tool calling arguments:
 
 - [`nemo_skills.mcp.servers.python_tool.PythonTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/python_tool.py) - Python code execution
 - [`nemo_skills.mcp.servers.exa_tool.ExaTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/exa_tool.py) - Web search via Exa API
+- [`nemo_skills.mcp.servers.periodictable_tool.PeriodictableTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/periodictable_tool.py) - Element, isotope, and neutron scattering lookup via periodictable (requires `periodictable`)

--- a/nemo_skills/mcp/servers/periodictable_tool.py
+++ b/nemo_skills/mcp/servers/periodictable_tool.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Periodic table MCP tool for element and isotope data.
+
+Wraps the ``periodictable`` library to provide element properties, isotope
+data, and neutron scattering factors. No API key required.
+
+Prerequisites:
+    pip install periodictable
+
+Usage:
+    ++tool_modules=[nemo_skills.mcp.servers.periodictable_tool::PeriodictableTool]
+"""
+
+import logging
+from typing import Annotated
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from nemo_skills.mcp.tool_providers import MCPClientTool
+
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP(name="periodictable")
+
+
+def _resolve_element(name_or_symbol: str):
+    """Resolve an element from a name or symbol string."""
+    import periodictable as pt
+
+    s = name_or_symbol.strip()
+    for el in pt.elements:
+        if el.symbol == 0:
+            continue
+        if s.lower() == el.name.lower() or s == el.symbol or s == str(el.number):
+            return el
+    return None
+
+
+@mcp.tool(name="element-info")
+def element_info(
+    element: Annotated[str, Field(description="Element symbol, name, or atomic number (e.g. 'Fe', 'iron', '26').")],
+) -> str:
+    """Look up an element. Returns atomic mass, number, density, crystal structure, and isotope list."""
+    el = _resolve_element(element)
+    if el is None:
+        return f"Element '{element}' not found. Try a symbol like 'Fe', name like 'iron', or number like '26'."
+
+    lines = [f"**{el.name}** ({el.symbol})"]
+    lines.append(f"Atomic number: {el.number}")
+    lines.append(f"Atomic mass: {el.mass} u")
+    if hasattr(el, "density") and el.density is not None:
+        lines.append(f"Density: {el.density} g/cm^3")
+    if hasattr(el, "crystal_structure") and el.crystal_structure is not None:
+        lines.append(f"Crystal structure: {el.crystal_structure}")
+
+    try:
+        if el.neutron.b_c is not None:
+            lines.append(f"Neutron b_c: {el.neutron.b_c} fm")
+        if el.neutron.coherent is not None:
+            lines.append(f"Neutron coherent xs: {el.neutron.coherent} barn")
+        if el.neutron.incoherent is not None:
+            lines.append(f"Neutron incoherent xs: {el.neutron.incoherent} barn")
+        if el.neutron.absorption is not None:
+            lines.append(f"Neutron absorption xs: {el.neutron.absorption} barn")
+    except AttributeError:
+        pass
+
+    isotopes = [iso for iso in el if iso.abundance and iso.abundance > 0]
+    if isotopes:
+        lines.append("\nNatural isotopes:")
+        for iso in sorted(isotopes, key=lambda x: -x.abundance):
+            lines.append(f"  {el.symbol}-{iso.isotope}: mass={iso.mass:.6f} u, abundance={iso.abundance:.4f}%")
+
+    return "\n".join(lines)
+
+
+@mcp.tool(name="isotope-info")
+def isotope_info(
+    element: Annotated[str, Field(description="Element symbol or name (e.g. 'U', 'uranium').")],
+    mass_number: Annotated[int, Field(description="Mass number A of the isotope (e.g. 235 for U-235).")],
+) -> str:
+    """Look up a specific isotope. Returns mass, abundance, and neutron scattering data."""
+    el = _resolve_element(element)
+    if el is None:
+        return f"Element '{element}' not found."
+
+    try:
+        iso = el[mass_number]
+    except (KeyError, IndexError):
+        return f"Isotope {el.symbol}-{mass_number} not found."
+
+    lines = [f"**{el.symbol}-{mass_number}**"]
+    if iso.mass is not None:
+        lines.append(f"Mass: {iso.mass:.8f} u")
+    if iso.abundance is not None:
+        lines.append(f"Natural abundance: {iso.abundance:.4f}%")
+
+    try:
+        n = iso.neutron
+        if n.b_c is not None:
+            lines.append(f"Neutron b_c: {n.b_c} fm")
+        if n.coherent is not None:
+            lines.append(f"Neutron coherent xs: {n.coherent} barn")
+        if n.incoherent is not None:
+            lines.append(f"Neutron incoherent xs: {n.incoherent} barn")
+        if n.absorption is not None:
+            lines.append(f"Neutron absorption xs: {n.absorption} barn")
+    except AttributeError:
+        pass
+
+    return "\n".join(lines)
+
+
+class PeriodictableTool(MCPClientTool):
+    def __init__(self) -> None:
+        super().__init__()
+        self.apply_config_updates(
+            {
+                "client": "nemo_skills.mcp.clients.MCPStdioClient",
+                "client_params": {
+                    "command": "python",
+                    "args": ["-m", "nemo_skills.mcp.servers.periodictable_tool"],
+                },
+            }
+        )
+
+
+def main():
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_skills/mcp/servers/periodictable_tool.py
+++ b/nemo_skills/mcp/servers/periodictable_tool.py
@@ -119,6 +119,7 @@ def isotope_info(
 
     return "\n".join(lines)
 
+
 class PeriodictableTool(Tool):
     def __init__(self) -> None:
         self._config: dict[str, Any] = {}
@@ -137,7 +138,9 @@ class PeriodictableTool(Tool):
                 "description": "Look up an element by symbol, name, or atomic number.",
                 "input_schema": {
                     "type": "object",
-                    "properties": {"element": {"type": "string", "description": "Element symbol, name, or atomic number."}},
+                    "properties": {
+                        "element": {"type": "string", "description": "Element symbol, name, or atomic number."}
+                    },
                     "required": ["element"],
                 },
             },

--- a/nemo_skills/mcp/servers/periodictable_tool.py
+++ b/nemo_skills/mcp/servers/periodictable_tool.py
@@ -42,7 +42,7 @@ def _resolve_element(name_or_symbol: str):
     for el in pt.elements:
         if el.symbol == 0:
             continue
-        if s.lower() == el.name.lower() or s == el.symbol or s == str(el.number):
+        if s.lower() == el.name.lower() or s.lower() == el.symbol.lower() or s == str(el.number):
             return el
     return None
 
@@ -63,17 +63,16 @@ def element_info(
     if hasattr(el, "crystal_structure") and el.crystal_structure is not None:
         lines.append(f"Crystal structure: {el.crystal_structure}")
 
-    try:
-        if el.neutron.b_c is not None:
-            lines.append(f"Neutron b_c: {el.neutron.b_c} fm")
-        if el.neutron.coherent is not None:
-            lines.append(f"Neutron coherent xs: {el.neutron.coherent} barn")
-        if el.neutron.incoherent is not None:
-            lines.append(f"Neutron incoherent xs: {el.neutron.incoherent} barn")
-        if el.neutron.absorption is not None:
-            lines.append(f"Neutron absorption xs: {el.neutron.absorption} barn")
-    except AttributeError:
-        pass
+    neutron = getattr(el, "neutron", None)
+    if neutron is not None:
+        if neutron.b_c is not None:
+            lines.append(f"Neutron b_c: {neutron.b_c} fm")
+        if neutron.coherent is not None:
+            lines.append(f"Neutron coherent xs: {neutron.coherent} barn")
+        if neutron.incoherent is not None:
+            lines.append(f"Neutron incoherent xs: {neutron.incoherent} barn")
+        if neutron.absorption is not None:
+            lines.append(f"Neutron absorption xs: {neutron.absorption} barn")
 
     isotopes = [iso for iso in el if iso.abundance and iso.abundance > 0]
     if isotopes:
@@ -104,18 +103,16 @@ def isotope_info(
     if iso.abundance is not None:
         lines.append(f"Natural abundance: {iso.abundance:.4f}%")
 
-    try:
-        n = iso.neutron
-        if n.b_c is not None:
-            lines.append(f"Neutron b_c: {n.b_c} fm")
-        if n.coherent is not None:
-            lines.append(f"Neutron coherent xs: {n.coherent} barn")
-        if n.incoherent is not None:
-            lines.append(f"Neutron incoherent xs: {n.incoherent} barn")
-        if n.absorption is not None:
-            lines.append(f"Neutron absorption xs: {n.absorption} barn")
-    except AttributeError:
-        pass
+    neutron = getattr(iso, "neutron", None)
+    if neutron is not None:
+        if neutron.b_c is not None:
+            lines.append(f"Neutron b_c: {neutron.b_c} fm")
+        if neutron.coherent is not None:
+            lines.append(f"Neutron coherent xs: {neutron.coherent} barn")
+        if neutron.incoherent is not None:
+            lines.append(f"Neutron incoherent xs: {neutron.incoherent} barn")
+        if neutron.absorption is not None:
+            lines.append(f"Neutron absorption xs: {neutron.absorption} barn")
 
     return "\n".join(lines)
 

--- a/nemo_skills/mcp/servers/periodictable_tool.py
+++ b/nemo_skills/mcp/servers/periodictable_tool.py
@@ -25,16 +25,13 @@ Usage:
 """
 
 import logging
-from typing import Annotated
+from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from nemo_skills.mcp.tool_providers import MCPClientTool
+from nemo_skills.mcp.tool_manager import Tool
 
 logger = logging.getLogger(__name__)
-
-mcp = FastMCP(name="periodictable")
 
 
 def _resolve_element(name_or_symbol: str):
@@ -50,7 +47,6 @@ def _resolve_element(name_or_symbol: str):
     return None
 
 
-@mcp.tool(name="element-info")
 def element_info(
     element: Annotated[str, Field(description="Element symbol, name, or atomic number (e.g. 'Fe', 'iron', '26').")],
 ) -> str:
@@ -88,7 +84,6 @@ def element_info(
     return "\n".join(lines)
 
 
-@mcp.tool(name="isotope-info")
 def isotope_info(
     element: Annotated[str, Field(description="Element symbol or name (e.g. 'U', 'uranium').")],
     mass_number: Annotated[int, Field(description="Mass number A of the isotope (e.g. 235 for U-235).")],
@@ -124,24 +119,46 @@ def isotope_info(
 
     return "\n".join(lines)
 
-
-class PeriodictableTool(MCPClientTool):
+class PeriodictableTool(Tool):
     def __init__(self) -> None:
-        super().__init__()
-        self.apply_config_updates(
+        self._config: dict[str, Any] = {}
+
+    def default_config(self) -> dict[str, Any]:
+        return dict(self._config)
+
+    def configure(self, overrides: dict[str, Any] | None = None, context: dict[str, Any] | None = None) -> None:
+        if overrides:
+            self._config.update(overrides)
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        return [
             {
-                "client": "nemo_skills.mcp.clients.MCPStdioClient",
-                "client_params": {
-                    "command": "python",
-                    "args": ["-m", "nemo_skills.mcp.servers.periodictable_tool"],
+                "name": "element-info",
+                "description": "Look up an element by symbol, name, or atomic number.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"element": {"type": "string", "description": "Element symbol, name, or atomic number."}},
+                    "required": ["element"],
                 },
-            }
-        )
+            },
+            {
+                "name": "isotope-info",
+                "description": "Look up isotope mass, abundance, and neutron scattering data.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "element": {"type": "string", "description": "Element symbol or name."},
+                        "mass_number": {"type": "integer", "description": "Mass number A of the isotope."},
+                    },
+                    "required": ["element", "mass_number"],
+                },
+            },
+        ]
 
-
-def main():
-    mcp.run(transport="stdio")
-
-
-if __name__ == "__main__":
-    main()
+    async def execute(self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None):
+        arguments = dict(arguments or {})
+        if tool_name == "element-info":
+            return element_info(**arguments)
+        if tool_name == "isotope-info":
+            return isotope_info(**arguments)
+        return f"Error: unknown tool '{tool_name}'"

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -1003,8 +1003,7 @@ async def test_direct_python_tool_cleanup_request_tolerates_delete_failure():
     await tool.cleanup_request("req-x")
     assert "req-x" not in tool.requests_to_sessions
 
-
-# -- Periodictable tool tests -----------------------------------------------
+# -- Periodictable direct tool tests ----------------------------------------
 
 
 class TestPeriodictableTool:
@@ -1012,19 +1011,14 @@ class TestPeriodictableTool:
         from nemo_skills.mcp.servers.periodictable_tool import PeriodictableTool
 
         tool = PeriodictableTool()
-        assert tool._config["client"] == "nemo_skills.mcp.clients.MCPStdioClient"
-        assert "nemo_skills.mcp.servers.periodictable_tool" in tool._config["client_params"]["args"]
+        assert tool.default_config() == {}
 
     @pytest.mark.asyncio
-    async def test_periodictable_stdio_list_tools(self):
+    async def test_periodictable_direct_list_tools(self):
         from nemo_skills.mcp.servers.periodictable_tool import PeriodictableTool
 
         tool = PeriodictableTool()
         tool.configure()
-        try:
-            tools = await tool.list_tools()
-            tool_names = {t["name"] for t in tools}
-            assert "element-info" in tool_names
-            assert "isotope-info" in tool_names
-        finally:
-            await tool.shutdown()
+        tool_names = {t["name"] for t in await tool.list_tools()}
+        assert "element-info" in tool_names
+        assert "isotope-info" in tool_names

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -1002,3 +1002,29 @@ async def test_direct_python_tool_cleanup_request_tolerates_delete_failure():
     # Must not raise; session must be removed from the mapping regardless.
     await tool.cleanup_request("req-x")
     assert "req-x" not in tool.requests_to_sessions
+
+
+# -- Periodictable tool tests -----------------------------------------------
+
+
+class TestPeriodictableTool:
+    def test_periodictable_tool_config(self):
+        from nemo_skills.mcp.servers.periodictable_tool import PeriodictableTool
+
+        tool = PeriodictableTool()
+        assert tool._config["client"] == "nemo_skills.mcp.clients.MCPStdioClient"
+        assert "nemo_skills.mcp.servers.periodictable_tool" in tool._config["client_params"]["args"]
+
+    @pytest.mark.asyncio
+    async def test_periodictable_stdio_list_tools(self):
+        from nemo_skills.mcp.servers.periodictable_tool import PeriodictableTool
+
+        tool = PeriodictableTool()
+        tool.configure()
+        try:
+            tools = await tool.list_tools()
+            tool_names = {t["name"] for t in tools}
+            assert "element-info" in tool_names
+            assert "isotope-info" in tool_names
+        finally:
+            await tool.shutdown()

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -1003,6 +1003,7 @@ async def test_direct_python_tool_cleanup_request_tolerates_delete_failure():
     await tool.cleanup_request("req-x")
     assert "req-x" not in tool.requests_to_sessions
 
+
 # -- Periodictable direct tool tests ----------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Reopened from an internal `NVIDIA-NeMo/Skills` branch so CI can access repository secrets.
- Replaces #1414.
- Add a built-in periodictable MCP tool for element, isotope, and neutron scattering lookup.
- Document the new built-in tool and add focused MCP client tests.

## Test plan
- `python -m py_compile nemo_skills/mcp/servers/periodictable_tool.py`
- `python -m pytest tests/test_mcp_clients.py::TestPeriodictableTool -q --tb=short`
- `python -m pytest tests/test_mcp_clients.py -q --tb=short`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a periodic table lookup tool for element and isotope details, including atomic properties, optional neutron scattering data, and natural isotope abundances.

* **Documentation**
  * Updated the built-in tools reference to list the periodic table lookup tool.

* **Tests**
  * Added tests verifying tool configuration and that element/isotope capabilities are listed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->