### PR TITLE
Add radioactive decay MCP tool

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
+      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       env:
         GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
@@ -110,6 +111,7 @@ jobs:
           --load \
           .
     - name: Run all tests
+      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       env:
         NV_INFERENCE_API_KEY: ${{ secrets.NV_INFERENCE_API_KEY }}
         NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
@@ -123,3 +125,12 @@ jobs:
         set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         ns prepare_data gsm8k math-500 hle
         python -m pytest tests/ -m "not gpu and not live" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv
+
+    - name: Run fork-safe MCP tests
+      if: ${{ env.HAS_GHCR_PAT != 'true' }}
+      run: |
+        python -m nemo_skills.code_execution.local_sandbox.local_sandbox_server &
+        SANDBOX_PID=$!
+        trap "kill ${SANDBOX_PID}" EXIT
+        sleep 5
+        python -m pytest tests/test_mcp_clients.py -m "not gpu and not live" --junitxml=pytest.xml --durations=30 -rs -s -vvv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,6 +17,8 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    env:
+      HAS_GHCR_PAT: ${{ secrets.GHCR_PAT != '' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -25,11 +26,14 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
+      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       uses: docker/login-action@v3
+      env:
+        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_PAT || github.token }}
+        password: ${{ env.GHCR_PAT }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -55,17 +59,32 @@ jobs:
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-        CACHE_ARGS_NEMO=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
-        CACHE_ARGS_SANDBOX=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
+        CACHE_ARGS_NEMO=()
+        CACHE_ARGS_SANDBOX=()
         if [ -n "${GHCR_PAT:-}" ]; then
+          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
           CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
+          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
           CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
         fi
+
+        retry_docker_build() {
+          for attempt in 1 2 3; do
+            if docker buildx build "$@"; then
+              return 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Docker build failed on attempt ${attempt}; retrying in 30s..."
+              sleep 30
+            fi
+          done
+          return 1
+        }
 
         # Build nemo-skills-image with expected tag
         NEMO_SKILLS_HASH=$(sha256sum dockerfiles/Dockerfile.nemo-skills | cut -d' ' -f1 | cut -c1-12)
         NEMO_SKILLS_TAG="locally-built-dockerfiles-dockerfile-nemo-skills:${NEMO_SKILLS_HASH}"
-        docker buildx build \
+        retry_docker_build \
           --tag nemo-skills-image \
           --tag ${NEMO_SKILLS_TAG} \
           --file dockerfiles/Dockerfile.nemo-skills \
@@ -82,7 +101,7 @@ jobs:
         # Build sandbox-image with expected tag
         SANDBOX_HASH=$(sha256sum dockerfiles/Dockerfile.sandbox | cut -d' ' -f1 | cut -c1-12)
         SANDBOX_TAG="locally-built-dockerfiles-dockerfile-sandbox:${SANDBOX_HASH}"
-        docker buildx build \
+        retry_docker_build \
           --tag nemo-skills-sandbox-image \
           --tag ${SANDBOX_TAG} \
           --file dockerfiles/Dockerfile.sandbox \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
+      if: ${{ secrets.GHCR_PAT != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -44,14 +45,24 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev] --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -e ".[dev,tools]" --extra-index-url https://download.pytorch.org/whl/cpu
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
+      env:
+        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+        CACHE_ARGS_NEMO=()
+        CACHE_ARGS_SANDBOX=()
+        if [ -n "${GHCR_PAT:-}" ]; then
+          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
+          CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
+          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
+          CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
+        fi
 
         # Build nemo-skills-image with expected tag
         NEMO_SKILLS_HASH=$(sha256sum dockerfiles/Dockerfile.nemo-skills | cut -d' ' -f1 | cut -c1-12)
@@ -60,8 +71,7 @@ jobs:
           --tag nemo-skills-image \
           --tag ${NEMO_SKILLS_TAG} \
           --file dockerfiles/Dockerfile.nemo-skills \
-          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache \
-          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min \
+          "${CACHE_ARGS_NEMO[@]}" \
           --load \
           .
 
@@ -79,8 +89,7 @@ jobs:
           --tag ${SANDBOX_TAG} \
           --file dockerfiles/Dockerfile.sandbox \
           --build-arg GITHUB_CI=1 \
-          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache \
-          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min \
+          "${CACHE_ARGS_SANDBOX[@]}" \
           --load \
           .
     - name: Run all tests
@@ -96,4 +105,4 @@ jobs:
         sleep 10
         set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         ns prepare_data gsm8k math-500 hle
-        python -m pytest tests/ -m "not gpu" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv
+        python -m pytest tests/ -m "not gpu and not live" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,6 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    env:
-      GHCR_PAT: ${{ secrets.GHCR_PAT }}
-      GHCR_TOKEN: ${{ secrets.GHCR_PAT || github.token }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -28,12 +25,11 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ env.GHCR_TOKEN != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ env.GHCR_TOKEN }}
+        password: ${{ secrets.GHCR_PAT || github.token }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -53,6 +49,8 @@ jobs:
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
+      env:
+        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,6 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    env:
-      HAS_GHCR_PAT: ${{ secrets.GHCR_PAT != '' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -26,14 +24,11 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       uses: docker/login-action@v3
-      env:
-        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ env.GHCR_PAT }}
+        password: ${{ secrets.GHCR_PAT }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -49,47 +44,24 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev,tools]" --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -e .[dev] --extra-index-url https://download.pytorch.org/whl/cpu
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
-      if: ${{ env.HAS_GHCR_PAT == 'true' }}
-      env:
-        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-        CACHE_ARGS_NEMO=()
-        CACHE_ARGS_SANDBOX=()
-        if [ -n "${GHCR_PAT:-}" ]; then
-          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
-          CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
-          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
-          CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
-        fi
-
-        retry_docker_build() {
-          for attempt in 1 2 3; do
-            if docker buildx build "$@"; then
-              return 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              echo "Docker build failed on attempt ${attempt}; retrying in 30s..."
-              sleep 30
-            fi
-          done
-          return 1
-        }
 
         # Build nemo-skills-image with expected tag
         NEMO_SKILLS_HASH=$(sha256sum dockerfiles/Dockerfile.nemo-skills | cut -d' ' -f1 | cut -c1-12)
         NEMO_SKILLS_TAG="locally-built-dockerfiles-dockerfile-nemo-skills:${NEMO_SKILLS_HASH}"
-        retry_docker_build \
+        docker buildx build \
           --tag nemo-skills-image \
           --tag ${NEMO_SKILLS_TAG} \
           --file dockerfiles/Dockerfile.nemo-skills \
-          "${CACHE_ARGS_NEMO[@]}" \
+          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache \
+          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min \
           --load \
           .
 
@@ -102,16 +74,16 @@ jobs:
         # Build sandbox-image with expected tag
         SANDBOX_HASH=$(sha256sum dockerfiles/Dockerfile.sandbox | cut -d' ' -f1 | cut -c1-12)
         SANDBOX_TAG="locally-built-dockerfiles-dockerfile-sandbox:${SANDBOX_HASH}"
-        retry_docker_build \
+        docker buildx build \
           --tag nemo-skills-sandbox-image \
           --tag ${SANDBOX_TAG} \
           --file dockerfiles/Dockerfile.sandbox \
           --build-arg GITHUB_CI=1 \
-          "${CACHE_ARGS_SANDBOX[@]}" \
+          --cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache \
+          --cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min \
           --load \
           .
     - name: Run all tests
-      if: ${{ env.HAS_GHCR_PAT == 'true' }}
       env:
         NV_INFERENCE_API_KEY: ${{ secrets.NV_INFERENCE_API_KEY }}
         NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
@@ -124,13 +96,4 @@ jobs:
         sleep 10
         set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         ns prepare_data gsm8k math-500 hle
-        python -m pytest tests/ -m "not gpu and not live" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv
-
-    - name: Run fork-safe MCP tests
-      if: ${{ env.HAS_GHCR_PAT != 'true' }}
-      run: |
-        python -m nemo_skills.code_execution.local_sandbox.local_sandbox_server &
-        SANDBOX_PID=$!
-        trap "kill ${SANDBOX_PID}" EXIT
-        sleep 5
-        python -m pytest tests/test_mcp_clients.py -m "not gpu and not live" --junitxml=pytest.xml --durations=30 -rs -s -vvv
+        python -m pytest tests/ -m "not gpu" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GHCR_PAT: ${{ secrets.GHCR_PAT }}
+      GHCR_TOKEN: ${{ secrets.GHCR_PAT || github.token }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -26,12 +28,12 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ env.GHCR_PAT != '' }}
+      if: ${{ env.GHCR_TOKEN != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ env.GHCR_PAT }}
+        password: ${{ env.GHCR_TOKEN }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -55,12 +57,10 @@ jobs:
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}
         REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-        CACHE_ARGS_NEMO=()
-        CACHE_ARGS_SANDBOX=()
+        CACHE_ARGS_NEMO=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
+        CACHE_ARGS_SANDBOX=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
         if [ -n "${GHCR_PAT:-}" ]; then
-          CACHE_ARGS_NEMO+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache)
           CACHE_ARGS_NEMO+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-image:cache,mode=min)
