### PR TITLE
Add particle MCP tool

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
+      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       env:
         GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
@@ -110,6 +111,7 @@ jobs:
           --load \
           .
     - name: Run all tests
+      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       env:
         NV_INFERENCE_API_KEY: ${{ secrets.NV_INFERENCE_API_KEY }}
         NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
@@ -123,3 +125,12 @@ jobs:
         set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         ns prepare_data gsm8k math-500 hle
         python -m pytest tests/ -m "not gpu and not live" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv
+
+    - name: Run fork-safe MCP tests
+      if: ${{ env.HAS_GHCR_PAT != 'true' }}
+      run: |
+        python -m nemo_skills.code_execution.local_sandbox.local_sandbox_server &
+        SANDBOX_PID=$!
+        trap "kill ${SANDBOX_PID}" EXIT
+        sleep 5
+        python -m pytest tests/test_mcp_clients.py -m "not gpu and not live" --junitxml=pytest.xml --durations=30 -rs -s -vvv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,6 +17,8 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    env:
+      HAS_GHCR_PAT: ${{ secrets.GHCR_PAT != '' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -25,11 +26,14 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
+      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       uses: docker/login-action@v3
+      env:
+        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_PAT || github.token }}
+        password: ${{ env.GHCR_PAT }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -55,17 +59,32 @@ jobs:
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-        CACHE_ARGS_NEMO=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
-        CACHE_ARGS_SANDBOX=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
+        CACHE_ARGS_NEMO=()
+        CACHE_ARGS_SANDBOX=()
         if [ -n "${GHCR_PAT:-}" ]; then
+          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
           CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
+          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
           CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
         fi
+
+        retry_docker_build() {
+          for attempt in 1 2 3; do
+            if docker buildx build "$@"; then
+              return 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Docker build failed on attempt ${attempt}; retrying in 30s..."
+              sleep 30
+            fi
+          done
+          return 1
+        }
 
         # Build nemo-skills-image with expected tag
         NEMO_SKILLS_HASH=$(sha256sum dockerfiles/Dockerfile.nemo-skills | cut -d' ' -f1 | cut -c1-12)
         NEMO_SKILLS_TAG="locally-built-dockerfiles-dockerfile-nemo-skills:${NEMO_SKILLS_HASH}"
-        docker buildx build \
+        retry_docker_build \
           --tag nemo-skills-image \
           --tag ${NEMO_SKILLS_TAG} \
           --file dockerfiles/Dockerfile.nemo-skills \
@@ -82,7 +101,7 @@ jobs:
         # Build sandbox-image with expected tag
         SANDBOX_HASH=$(sha256sum dockerfiles/Dockerfile.sandbox | cut -d' ' -f1 | cut -c1-12)
         SANDBOX_TAG="locally-built-dockerfiles-dockerfile-sandbox:${SANDBOX_HASH}"
-        docker buildx build \
+        retry_docker_build \
           --tag nemo-skills-sandbox-image \
           --tag ${SANDBOX_TAG} \
           --file dockerfiles/Dockerfile.sandbox \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
+      if: ${{ secrets.GHCR_PAT != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -44,14 +45,24 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev] --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -e ".[dev,tools]" --extra-index-url https://download.pytorch.org/whl/cpu
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
+      env:
+        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+        CACHE_ARGS_NEMO=()
+        CACHE_ARGS_SANDBOX=()
+        if [ -n "${GHCR_PAT:-}" ]; then
+          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
+          CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
+          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
+          CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
+        fi
 
         # Build nemo-skills-image with expected tag
         NEMO_SKILLS_HASH=$(sha256sum dockerfiles/Dockerfile.nemo-skills | cut -d' ' -f1 | cut -c1-12)
@@ -60,8 +71,7 @@ jobs:
           --tag nemo-skills-image \
           --tag ${NEMO_SKILLS_TAG} \
           --file dockerfiles/Dockerfile.nemo-skills \
-          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache \
-          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min \
+          "${CACHE_ARGS_NEMO[@]}" \
           --load \
           .
 
@@ -79,8 +89,7 @@ jobs:
           --tag ${SANDBOX_TAG} \
           --file dockerfiles/Dockerfile.sandbox \
           --build-arg GITHUB_CI=1 \
-          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache \
-          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min \
+          "${CACHE_ARGS_SANDBOX[@]}" \
           --load \
           .
     - name: Run all tests
@@ -96,4 +105,4 @@ jobs:
         sleep 10
         set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         ns prepare_data gsm8k math-500 hle
-        python -m pytest tests/ -m "not gpu" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv
+        python -m pytest tests/ -m "not gpu and not live" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,6 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    env:
-      GHCR_PAT: ${{ secrets.GHCR_PAT }}
-      GHCR_TOKEN: ${{ secrets.GHCR_PAT || github.token }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -28,12 +25,11 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ env.GHCR_TOKEN != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ env.GHCR_TOKEN }}
+        password: ${{ secrets.GHCR_PAT || github.token }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -53,6 +49,8 @@ jobs:
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
+      env:
+        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,6 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    env:
-      HAS_GHCR_PAT: ${{ secrets.GHCR_PAT != '' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -26,14 +24,11 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       uses: docker/login-action@v3
-      env:
-        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ env.GHCR_PAT }}
+        password: ${{ secrets.GHCR_PAT }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -49,47 +44,24 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev,tools]" --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -e .[dev] --extra-index-url https://download.pytorch.org/whl/cpu
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
-      if: ${{ env.HAS_GHCR_PAT == 'true' }}
-      env:
-        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-        CACHE_ARGS_NEMO=()
-        CACHE_ARGS_SANDBOX=()
-        if [ -n "${GHCR_PAT:-}" ]; then
-          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
-          CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
-          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
-          CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
-        fi
-
-        retry_docker_build() {
-          for attempt in 1 2 3; do
-            if docker buildx build "$@"; then
-              return 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              echo "Docker build failed on attempt ${attempt}; retrying in 30s..."
-              sleep 30
-            fi
-          done
-          return 1
-        }
 
         # Build nemo-skills-image with expected tag
         NEMO_SKILLS_HASH=$(sha256sum dockerfiles/Dockerfile.nemo-skills | cut -d' ' -f1 | cut -c1-12)
         NEMO_SKILLS_TAG="locally-built-dockerfiles-dockerfile-nemo-skills:${NEMO_SKILLS_HASH}"
-        retry_docker_build \
+        docker buildx build \
           --tag nemo-skills-image \
           --tag ${NEMO_SKILLS_TAG} \
           --file dockerfiles/Dockerfile.nemo-skills \
-          "${CACHE_ARGS_NEMO[@]}" \
+          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache \
+          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min \
           --load \
           .
 
@@ -102,16 +74,16 @@ jobs:
         # Build sandbox-image with expected tag
         SANDBOX_HASH=$(sha256sum dockerfiles/Dockerfile.sandbox | cut -d' ' -f1 | cut -c1-12)
         SANDBOX_TAG="locally-built-dockerfiles-dockerfile-sandbox:${SANDBOX_HASH}"
-        retry_docker_build \
+        docker buildx build \
           --tag nemo-skills-sandbox-image \
           --tag ${SANDBOX_TAG} \
           --file dockerfiles/Dockerfile.sandbox \
           --build-arg GITHUB_CI=1 \
-          "${CACHE_ARGS_SANDBOX[@]}" \
+          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache \
+          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min \
           --load \
           .
     - name: Run all tests
-      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       env:
         NV_INFERENCE_API_KEY: ${{ secrets.NV_INFERENCE_API_KEY }}
         NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
@@ -124,13 +96,4 @@ jobs:
         sleep 10
         set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         ns prepare_data gsm8k math-500 hle
-        python -m pytest tests/ -m "not gpu and not live" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv
-
-    - name: Run fork-safe MCP tests
-      if: ${{ env.HAS_GHCR_PAT != 'true' }}
-      run: |
-        python -m nemo_skills.code_execution.local_sandbox.local_sandbox_server &
-        SANDBOX_PID=$!
-        trap "kill ${SANDBOX_PID}" EXIT
-        sleep 5
-        python -m pytest tests/test_mcp_clients.py -m "not gpu and not live" --junitxml=pytest.xml --durations=30 -rs -s -vvv
+        python -m pytest tests/ -m "not gpu" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GHCR_PAT: ${{ secrets.GHCR_PAT }}
+      GHCR_TOKEN: ${{ secrets.GHCR_PAT || github.token }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -26,12 +28,12 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ env.GHCR_PAT != '' }}
+      if: ${{ env.GHCR_TOKEN != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ env.GHCR_PAT }}
+        password: ${{ env.GHCR_TOKEN }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -55,12 +57,10 @@ jobs:
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-        CACHE_ARGS_NEMO=()
-        CACHE_ARGS_SANDBOX=()
+        CACHE_ARGS_NEMO=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
+        CACHE_ARGS_SANDBOX=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
         if [ -n "${GHCR_PAT:-}" ]; then
-          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
           CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
-          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
           CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
         fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    env:
+      GHCR_PAT: ${{ secrets.GHCR_PAT }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -24,12 +26,12 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ secrets.GHCR_PAT != '' }}
+      if: ${{ env.GHCR_PAT != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_PAT }}
+        password: ${{ env.GHCR_PAT }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -49,8 +51,6 @@ jobs:
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
-      env:
-        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}

--- a/docs/agentic_inference/tool_calling.md
+++ b/docs/agentic_inference/tool_calling.md
@@ -371,3 +371,4 @@ For vLLM, you may need to specify tool calling arguments:
 
 - [`nemo_skills.mcp.servers.python_tool.PythonTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/python_tool.py) - Python code execution
 - [`nemo_skills.mcp.servers.exa_tool.ExaTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/exa_tool.py) - Web search via Exa API
+- [`nemo_skills.mcp.servers.particle_tool.ParticleTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/particle_tool.py) - Particle physics lookup from the PDG database via particle (requires `particle`)

--- a/docs/agentic_inference/tool_calling.md
+++ b/docs/agentic_inference/tool_calling.md
@@ -371,4 +371,5 @@ For vLLM, you may need to specify tool calling arguments:
 
 - [`nemo_skills.mcp.servers.python_tool.PythonTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/python_tool.py) - Python code execution
 - [`nemo_skills.mcp.servers.exa_tool.ExaTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/exa_tool.py) - Web search via Exa API
+- [`nemo_skills.mcp.servers.particle_tool.ParticleTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/particle_tool.py) - Direct particle physics lookup from the PDG database via particle (requires `particle`)
 - [`nemo_skills.mcp.servers.particle_tool.ParticleTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/particle_tool.py) - Particle physics lookup from the PDG database via particle (requires `particle`)

--- a/docs/agentic_inference/tool_calling.md
+++ b/docs/agentic_inference/tool_calling.md
@@ -372,4 +372,3 @@ For vLLM, you may need to specify tool calling arguments:
 - [`nemo_skills.mcp.servers.python_tool.PythonTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/python_tool.py) - Python code execution
 - [`nemo_skills.mcp.servers.exa_tool.ExaTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/exa_tool.py) - Web search via Exa API
 - [`nemo_skills.mcp.servers.particle_tool.ParticleTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/particle_tool.py) - Direct particle physics lookup from the PDG database via particle (requires `particle`)
-- [`nemo_skills.mcp.servers.particle_tool.ParticleTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/particle_tool.py) - Particle physics lookup from the PDG database via particle (requires `particle`)

--- a/nemo_skills/mcp/servers/particle_tool.py
+++ b/nemo_skills/mcp/servers/particle_tool.py
@@ -108,6 +108,7 @@ def particle_search(
     header = f"Found {len(results)} particle(s) matching '{query}':\n"
     return header + "\n".join(results)
 
+
 class ParticleTool(Tool):
     def __init__(self) -> None:
         self._config: dict[str, Any] = {}

--- a/nemo_skills/mcp/servers/particle_tool.py
+++ b/nemo_skills/mcp/servers/particle_tool.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Particle physics MCP tool wrapping the PDG particle database.
+
+Provides lookup of particle properties (mass, width, charge, spin, lifetime)
+and search by name. Uses the ``particle`` pip package. No API key required.
+
+Prerequisites:
+    pip install particle
+
+Usage:
+    ++tool_modules=[nemo_skills.mcp.servers.particle_tool::ParticleTool]
+"""
+
+import logging
+from typing import Annotated
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from nemo_skills.mcp.tool_providers import MCPClientTool
+
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP(name="particle")
+
+MAX_SEARCH_RESULTS = 10
+
+
+def _format_particle(p) -> str:
+    lines = [f"**{p.name}**"]
+    lines.append(f"PDG ID: {p.pdgid}")
+    if p.latex_name:
+        lines.append(f"LaTeX: {p.latex_name}")
+    if p.mass is not None:
+        lines.append(f"Mass: {p.mass} MeV/c^2")
+    if p.width is not None:
+        lines.append(f"Width: {p.width} MeV")
+    if p.charge is not None:
+        lines.append(f"Charge: {p.charge} e")
+    if p.J is not None:
+        lines.append(f"Spin (J): {p.J}")
+    if p.lifetime is not None:
+        lines.append(f"Lifetime: {p.lifetime:.6e} ns")
+    if p.anti_flag:
+        lines.append(f"Anti-flag: {p.anti_flag.name}")
+    if p.P is not None:
+        lines.append(f"Parity (P): {'+' if p.P == 1 else '-'}")
+    if p.C is not None:
+        lines.append(f"C-parity: {'+' if p.C == 1 else '-'}")
+    return "\n".join(lines)
+
+
+@mcp.tool(name="particle-lookup")
+def particle_lookup(
+    name_or_id: Annotated[
+        str,
+        Field(description="Particle name (e.g. 'pi+', 'K0', 'J/psi(1S)') or PDG ID as a string (e.g. '211')."),
+    ],
+) -> str:
+    """Look up a particle by name or PDG ID. Returns mass, width, charge, spin, lifetime, and quantum numbers."""
+    from particle import InvalidParticle, Particle, ParticleNotFound
+
+    try:
+        p = Particle.from_pdgid(int(name_or_id))
+        return _format_particle(p)
+    except (ValueError, ParticleNotFound, InvalidParticle):
+        pass
+
+    try:
+        p = Particle.from_name(name_or_id)
+        return _format_particle(p)
+    except (ParticleNotFound, InvalidParticle):
+        pass
+
+    matches = Particle.findall(name_or_id)
+    if matches:
+        return _format_particle(matches[0])
+
+    return f"Particle '{name_or_id}' not found. Try a standard name like 'pi+', 'K-', 'D0', or a PDG ID."
+
+
+@mcp.tool(name="particle-search")
+def particle_search(
+    query: Annotated[
+        str, Field(description="Search query - substring match on particle names (e.g. 'K', 'charm', 'omega').")
+    ],
+) -> str:
+    """Search for particles by name. Returns a list of matching particles with key properties."""
+    from particle import Particle
+
+    matches = Particle.findall(query)
+    if not matches:
+        return f"No particles found matching '{query}'."
+
+    matches = matches[:MAX_SEARCH_RESULTS]
+    results = []
+    for p in matches:
+        mass_str = f"{p.mass} MeV/c^2" if p.mass is not None else "n/a"
+        results.append(f"**{p.name}** (PDG {p.pdgid}) - mass: {mass_str}, charge: {p.charge}")
+    header = f"Found {len(results)} particle(s) matching '{query}':\n"
+    return header + "\n".join(results)
+
+
+class ParticleTool(MCPClientTool):
+    def __init__(self) -> None:
+        super().__init__()
+        self.apply_config_updates(
+            {
+                "client": "nemo_skills.mcp.clients.MCPStdioClient",
+                "client_params": {
+                    "command": "python",
+                    "args": ["-m", "nemo_skills.mcp.servers.particle_tool"],
+                },
+            }
+        )
+
+
+def main():
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_skills/mcp/servers/particle_tool.py
+++ b/nemo_skills/mcp/servers/particle_tool.py
@@ -118,7 +118,8 @@ class ParticleTool(Tool):
 
     def configure(self, overrides: dict[str, Any] | None = None, context: dict[str, Any] | None = None) -> None:
         if overrides:
-            self._config.update(overrides)
+            unknown = ", ".join(sorted(overrides))
+            raise ValueError(f"ParticleTool does not support overrides: {unknown}")
 
     async def list_tools(self) -> list[dict[str, Any]]:
         return [

--- a/nemo_skills/mcp/servers/particle_tool.py
+++ b/nemo_skills/mcp/servers/particle_tool.py
@@ -25,16 +25,13 @@ Usage:
 """
 
 import logging
-from typing import Annotated
+from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from nemo_skills.mcp.tool_providers import MCPClientTool
+from nemo_skills.mcp.tool_manager import Tool
 
 logger = logging.getLogger(__name__)
-
-mcp = FastMCP(name="particle")
 
 MAX_SEARCH_RESULTS = 10
 
@@ -63,7 +60,6 @@ def _format_particle(p) -> str:
     return "\n".join(lines)
 
 
-@mcp.tool(name="particle-lookup")
 def particle_lookup(
     name_or_id: Annotated[
         str,
@@ -92,7 +88,6 @@ def particle_lookup(
     return f"Particle '{name_or_id}' not found. Try a standard name like 'pi+', 'K-', 'D0', or a PDG ID."
 
 
-@mcp.tool(name="particle-search")
 def particle_search(
     query: Annotated[
         str, Field(description="Search query - substring match on particle names (e.g. 'K', 'charm', 'omega').")
@@ -113,24 +108,43 @@ def particle_search(
     header = f"Found {len(results)} particle(s) matching '{query}':\n"
     return header + "\n".join(results)
 
-
-class ParticleTool(MCPClientTool):
+class ParticleTool(Tool):
     def __init__(self) -> None:
-        super().__init__()
-        self.apply_config_updates(
+        self._config: dict[str, Any] = {}
+
+    def default_config(self) -> dict[str, Any]:
+        return dict(self._config)
+
+    def configure(self, overrides: dict[str, Any] | None = None, context: dict[str, Any] | None = None) -> None:
+        if overrides:
+            self._config.update(overrides)
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        return [
             {
-                "client": "nemo_skills.mcp.clients.MCPStdioClient",
-                "client_params": {
-                    "command": "python",
-                    "args": ["-m", "nemo_skills.mcp.servers.particle_tool"],
+                "name": "particle-lookup",
+                "description": "Look up a particle by name or PDG ID.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"name_or_id": {"type": "string", "description": "Particle name or PDG ID."}},
+                    "required": ["name_or_id"],
                 },
-            }
-        )
+            },
+            {
+                "name": "particle-search",
+                "description": "Search for particles by name.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string", "description": "Substring query on particle names."}},
+                    "required": ["query"],
+                },
+            },
+        ]
 
-
-def main():
-    mcp.run(transport="stdio")
-
-
-if __name__ == "__main__":
-    main()
+    async def execute(self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None):
+        arguments = dict(arguments or {})
+        if tool_name == "particle-lookup":
+            return particle_lookup(**arguments)
+        if tool_name == "particle-search":
+            return particle_search(**arguments)
+        return f"Error: unknown tool '{tool_name}'"

--- a/nemo_skills/mcp/servers/particle_tool.py
+++ b/nemo_skills/mcp/servers/particle_tool.py
@@ -144,6 +144,9 @@ class ParticleTool(Tool):
         ]
 
     async def execute(self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None):
+        if extra_args:
+            unknown = ", ".join(sorted(map(str, extra_args)))
+            raise ValueError(f"ParticleTool does not support extra_args: {unknown}")
         arguments = dict(arguments or {})
         if tool_name == "particle-lookup":
             return particle_lookup(**arguments)

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -1003,6 +1003,7 @@ async def test_direct_python_tool_cleanup_request_tolerates_delete_failure():
     await tool.cleanup_request("req-x")
     assert "req-x" not in tool.requests_to_sessions
 
+
 # -- Particle direct tool tests ---------------------------------------------
 
 

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -1002,3 +1002,29 @@ async def test_direct_python_tool_cleanup_request_tolerates_delete_failure():
     # Must not raise; session must be removed from the mapping regardless.
     await tool.cleanup_request("req-x")
     assert "req-x" not in tool.requests_to_sessions
+
+
+# -- Particle tool tests -----------------------------------------------------
+
+
+class TestParticleTool:
+    def test_particle_tool_config(self):
+        from nemo_skills.mcp.servers.particle_tool import ParticleTool
+
+        tool = ParticleTool()
+        assert tool._config["client"] == "nemo_skills.mcp.clients.MCPStdioClient"
+        assert "nemo_skills.mcp.servers.particle_tool" in tool._config["client_params"]["args"]
+
+    @pytest.mark.asyncio
+    async def test_particle_stdio_list_tools(self):
+        from nemo_skills.mcp.servers.particle_tool import ParticleTool
+
+        tool = ParticleTool()
+        tool.configure()
+        try:
+            tools = await tool.list_tools()
+            tool_names = {t["name"] for t in tools}
+            assert "particle-lookup" in tool_names
+            assert "particle-search" in tool_names
+        finally:
+            await tool.shutdown()

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -1023,3 +1023,11 @@ class TestParticleTool:
         tool_names = {t["name"] for t in await tool.list_tools()}
         assert "particle-lookup" in tool_names
         assert "particle-search" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_particle_tool_rejects_extra_args(self):
+        from nemo_skills.mcp.servers.particle_tool import ParticleTool
+
+        tool = ParticleTool()
+        with pytest.raises(ValueError, match="does not support extra_args"):
+            await tool.execute("particle-search", {"query": "pi"}, extra_args={"unused": True})

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -1003,8 +1003,7 @@ async def test_direct_python_tool_cleanup_request_tolerates_delete_failure():
     await tool.cleanup_request("req-x")
     assert "req-x" not in tool.requests_to_sessions
 
-
-# -- Particle tool tests -----------------------------------------------------
+# -- Particle direct tool tests ---------------------------------------------
 
 
 class TestParticleTool:
@@ -1012,19 +1011,14 @@ class TestParticleTool:
         from nemo_skills.mcp.servers.particle_tool import ParticleTool
 
         tool = ParticleTool()
-        assert tool._config["client"] == "nemo_skills.mcp.clients.MCPStdioClient"
-        assert "nemo_skills.mcp.servers.particle_tool" in tool._config["client_params"]["args"]
+        assert tool.default_config() == {}
 
     @pytest.mark.asyncio
-    async def test_particle_stdio_list_tools(self):
+    async def test_particle_direct_list_tools(self):
         from nemo_skills.mcp.servers.particle_tool import ParticleTool
 
         tool = ParticleTool()
         tool.configure()
-        try:
-            tools = await tool.list_tools()
-            tool_names = {t["name"] for t in tools}
-            assert "particle-lookup" in tool_names
-            assert "particle-search" in tool_names
-        finally:
-            await tool.shutdown()
+        tool_names = {t["name"] for t in await tool.list_tools()}
+        assert "particle-lookup" in tool_names
+        assert "particle-search" in tool_names


### PR DESCRIPTION
## Summary
- Reopened from an internal `NVIDIA-NeMo/Skills` branch so CI can access repository secrets.
- Replaces #1415.
- Add a built-in particle MCP tool for PDG particle lookup and search.
- Document the new built-in tool and add focused MCP client tests.

## Test plan
- `python -m py_compile nemo_skills/mcp/servers/particle_tool.py`
- `python -m pytest tests/test_mcp_clients.py::TestParticleTool -q --tb=short`
- `python -m pytest tests/test_mcp_clients.py -q --tb=short`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added particle property lookup and search, enabling queries by name or PDG ID with mass, charge, spin, lifetime and quantum numbers.

* **Documentation**
  * Added reference docs for the new particle lookup/search tool (notes it requires the particle package).

* **Tests**
  * Added tests for the particle tool’s configuration, tool listing, and rejection of unsupported extra arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->