### PR TITLE
Categorize MCP server modules

### DIFF
--- a/docs/agentic_inference/tool_calling.md
+++ b/docs/agentic_inference/tool_calling.md
@@ -370,10 +370,10 @@ For vLLM, you may need to specify tool calling arguments:
 ### Built-in Tools
 
 - [`nemo_skills.mcp.servers.python_tool.PythonTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/python_tool.py) - Python code execution
-- [`nemo_skills.mcp.servers.arxiv_tool.ArxivSearchTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/arxiv_tool.py) - ArXiv paper search and retrieval (no API key required)
+- [`nemo_skills.mcp.servers.web.arxiv_tool.ArxivSearchTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/web/arxiv_tool.py) - ArXiv paper search and retrieval (no API key required)
 - [`nemo_skills.mcp.servers.exa_tool.ExaTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/exa_tool.py) - Web search via Exa API
-- [`nemo_skills.mcp.servers.periodictable_tool.PeriodictableTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/periodictable_tool.py) - Direct element, isotope, and neutron scattering lookup via periodictable (requires `periodictable`)
-- [`nemo_skills.mcp.servers.particle_tool.ParticleTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/particle_tool.py) - Direct particle physics lookup from the PDG database via particle (requires `particle`)
-- [`nemo_skills.mcp.servers.radioactivedecay_tool.RadioactivedecayTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/radioactivedecay_tool.py) - Direct nuclear nuclide and decay-chain lookup via radioactivedecay (requires `radioactivedecay`)
-- [`nemo_skills.mcp.servers.coolprop_tool.CoolPropTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/coolprop_tool.py) - Direct thermophysical fluid property lookup via CoolProp (requires `CoolProp`)
-- [`nemo_skills.mcp.servers.wikipedia_tool.WikipediaSearchTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/wikipedia_tool.py) - Direct Wikipedia article search and retrieval (no API key required)
+- [`nemo_skills.mcp.servers.chemistry.periodictable_tool.PeriodictableTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/chemistry/periodictable_tool.py) - Direct element, isotope, and neutron scattering lookup via periodictable (requires `periodictable`)
+- [`nemo_skills.mcp.servers.physics.particle_tool.ParticleTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/physics/particle_tool.py) - Direct particle physics lookup from the PDG database via particle (requires `particle`)
+- [`nemo_skills.mcp.servers.physics.radioactivedecay_tool.RadioactivedecayTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/physics/radioactivedecay_tool.py) - Direct nuclear nuclide and decay-chain lookup via radioactivedecay (requires `radioactivedecay`)
+- [`nemo_skills.mcp.servers.physics.coolprop_tool.CoolPropTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/physics/coolprop_tool.py) - Direct thermophysical fluid property lookup via CoolProp (requires `CoolProp`)
+- [`nemo_skills.mcp.servers.web.wikipedia_tool.WikipediaSearchTool`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/mcp/servers/web/wikipedia_tool.py) - Direct Wikipedia article search and retrieval (no API key required)

--- a/nemo_skills/mcp/servers/chemistry/__init__.py
+++ b/nemo_skills/mcp/servers/chemistry/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemo_skills/mcp/servers/chemistry/periodictable_tool.py
+++ b/nemo_skills/mcp/servers/chemistry/periodictable_tool.py
@@ -21,7 +21,7 @@ Prerequisites:
     pip install periodictable
 
 Usage:
-    ++tool_modules=[nemo_skills.mcp.servers.periodictable_tool::PeriodictableTool]
+    ++tool_modules=[nemo_skills.mcp.servers.chemistry.periodictable_tool::PeriodictableTool]
 """
 
 import logging

--- a/nemo_skills/mcp/servers/physics/__init__.py
+++ b/nemo_skills/mcp/servers/physics/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemo_skills/mcp/servers/physics/coolprop_tool.py
+++ b/nemo_skills/mcp/servers/physics/coolprop_tool.py
@@ -21,7 +21,7 @@ Prerequisites:
     pip install CoolProp
 
 Usage:
-    ++tool_modules=[nemo_skills.mcp.servers.coolprop_tool::CoolPropTool]
+    ++tool_modules=[nemo_skills.mcp.servers.physics.coolprop_tool::CoolPropTool]
 """
 
 import logging

--- a/nemo_skills/mcp/servers/physics/particle_tool.py
+++ b/nemo_skills/mcp/servers/physics/particle_tool.py
@@ -21,7 +21,7 @@ Prerequisites:
     pip install particle
 
 Usage:
-    ++tool_modules=[nemo_skills.mcp.servers.particle_tool::ParticleTool]
+    ++tool_modules=[nemo_skills.mcp.servers.physics.particle_tool::ParticleTool]
 """
 
 import logging

--- a/nemo_skills/mcp/servers/physics/radioactivedecay_tool.py
+++ b/nemo_skills/mcp/servers/physics/radioactivedecay_tool.py
@@ -21,7 +21,7 @@ Prerequisites:
     pip install radioactivedecay
 
 Usage:
-    ++tool_modules=[nemo_skills.mcp.servers.radioactivedecay_tool::RadioactivedecayTool]
+    ++tool_modules=[nemo_skills.mcp.servers.physics.radioactivedecay_tool::RadioactivedecayTool]
 """
 
 import logging

--- a/nemo_skills/mcp/servers/web/__init__.py
+++ b/nemo_skills/mcp/servers/web/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemo_skills/mcp/servers/web/arxiv_tool.py
+++ b/nemo_skills/mcp/servers/web/arxiv_tool.py
@@ -23,7 +23,7 @@ Tool names are kept as `arxiv-search` / `arxiv-get` for backward
 compatibility with prior generation runs that already learned to use them.
 
 Usage:
-    ++tool_modules=[nemo_skills.mcp.servers.arxiv_tool::ArxivSearchTool]
+    ++tool_modules=[nemo_skills.mcp.servers.web.arxiv_tool::ArxivSearchTool]
 """
 
 import asyncio

--- a/nemo_skills/mcp/servers/web/wikipedia_tool.py
+++ b/nemo_skills/mcp/servers/web/wikipedia_tool.py
@@ -29,7 +29,7 @@ New auxiliary:
 - `wikipedia-section(title, section)`  — fetch a single named section
 
 Usage:
-    ++tool_modules=[nemo_skills.mcp.servers.wikipedia_tool::WikipediaSearchTool]
+    ++tool_modules=[nemo_skills.mcp.servers.web.wikipedia_tool::WikipediaSearchTool]
 """
 
 import asyncio

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -1009,14 +1009,14 @@ async def test_direct_python_tool_cleanup_request_tolerates_delete_failure():
 
 class TestRadioactivedecayTool:
     def test_radioactivedecay_tool_config(self):
-        from nemo_skills.mcp.servers.radioactivedecay_tool import RadioactivedecayTool
+        from nemo_skills.mcp.servers.physics.radioactivedecay_tool import RadioactivedecayTool
 
         tool = RadioactivedecayTool()
         assert tool.default_config()["time_unit"] == "s"
 
     @pytest.mark.asyncio
     async def test_radioactivedecay_direct_list_tools(self):
-        from nemo_skills.mcp.servers.radioactivedecay_tool import RadioactivedecayTool
+        from nemo_skills.mcp.servers.physics.radioactivedecay_tool import RadioactivedecayTool
 
         tool = RadioactivedecayTool()
         tool.configure()
@@ -1029,7 +1029,7 @@ class TestRadioactivedecayTool:
 
     @pytest.mark.asyncio
     async def test_radioactivedecay_rejects_non_finite_time(self):
-        from nemo_skills.mcp.servers.radioactivedecay_tool import RadioactivedecayTool
+        from nemo_skills.mcp.servers.physics.radioactivedecay_tool import RadioactivedecayTool
 
         tool = RadioactivedecayTool()
         tool.configure()
@@ -1042,14 +1042,14 @@ class TestRadioactivedecayTool:
 
 class TestParticleTool:
     def test_particle_tool_config(self):
-        from nemo_skills.mcp.servers.particle_tool import ParticleTool
+        from nemo_skills.mcp.servers.physics.particle_tool import ParticleTool
 
         tool = ParticleTool()
         assert tool.default_config() == {}
 
     @pytest.mark.asyncio
     async def test_particle_direct_list_tools(self):
-        from nemo_skills.mcp.servers.particle_tool import ParticleTool
+        from nemo_skills.mcp.servers.physics.particle_tool import ParticleTool
 
         tool = ParticleTool()
         tool.configure()
@@ -1059,7 +1059,7 @@ class TestParticleTool:
 
     @pytest.mark.asyncio
     async def test_particle_tool_rejects_extra_args(self):
-        from nemo_skills.mcp.servers.particle_tool import ParticleTool
+        from nemo_skills.mcp.servers.physics.particle_tool import ParticleTool
 
         tool = ParticleTool()
         with pytest.raises(ValueError, match="does not support extra_args"):
@@ -1071,14 +1071,14 @@ class TestParticleTool:
 
 class TestPeriodictableTool:
     def test_periodictable_tool_config(self):
-        from nemo_skills.mcp.servers.periodictable_tool import PeriodictableTool
+        from nemo_skills.mcp.servers.chemistry.periodictable_tool import PeriodictableTool
 
         tool = PeriodictableTool()
         assert tool.default_config() == {}
 
     @pytest.mark.asyncio
     async def test_periodictable_direct_list_tools(self):
-        from nemo_skills.mcp.servers.periodictable_tool import PeriodictableTool
+        from nemo_skills.mcp.servers.chemistry.periodictable_tool import PeriodictableTool
 
         tool = PeriodictableTool()
         tool.configure()
@@ -1092,14 +1092,14 @@ class TestPeriodictableTool:
 
 class TestCoolPropTool:
     def test_coolprop_tool_config(self):
-        from nemo_skills.mcp.servers.coolprop_tool import CoolPropTool
+        from nemo_skills.mcp.servers.physics.coolprop_tool import CoolPropTool
 
         tool = CoolPropTool()
         assert tool.default_config() == {}
 
     @pytest.mark.asyncio
     async def test_coolprop_direct_list_tools(self):
-        from nemo_skills.mcp.servers.coolprop_tool import CoolPropTool
+        from nemo_skills.mcp.servers.physics.coolprop_tool import CoolPropTool
 
         tool = CoolPropTool()
         tool.configure()
@@ -1113,14 +1113,14 @@ class TestCoolPropTool:
 
 class TestWikipediaTool:
     def test_wikipedia_tool_config(self):
-        from nemo_skills.mcp.servers.wikipedia_tool import WikipediaSearchTool
+        from nemo_skills.mcp.servers.web.wikipedia_tool import WikipediaSearchTool
 
         tool = WikipediaSearchTool()
         assert tool.default_config()["num_results"] == 3
 
     @pytest.mark.asyncio
     async def test_wikipedia_search_rejects_out_of_range_num_results(self):
-        from nemo_skills.mcp.servers.wikipedia_tool import WikipediaSearchTool
+        from nemo_skills.mcp.servers.web.wikipedia_tool import WikipediaSearchTool
 
         tool = WikipediaSearchTool()
         tool.configure()
@@ -1129,7 +1129,7 @@ class TestWikipediaTool:
 
     @pytest.mark.asyncio
     async def test_wikipedia_direct_list_tools(self):
-        from nemo_skills.mcp.servers.wikipedia_tool import WikipediaSearchTool
+        from nemo_skills.mcp.servers.web.wikipedia_tool import WikipediaSearchTool
 
         tool = WikipediaSearchTool()
         tool.configure()
@@ -1154,8 +1154,8 @@ class TestWikipediaTool:
 
     @pytest.mark.asyncio
     async def test_wikipedia_execute_dispatch_contracts(self, monkeypatch):
-        from nemo_skills.mcp.servers import wikipedia_tool
-        from nemo_skills.mcp.servers.wikipedia_tool import WikipediaSearchTool
+        from nemo_skills.mcp.servers.web import wikipedia_tool
+        from nemo_skills.mcp.servers.web.wikipedia_tool import WikipediaSearchTool
 
         async def fake_page(title):
             return f"page:{title}"
@@ -1187,14 +1187,14 @@ class TestWikipediaTool:
 
 class TestArxivTool:
     def test_arxiv_tool_config(self):
-        from nemo_skills.mcp.servers.arxiv_tool import ArxivSearchTool
+        from nemo_skills.mcp.servers.web.arxiv_tool import ArxivSearchTool
 
         tool = ArxivSearchTool()
         assert tool.default_config()["max_results"] == 3
 
     @pytest.mark.asyncio
     async def test_arxiv_search_rejects_non_positive_max_results(self):
-        from nemo_skills.mcp.servers.arxiv_tool import ArxivSearchTool
+        from nemo_skills.mcp.servers.web.arxiv_tool import ArxivSearchTool
 
         tool = ArxivSearchTool()
         tool.configure()
@@ -1203,7 +1203,7 @@ class TestArxivTool:
 
     @pytest.mark.asyncio
     async def test_arxiv_direct_list_tools(self):
-        from nemo_skills.mcp.servers.arxiv_tool import ArxivSearchTool
+        from nemo_skills.mcp.servers.web.arxiv_tool import ArxivSearchTool
 
         tool = ArxivSearchTool()
         tool.configure()


### PR DESCRIPTION
## Summary
- Move web retrieval MCP tools under `nemo_skills.mcp.servers.web`.
- Move physics-oriented MCP tools under `nemo_skills.mcp.servers.physics`.
- Move the periodictable MCP tool under `nemo_skills.mcp.servers.chemistry`.
- Update docs and tests to use the new module paths.

## Test plan
- `python -m py_compile nemo_skills/mcp/servers/web/arxiv_tool.py nemo_skills/mcp/servers/web/wikipedia_tool.py nemo_skills/mcp/servers/physics/coolprop_tool.py nemo_skills/mcp/servers/physics/particle_tool.py nemo_skills/mcp/servers/physics/radioactivedecay_tool.py nemo_skills/mcp/servers/chemistry/periodictable_tool.py`
- `python -m ruff format --check tests/test_mcp_clients.py nemo_skills/mcp/servers/web/arxiv_tool.py nemo_skills/mcp/servers/web/wikipedia_tool.py nemo_skills/mcp/servers/physics/coolprop_tool.py nemo_skills/mcp/servers/physics/particle_tool.py nemo_skills/mcp/servers/physics/radioactivedecay_tool.py nemo_skills/mcp/servers/chemistry/periodictable_tool.py`
- `python -m pytest tests/test_mcp_clients.py::TestArxivTool tests/test_mcp_clients.py::TestWikipediaTool tests/test_mcp_clients.py::TestCoolPropTool tests/test_mcp_clients.py::TestParticleTool tests/test_mcp_clients.py::TestRadioactivedecayTool tests/test_mcp_clients.py::TestPeriodictableTool -q --tb=short`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal tool module structure to improve package organization and maintainability. Updated documentation and test references to reflect new module paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->