-          CACHE_ARGS_SANDBOX+=(--cache-from type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache)
           CACHE_ARGS_SANDBOX+=(--cache-to type=registry,ref=ghcr.io/${REPO_LOWER}/nemo-skills-sandbox-image:cache,mode=min)
         fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    env:
+      GHCR_PAT: ${{ secrets.GHCR_PAT }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -24,12 +26,12 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GHCR
-      if: ${{ secrets.GHCR_PAT != '' }}
+      if: ${{ env.GHCR_PAT != '' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_PAT }}
+        password: ${{ env.GHCR_PAT }}
 
     - name: Free up disk space on Ubuntu
       run: |
@@ -49,8 +51,6 @@ jobs:
         # Clear pip cache
         pip cache purge || true
     - name: Build Images
-      env:
-        GHCR_PAT: ${{ secrets.GHCR_PAT }}
       run: |
         # Calculate image tags that match what Python code expects
         # Python generates: locally-built-{sanitized_path}:{sha256_hash[:12]}

--- a/docs/agentic_inference/tool_calling.md
+++ b/docs/agentic_inference/tool_calling.md
@@ -372,4 +372,3 @@ For vLLM, you may need to specify tool calling arguments:
 - [`nemo_skills.mcp.servers.python_tool.PythonTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/python_tool.py) - Python code execution
 - [`nemo_skills.mcp.servers.exa_tool.ExaTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/exa_tool.py) - Web search via Exa API
 - [`nemo_skills.mcp.servers.radioactivedecay_tool.RadioactivedecayTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/radioactivedecay_tool.py) - Direct nuclear nuclide and decay-chain lookup via radioactivedecay (requires `radioactivedecay`)
-- [`nemo_skills.mcp.servers.radioactivedecay_tool.RadioactivedecayTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/radioactivedecay_tool.py) - Nuclear nuclide and decay-chain lookup via radioactivedecay (requires `radioactivedecay`)

--- a/docs/agentic_inference/tool_calling.md
+++ b/docs/agentic_inference/tool_calling.md
@@ -371,4 +371,5 @@ For vLLM, you may need to specify tool calling arguments:
 
 - [`nemo_skills.mcp.servers.python_tool.PythonTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/python_tool.py) - Python code execution
 - [`nemo_skills.mcp.servers.exa_tool.ExaTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/exa_tool.py) - Web search via Exa API
+- [`nemo_skills.mcp.servers.radioactivedecay_tool.RadioactivedecayTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/radioactivedecay_tool.py) - Direct nuclear nuclide and decay-chain lookup via radioactivedecay (requires `radioactivedecay`)
 - [`nemo_skills.mcp.servers.radioactivedecay_tool.RadioactivedecayTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/radioactivedecay_tool.py) - Nuclear nuclide and decay-chain lookup via radioactivedecay (requires `radioactivedecay`)

--- a/docs/agentic_inference/tool_calling.md
+++ b/docs/agentic_inference/tool_calling.md
@@ -371,3 +371,4 @@ For vLLM, you may need to specify tool calling arguments:
 
 - [`nemo_skills.mcp.servers.python_tool.PythonTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/python_tool.py) - Python code execution
 - [`nemo_skills.mcp.servers.exa_tool.ExaTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/exa_tool.py) - Web search via Exa API
+- [`nemo_skills.mcp.servers.radioactivedecay_tool.RadioactivedecayTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/radioactivedecay_tool.py) - Nuclear nuclide and decay-chain lookup via radioactivedecay (requires `radioactivedecay`)

--- a/nemo_skills/mcp/servers/radioactivedecay_tool.py
+++ b/nemo_skills/mcp/servers/radioactivedecay_tool.py
@@ -26,21 +26,17 @@ Usage:
 
 import logging
 import math
-from typing import Annotated
+from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from nemo_skills.mcp.tool_providers import MCPClientTool
+from nemo_skills.mcp.tool_manager import Tool
 
 logger = logging.getLogger(__name__)
-
-mcp = FastMCP(name="radioactivedecay")
 
 VALID_TIME_UNITS = {"ps", "ns", "us", "ms", "s", "m", "h", "d", "y", "ky", "My", "Gy", "Ty"}
 
 
-@mcp.tool(name="nuclide-info")
 def nuclide_info(
     nuclide: Annotated[str, Field(description="Nuclide in standard notation (e.g. 'H-3', 'U-238', 'Co-60').")],
 ) -> str:
@@ -82,7 +78,6 @@ def nuclide_info(
     return "\n".join(lines)
 
 
-@mcp.tool(name="decay-chain")
 def decay_chain(
     nuclide: Annotated[str, Field(description="Starting nuclide (e.g. 'U-238', 'Co-60').")],
     time: Annotated[float, Field(description="Elapsed time for decay calculation.")],
@@ -117,27 +112,47 @@ def decay_chain(
 
     return "\n".join(lines)
 
-
-class RadioactivedecayTool(MCPClientTool):
+class RadioactivedecayTool(Tool):
     def __init__(self) -> None:
-        super().__init__()
-        self.apply_config_updates(
+        self._config: dict[str, Any] = {"time_unit": "s"}
+
+    def default_config(self) -> dict[str, Any]:
+        return dict(self._config)
+
+    def configure(self, overrides: dict[str, Any] | None = None, context: dict[str, Any] | None = None) -> None:
+        if overrides:
+            self._config.update(overrides)
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        return [
             {
-                "client": "nemo_skills.mcp.clients.MCPStdioClient",
-                "client_params": {
-                    "command": "python",
-                    "args": ["-m", "nemo_skills.mcp.servers.radioactivedecay_tool"],
+                "name": "nuclide-info",
+                "description": "Look up half-life, decay modes, progeny, and branching fractions for a nuclide.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"nuclide": {"type": "string", "description": "Nuclide notation, e.g. H-3, U-238, Co-60."}},
+                    "required": ["nuclide"],
                 },
-                "hide_args": {
-                    "decay-chain": ["time_unit"],
+            },
+            {
+                "name": "decay-chain",
+                "description": "Calculate decay-chain product activities after an elapsed time.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "nuclide": {"type": "string", "description": "Starting nuclide."},
+                        "time": {"type": "number", "description": "Elapsed time for the decay calculation."},
+                    },
+                    "required": ["nuclide", "time"],
                 },
-            }
-        )
+            },
+        ]
 
-
-def main():
-    mcp.run(transport="stdio")
-
-
-if __name__ == "__main__":
-    main()
+    async def execute(self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None):
+        arguments = dict(arguments or {})
+        if tool_name == "nuclide-info":
+            return nuclide_info(**arguments)
+        if tool_name == "decay-chain":
+            arguments.setdefault("time_unit", self._config.get("time_unit", "s"))
+            return decay_chain(**arguments)
+        return f"Error: unknown tool '{tool_name}'"

--- a/nemo_skills/mcp/servers/radioactivedecay_tool.py
+++ b/nemo_skills/mcp/servers/radioactivedecay_tool.py
@@ -112,6 +112,7 @@ def decay_chain(
 
     return "\n".join(lines)
 
+
 class RadioactivedecayTool(Tool):
     def __init__(self) -> None:
         self._config: dict[str, Any] = {"time_unit": "s"}
@@ -130,7 +131,9 @@ class RadioactivedecayTool(Tool):
                 "description": "Look up half-life, decay modes, progeny, and branching fractions for a nuclide.",
                 "input_schema": {
                     "type": "object",
-                    "properties": {"nuclide": {"type": "string", "description": "Nuclide notation, e.g. H-3, U-238, Co-60."}},
+                    "properties": {
+                        "nuclide": {"type": "string", "description": "Nuclide notation, e.g. H-3, U-238, Co-60."}
+                    },
                     "required": ["nuclide"],
                 },
             },

--- a/nemo_skills/mcp/servers/radioactivedecay_tool.py
+++ b/nemo_skills/mcp/servers/radioactivedecay_tool.py
@@ -84,8 +84,6 @@ def decay_chain(
     time_unit: Annotated[str, Field(description="Time unit: s, m, h, d, y, ky, My, Gy, Ty, ps, ns, us, ms.")] = "s",
 ) -> str:
     """Calculate the decay chain products and activities after a given time."""
-    import radioactivedecay as rd
-
     if time_unit not in VALID_TIME_UNITS:
         return f"Invalid time unit '{time_unit}'. Valid units: {', '.join(sorted(VALID_TIME_UNITS))}"
 
@@ -93,6 +91,8 @@ def decay_chain(
         return "Time must be a finite number."
     if time < 0:
         return "Time must be non-negative."
+
+    import radioactivedecay as rd
 
     try:
         rd.Nuclide(nuclide)

--- a/nemo_skills/mcp/servers/radioactivedecay_tool.py
+++ b/nemo_skills/mcp/servers/radioactivedecay_tool.py
@@ -121,8 +121,18 @@ class RadioactivedecayTool(Tool):
         return dict(self._config)
 
     def configure(self, overrides: dict[str, Any] | None = None, context: dict[str, Any] | None = None) -> None:
-        if overrides:
-            self._config.update(overrides)
+        if not overrides:
+            return
+
+        allowed = {"time_unit"}
+        unknown = set(overrides) - allowed
+        if unknown:
+            raise ValueError(f"Unsupported RadioactivedecayTool override(s): {sorted(unknown)}")
+
+        time_unit = overrides.get("time_unit", self._config["time_unit"])
+        if time_unit not in VALID_TIME_UNITS:
+            raise ValueError(f"Invalid time unit '{time_unit}'. Valid units: {', '.join(sorted(VALID_TIME_UNITS))}")
+        self._config["time_unit"] = time_unit
 
     async def list_tools(self) -> list[dict[str, Any]]:
         return [
@@ -156,6 +166,6 @@ class RadioactivedecayTool(Tool):
         if tool_name == "nuclide-info":
             return nuclide_info(**arguments)
         if tool_name == "decay-chain":
-            arguments.setdefault("time_unit", self._config.get("time_unit", "s"))
+            arguments.setdefault("time_unit", self._config["time_unit"])
             return decay_chain(**arguments)
         return f"Error: unknown tool '{tool_name}'"

--- a/nemo_skills/mcp/servers/radioactivedecay_tool.py
+++ b/nemo_skills/mcp/servers/radioactivedecay_tool.py
@@ -25,6 +25,7 @@ Usage:
 """
 
 import logging
+import math
 from typing import Annotated
 
 from mcp.server.fastmcp import FastMCP
@@ -93,6 +94,8 @@ def decay_chain(
     if time_unit not in VALID_TIME_UNITS:
         return f"Invalid time unit '{time_unit}'. Valid units: {', '.join(sorted(VALID_TIME_UNITS))}"
 
+    if not math.isfinite(time):
+        return "Time must be a finite number."
     if time < 0:
         return "Time must be non-negative."
 

--- a/nemo_skills/mcp/servers/radioactivedecay_tool.py
+++ b/nemo_skills/mcp/servers/radioactivedecay_tool.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Radioactive decay MCP tool for nuclear decay chain calculations.
+
+Wraps the ``radioactivedecay`` library to provide nuclide information and
+time-evolution of decay chains. No API key required.
+
+Prerequisites:
+    pip install radioactivedecay
+
+Usage:
+    ++tool_modules=[nemo_skills.mcp.servers.radioactivedecay_tool::RadioactivedecayTool]
+"""
+
+import logging
+from typing import Annotated
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from nemo_skills.mcp.tool_providers import MCPClientTool
+
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP(name="radioactivedecay")
+
+VALID_TIME_UNITS = {"ps", "ns", "us", "ms", "s", "m", "h", "d", "y", "ky", "My", "Gy", "Ty"}
+
+
+@mcp.tool(name="nuclide-info")
+def nuclide_info(
+    nuclide: Annotated[str, Field(description="Nuclide in standard notation (e.g. 'H-3', 'U-238', 'Co-60').")],
+) -> str:
+    """Look up a radioactive nuclide. Returns half-life, decay modes, progeny, and branching fractions."""
+    import radioactivedecay as rd
+
+    try:
+        nuc = rd.Nuclide(nuclide)
+    except ValueError:
+        return f"Nuclide '{nuclide}' not found. Use notation like 'H-3', 'U-238', 'Co-60'."
+
+    lines = [f"**{nuc.nuclide}**"]
+    lines.append(f"Atomic number (Z): {nuc.Z}")
+    lines.append(f"Mass number (A): {nuc.A}")
+
+    half_life_s = nuc.half_life()
+    if half_life_s == float("inf"):
+        lines.append("Half-life: stable")
+    else:
+        for unit in ["y", "d", "h", "m", "s"]:
+            hl = nuc.half_life(unit)
+            if hl >= 1.0:
+                lines.append(f"Half-life: {hl:.6g} {unit}")
+                break
+        else:
+            lines.append(f"Half-life: {half_life_s:.6g} s")
+
+    modes = nuc.decay_modes()
+    if modes:
+        lines.append(f"Decay modes: {', '.join(str(m) for m in modes)}")
+
+    progeny = nuc.progeny()
+    branching = nuc.branching_fractions()
+    if progeny:
+        lines.append("Progeny:")
+        for daughter, bf in zip(progeny, branching):
+            lines.append(f"  {daughter} (branching fraction: {bf:.6g})")
+
+    return "\n".join(lines)
+
+
+@mcp.tool(name="decay-chain")
+def decay_chain(
+    nuclide: Annotated[str, Field(description="Starting nuclide (e.g. 'U-238', 'Co-60').")],
+    time: Annotated[float, Field(description="Elapsed time for decay calculation.")],
+    time_unit: Annotated[str, Field(description="Time unit: s, m, h, d, y, ky, My, Gy, Ty, ps, ns, us, ms.")] = "s",
+) -> str:
+    """Calculate the decay chain products and activities after a given time."""
+    import radioactivedecay as rd
+
+    if time_unit not in VALID_TIME_UNITS:
+        return f"Invalid time unit '{time_unit}'. Valid units: {', '.join(sorted(VALID_TIME_UNITS))}"
+
+    if time < 0:
+        return "Time must be non-negative."
+
+    try:
+        rd.Nuclide(nuclide)
+    except ValueError:
+        return f"Nuclide '{nuclide}' not found. Use notation like 'H-3', 'U-238', 'Co-60'."
+
+    inv = rd.Inventory({nuclide: 1.0}, "Bq")
+    decayed = inv.decay(time, time_unit)
+    activities = decayed.activities("Bq")
+
+    lines = [f"**Decay of {nuclide} after {time} {time_unit}**", ""]
+    lines.append(f"{'Nuclide':<12} {'Activity (Bq)':>15}")
+    lines.append("-" * 28)
+    for nuc_name, activity in sorted(activities.items(), key=lambda x: -x[1]):
+        if activity > 1e-15:
+            lines.append(f"{str(nuc_name):<12} {activity:>15.6e}")
+
+    return "\n".join(lines)
+
+
+class RadioactivedecayTool(MCPClientTool):
+    def __init__(self) -> None:
+        super().__init__()
+        self.apply_config_updates(
+            {
+                "client": "nemo_skills.mcp.clients.MCPStdioClient",
+                "client_params": {
+                    "command": "python",
+                    "args": ["-m", "nemo_skills.mcp.servers.radioactivedecay_tool"],
+                },
+                "hide_args": {
+                    "decay-chain": ["time_unit"],
+                },
+            }
+        )
+
+
+def main():
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -1003,8 +1003,7 @@ async def test_direct_python_tool_cleanup_request_tolerates_delete_failure():
     await tool.cleanup_request("req-x")
     assert "req-x" not in tool.requests_to_sessions
 
-
-# -- Radioactive decay tool tests -------------------------------------------
+# -- Radioactive decay direct tool tests ------------------------------------
 
 
 class TestRadioactivedecayTool:
@@ -1012,23 +1011,26 @@ class TestRadioactivedecayTool:
         from nemo_skills.mcp.servers.radioactivedecay_tool import RadioactivedecayTool
 
         tool = RadioactivedecayTool()
-        assert tool._config["client"] == "nemo_skills.mcp.clients.MCPStdioClient"
-        assert "nemo_skills.mcp.servers.radioactivedecay_tool" in tool._config["client_params"]["args"]
+        assert tool.default_config()["time_unit"] == "s"
 
     @pytest.mark.asyncio
-    async def test_radioactivedecay_stdio_list_tools(self):
+    async def test_radioactivedecay_direct_list_tools(self):
         from nemo_skills.mcp.servers.radioactivedecay_tool import RadioactivedecayTool
 
         tool = RadioactivedecayTool()
         tool.configure()
-        try:
-            tools = await tool.list_tools()
-            tool_names = {t["name"] for t in tools}
-            assert "nuclide-info" in tool_names
-            assert "decay-chain" in tool_names
+        tools = await tool.list_tools()
+        tool_names = {t["name"] for t in tools}
+        assert "nuclide-info" in tool_names
+        assert "decay-chain" in tool_names
+        decay_tool = next(t for t in tools if t["name"] == "decay-chain")
+        assert "time_unit" not in decay_tool["input_schema"]["properties"]
 
-            decay_tool = next(t for t in tools if t["name"] == "decay-chain")
-            schema_props = decay_tool["input_schema"]["properties"]
-            assert "time_unit" not in schema_props
-        finally:
-            await tool.shutdown()
+    @pytest.mark.asyncio
+    async def test_radioactivedecay_rejects_non_finite_time(self):
+        from nemo_skills.mcp.servers.radioactivedecay_tool import RadioactivedecayTool
+
+        tool = RadioactivedecayTool()
+        tool.configure()
+        result = await tool.execute("decay-chain", {"nuclide": "H-3", "time": float("inf")})
+        assert result == "Time must be a finite number."

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -1002,3 +1002,33 @@ async def test_direct_python_tool_cleanup_request_tolerates_delete_failure():
     # Must not raise; session must be removed from the mapping regardless.
     await tool.cleanup_request("req-x")
     assert "req-x" not in tool.requests_to_sessions
+
+
+# -- Radioactive decay tool tests -------------------------------------------
+
+
+class TestRadioactivedecayTool:
+    def test_radioactivedecay_tool_config(self):
+        from nemo_skills.mcp.servers.radioactivedecay_tool import RadioactivedecayTool
+
+        tool = RadioactivedecayTool()
+        assert tool._config["client"] == "nemo_skills.mcp.clients.MCPStdioClient"
+        assert "nemo_skills.mcp.servers.radioactivedecay_tool" in tool._config["client_params"]["args"]
+
+    @pytest.mark.asyncio
+    async def test_radioactivedecay_stdio_list_tools(self):
+        from nemo_skills.mcp.servers.radioactivedecay_tool import RadioactivedecayTool
+
+        tool = RadioactivedecayTool()
+        tool.configure()
+        try:
+            tools = await tool.list_tools()
+            tool_names = {t["name"] for t in tools}
+            assert "nuclide-info" in tool_names
+            assert "decay-chain" in tool_names
+
+            decay_tool = next(t for t in tools if t["name"] == "decay-chain")
+            schema_props = decay_tool["input_schema"]["properties"]
+            assert "time_unit" not in schema_props
+        finally:
+            await tool.shutdown()

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -1003,6 +1003,7 @@ async def test_direct_python_tool_cleanup_request_tolerates_delete_failure():
     await tool.cleanup_request("req-x")
     assert "req-x" not in tool.requests_to_sessions
 
+
 # -- Radioactive decay direct tool tests ------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Reopened from an internal `NVIDIA-NeMo/Skills` branch so CI can access repository secrets.
- Replaces #1416.
- Add a built-in radioactivedecay MCP tool for nuclide lookup and decay-chain calculations.
- Document the new built-in tool and add focused MCP client tests.

## Test plan
- `python -m py_compile nemo_skills/mcp/servers/radioactivedecay_tool.py`
- `python -m pytest tests/test_mcp_clients.py::TestRadioactivedecayTool -q --tb=short`
- `python -m pytest tests/test_mcp_clients.py -q --tb=short`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a radioactive-decay tool for nuclide lookup and decay-chain activity calculations with a configurable default time unit.

* **Bug Fixes / Validation**
  * Enforced supported time units, non-negative/finite time values, and graceful handling of unknown nuclides with clear error responses.

* **Documentation**
  * Reference guide updated to list the new radioactive-decay tool.

* **Tests**
  * Added tests for configuration, tool listing, and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->