### PR TITLE
fix bleu score calculation

### DIFF
--- a/nemo_skills/dataset/covost2/__init__.py
+++ b/nemo_skills/dataset/covost2/__init__.py
@@ -16,7 +16,3 @@ REQUIRES_DATA_DIR = True
 METRICS_TYPE = "audio"
 EVAL_ARGS = "++eval_type=audio ++eval_config.normalization_mode=multilingual"
 GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
-JUDGE_PIPELINE_ARGS = {
-    "source_key": "extra_fields.src_text",
-    "reference_key": "extra_fields.tgt_text",
-}

--- a/nemo_skills/dataset/covost2/prepare.py
+++ b/nemo_skills/dataset/covost2/prepare.py
@@ -173,9 +173,11 @@ def _build_record(
     subset_for_metrics: str,
     task_type: str,
     extra_fields: dict,
+    source: str | None = None,
+    reference: str | None = None,
 ) -> dict:
     audio_metadata = {"path": container_audio_path, "duration": duration}
-    return {
+    record = {
         "expected_answer": expected_answer,
         "audio_path": container_audio_path,
         "duration": duration,
@@ -187,6 +189,11 @@ def _build_record(
         "task_type": f"Multilingual-{task_type.upper()}",
         "extra_fields": extra_fields,
     }
+    if source is not None:
+        record["source"] = source
+    if reference is not None:
+        record["reference"] = reference
+    return record
 
 
 def prepare_covost2(
@@ -269,6 +276,8 @@ def prepare_covost2(
                             "src_lang": src_lang,
                             "tgt_lang": tgt_lang,
                         },
+                        source=item["sentence"],
+                        reference=item["translation"],
                     )
                     out.write(json.dumps(record, ensure_ascii=False) + "\n")
     print(f"CoVoST2 {task_type} dataset prepared: {output_jsonl}")

--- a/nemo_skills/dataset/fleurs/__init__.py
+++ b/nemo_skills/dataset/fleurs/__init__.py
@@ -16,7 +16,3 @@ REQUIRES_DATA_DIR = True
 METRICS_TYPE = "audio"
 EVAL_ARGS = "++eval_type=audio ++eval_config.normalization_mode=multilingual"
 GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"
-JUDGE_PIPELINE_ARGS = {
-    "source_key": "extra_fields.src_raw_text",
-    "reference_key": "extra_fields.tgt_raw_text",
-}

--- a/nemo_skills/dataset/fleurs/prepare.py
+++ b/nemo_skills/dataset/fleurs/prepare.py
@@ -151,9 +151,11 @@ def _build_record(
     subset_for_metrics: str,
     task_type: str,
     extra_fields: dict,
+    source: str | None = None,
+    reference: str | None = None,
 ) -> dict:
     audio_metadata = {"path": container_audio_path, "duration": duration}
-    return {
+    record = {
         "expected_answer": expected_answer,
         "audio_path": container_audio_path,
         "duration": duration,
@@ -165,6 +167,11 @@ def _build_record(
         "task_type": f"Multilingual-{task_type.upper()}",
         "extra_fields": extra_fields,
     }
+    if source is not None:
+        record["source"] = source
+    if reference is not None:
+        record["reference"] = reference
+    return record
 
 
 def prepare_fleurs(data_dir: Path, split: str, languages: list[str], no_audio: bool, task_type: str) -> None:
@@ -244,8 +251,12 @@ def prepare_fleurs(data_dir: Path, split: str, languages: list[str], no_audio: b
                             "tgt_lang_group": FLEURS_LANG_TO_GROUP[tgt_locale],
                         }
                     )
+                    source_text = source_row["raw_transcription"]
+                    reference_text = target_row["raw_transcription"]
                 else:
                     expected_answer = source_row[gt_key]
+                    source_text = None
+                    reference_text = None
 
                 record = _build_record(
                     expected_answer=expected_answer,
@@ -255,6 +266,8 @@ def prepare_fleurs(data_dir: Path, split: str, languages: list[str], no_audio: b
                     subset_for_metrics=subset_for_metrics,
                     task_type=task_type,
                     extra_fields=extra_fields,
+                    source=source_text,
+                    reference=reference_text,
                 )
                 out.write(json.dumps(record, ensure_ascii=False) + "\n")
     print(f"Fleurs {task_type} dataset prepared: {output_jsonl}")

--- a/nemo_skills/dataset/flores200/__init__.py
+++ b/nemo_skills/dataset/flores200/__init__.py
@@ -16,7 +16,3 @@
 METRICS_TYPE = "translation"
 GENERATION_ARGS = "++prompt_config=multilingual/segment-translation"
 EVAL_SPLIT = "devtest"
-JUDGE_PIPELINE_ARGS = {
-    "source_key": "text",
-    "reference_key": "translation",
-}

--- a/nemo_skills/dataset/flores200/prepare.py
+++ b/nemo_skills/dataset/flores200/prepare.py
@@ -25,10 +25,10 @@ def write_data_to_file(output_file, datasets, src_languages, tgt_languages):
         for src_lang in src_languages:
             for tgt_lang in tgt_languages:
                 if src_lang != tgt_lang:
-                    for src, tgt in zip(datasets[src_lang], datasets[tgt_lang], strict=True):
+                    for src, ref in zip(datasets[src_lang], datasets[tgt_lang], strict=True):
                         json_dict = {
-                            "text": src,
-                            "translation": tgt,
+                            "source": src,
+                            "reference": ref,
                             "source_language": src_lang,
                             "target_language": tgt_lang,
                             "source_lang_name": Language(src_lang).display_name(),

--- a/nemo_skills/dataset/wmt24pp/__init__.py
+++ b/nemo_skills/dataset/wmt24pp/__init__.py
@@ -15,7 +15,3 @@
 
 METRICS_TYPE = "translation"
 GENERATION_ARGS = "++prompt_config=multilingual/segment-translation"
-JUDGE_PIPELINE_ARGS = {
-    "source_key": "text",
-    "reference_key": "translation",
-}

--- a/nemo_skills/dataset/wmt24pp/prepare.py
+++ b/nemo_skills/dataset/wmt24pp/prepare.py
@@ -23,10 +23,10 @@ from langcodes import Language
 def write_data_to_file(output_file, datasets, tgt_languages):
     with open(output_file, "wt", encoding="utf-8") as fout:
         for tgt_lang in tgt_languages:
-            for src, tgt in zip(datasets[tgt_lang]["source"], datasets[tgt_lang]["target"], strict=True):
+            for src, ref in zip(datasets[tgt_lang]["source"], datasets[tgt_lang]["reference"], strict=True):
                 json_dict = {
-                    "text": src,
-                    "translation": tgt,
+                    "source": src,
+                    "reference": ref,
                     "source_language": "en",
                     "target_language": tgt_lang,
                     "source_lang_name": "English",

--- a/nemo_skills/dataset/wmt24pp/prepare.py
+++ b/nemo_skills/dataset/wmt24pp/prepare.py
@@ -23,7 +23,7 @@ from langcodes import Language
 def write_data_to_file(output_file, datasets, tgt_languages):
     with open(output_file, "wt", encoding="utf-8") as fout:
         for tgt_lang in tgt_languages:
-            for src, ref in zip(datasets[tgt_lang]["source"], datasets[tgt_lang]["reference"], strict=True):
+            for src, ref in zip(datasets[tgt_lang]["source"], datasets[tgt_lang]["target"], strict=True):
                 json_dict = {
                     "source": src,
                     "reference": ref,

--- a/nemo_skills/evaluation/evaluator/audio.py
+++ b/nemo_skills/evaluation/evaluator/audio.py
@@ -585,10 +585,9 @@ def evaluate_translation(
     tgt_lang: str | None = None,
 ) -> dict[str, Any]:
     """Evaluate translation: computes sentence-level BLEU score."""
+    tokenize = resolve_bleu_tokenize(tgt_lang)
     try:
         import sacrebleu
-
-        tokenize = resolve_bleu_tokenize(tgt_lang)
 
         text = reference.strip()
         pred_text = hypothesis.strip()
@@ -600,7 +599,7 @@ def evaluate_translation(
             "is_correct": bleu_score > 0.3,
             "text": text,
             "pred_text": pred_text,
-            "tgt_lang": tgt_lang,
+            "bleu_tokenize": tokenize,
         }
     except Exception as e:
         return {
@@ -609,7 +608,7 @@ def evaluate_translation(
             "error": str(e),
             "text": reference.strip(),
             "pred_text": hypothesis.strip(),
-            "tgt_lang": tgt_lang,
+            "bleu_tokenize": tokenize,
         }
 
 

--- a/nemo_skills/evaluation/evaluator/audio.py
+++ b/nemo_skills/evaluation/evaluator/audio.py
@@ -568,11 +568,7 @@ _BLEU_TOKENIZE_BY_LANG = {
 
 
 def resolve_bleu_tokenize(tgt_lang: str | None) -> str:
-    """Resolve sacrebleu tokenize from a target language code.
-
-    Shared by sentence-level and corpus-level BLEU so both stay consistent
-    for languages that need language-specific tokenization (ja/zh/ko).
-    """
+    """Resolve sacrebleu tokenize from a target language code."""
     if not isinstance(tgt_lang, str):
         return "13a"
     lang_code = tgt_lang.split("_")[0]

--- a/nemo_skills/evaluation/evaluator/audio.py
+++ b/nemo_skills/evaluation/evaluator/audio.py
@@ -558,6 +558,27 @@ def evaluate_asr(
     return result
 
 
+def resolve_bleu_tokenize(tgt_lang: str | None) -> str:
+    """Resolve sacrebleu tokenize from a target language code.
+
+    Shared by sentence-level and corpus-level BLEU so both stay consistent
+    for languages that need language-specific tokenization (ja/zh/ko).
+    """
+    tokenize = "13a"
+    if isinstance(tgt_lang, str):
+        lang_code = tgt_lang.split("_")[0]
+        if lang_code in ["cmn", "yue"]:
+            lang_code = "zh"
+
+        if lang_code == "ja":
+            tokenize = "ja-mecab"
+        elif lang_code == "zh":
+            tokenize = "zh"
+        elif lang_code == "ko":
+            tokenize = "ko-mecab"
+    return tokenize
+
+
 def evaluate_translation(
     reference: str,
     hypothesis: str,
@@ -567,18 +588,7 @@ def evaluate_translation(
     try:
         import sacrebleu
 
-        tokenize = "13a"
-        if isinstance(tgt_lang, str):
-            lang_code = tgt_lang.split("_")[0]
-            if lang_code in ["cmn", "yue"]:
-                lang_code = "zh"
-
-            if lang_code == "ja":
-                tokenize = "ja-mecab"
-            elif lang_code == "zh":
-                tokenize = "zh"
-            elif lang_code == "ko":
-                tokenize = "ko-mecab"
+        tokenize = resolve_bleu_tokenize(tgt_lang)
 
         text = reference.strip()
         pred_text = hypothesis.strip()
@@ -590,6 +600,7 @@ def evaluate_translation(
             "is_correct": bleu_score > 0.3,
             "text": text,
             "pred_text": pred_text,
+            "tgt_lang": tgt_lang,
         }
     except Exception as e:
         return {
@@ -598,6 +609,7 @@ def evaluate_translation(
             "error": str(e),
             "text": reference.strip(),
             "pred_text": hypothesis.strip(),
+            "tgt_lang": tgt_lang,
         }
 
 

--- a/nemo_skills/evaluation/evaluator/audio.py
+++ b/nemo_skills/evaluation/evaluator/audio.py
@@ -558,25 +558,25 @@ def evaluate_asr(
     return result
 
 
+_BLEU_TOKENIZE_BY_LANG = {
+    "ja": "ja-mecab",
+    "zh": "zh",
+    "cmn": "zh",
+    "yue": "zh",
+    "ko": "ko-mecab",
+}
+
+
 def resolve_bleu_tokenize(tgt_lang: str | None) -> str:
     """Resolve sacrebleu tokenize from a target language code.
 
     Shared by sentence-level and corpus-level BLEU so both stay consistent
     for languages that need language-specific tokenization (ja/zh/ko).
     """
-    tokenize = "13a"
-    if isinstance(tgt_lang, str):
-        lang_code = tgt_lang.split("_")[0]
-        if lang_code in ["cmn", "yue"]:
-            lang_code = "zh"
-
-        if lang_code == "ja":
-            tokenize = "ja-mecab"
-        elif lang_code == "zh":
-            tokenize = "zh"
-        elif lang_code == "ko":
-            tokenize = "ko-mecab"
-    return tokenize
+    if not isinstance(tgt_lang, str):
+        return "13a"
+    lang_code = tgt_lang.split("_")[0]
+    return _BLEU_TOKENIZE_BY_LANG.get(lang_code, "13a")
 
 
 def evaluate_translation(

--- a/nemo_skills/evaluation/evaluator/comet.py
+++ b/nemo_skills/evaluation/evaluator/comet.py
@@ -46,22 +46,11 @@ def load_comet_model(model_path: str):
     return model
 
 
-def _get_nested(sample: dict, key: str):
-    if "." in key:
-        value = sample
-        for part in key.split("."):
-            value = value[part]
-        return value
-    return sample[key]
-
-
 def process_file(
     input_file: Path,
     output_file: Path,
     comet_model,
     batch_size: int = 16,
-    source_key: str = "source",
-    reference_key: str = "reference",
 ):
     """Copy input file to output location and run xCOMET-XXL evaluation."""
     LOG.info(f"Processing {input_file} -> {output_file}")
@@ -87,9 +76,9 @@ def process_file(
         try:
             comet_list.append(
                 {
-                    "src": _get_nested(sample, source_key),
-                    "mt": _get_nested(sample, "generation"),
-                    "ref": _get_nested(sample, reference_key),
+                    "src": sample["source"],
+                    "mt": sample["generation"],
+                    "ref": sample["reference"],
                 }
             )
         except KeyError as e:
@@ -150,18 +139,6 @@ def main():
         default=1,
         help="Number of random seeds (for multiple seeds mode)",
     )
-    parser.add_argument(
-        "--source-key",
-        type=str,
-        default="source",
-        help="Sample field (supports dotted paths) holding the source text passed as COMET 'src'",
-    )
-    parser.add_argument(
-        "--reference-key",
-        type=str,
-        default="reference",
-        help="Sample field (supports dotted paths) holding the reference translation passed as COMET 'ref'",
-    )
     args = parser.parse_args()
 
     output_dir = Path(args.output_dir)
@@ -193,8 +170,6 @@ def main():
             output_file,
             comet_model,
             args.batch_size,
-            source_key=args.source_key,
-            reference_key=args.reference_key,
         )
 
     LOG.info("All files processed successfully")

--- a/nemo_skills/evaluation/metrics/audio_metrics.py
+++ b/nemo_skills/evaluation/metrics/audio_metrics.py
@@ -40,6 +40,42 @@ from nemo_skills.utils import get_logger_name
 LOG = logging.getLogger(get_logger_name(__file__))
 
 
+def compute_corpus_bleu(
+    hyps: list[str],
+    refs: list[str],
+    tgt_langs: list[str | None],
+) -> float:
+    """Compute corpus BLEU using the same tokenizer that sentence-level BLEU used.
+
+    Groups (hyp, ref) pairs by the tokenize resolved from each sample's tgt_lang
+    so ja/zh/ko aren't silently scored under the default 13a tokenizer. With a
+    single language, this is one corpus_bleu call; with mixed languages we
+    weighted-average per-language corpus_bleu scores by sample count.
+    """
+    from sacrebleu import corpus_bleu
+
+    from nemo_skills.evaluation.evaluator.audio import resolve_bleu_tokenize
+
+    groups: dict[str, tuple[list[str], list[str]]] = {}
+    for hyp, ref, tgt_lang in zip(hyps, refs, tgt_langs, strict=True):
+        tokenize = resolve_bleu_tokenize(tgt_lang)
+        bucket = groups.setdefault(tokenize, ([], []))
+        bucket[0].append(hyp)
+        bucket[1].append(ref)
+
+    if len(groups) == 1:
+        tokenize, (group_hyps, group_refs) = next(iter(groups.items()))
+        return corpus_bleu(hypotheses=group_hyps, references=[group_refs], tokenize=tokenize).score
+
+    weighted_sum = 0.0
+    total = 0
+    for tokenize, (group_hyps, group_refs) in groups.items():
+        score = corpus_bleu(hypotheses=group_hyps, references=[group_refs], tokenize=tokenize).score
+        weighted_sum += score * len(group_hyps)
+        total += len(group_hyps)
+    return weighted_sum / total
+
+
 class AudioMetrics(BaseMetrics):
     """Metrics class for audio evaluation tasks.
 
@@ -73,6 +109,7 @@ class AudioMetrics(BaseMetrics):
         self.per_scores = []
         self.bleu_hyps: list[str] = []
         self.bleu_refs: list[str] = []
+        self.bleu_tgt_langs: list[str | None] = []
         self.comet_scores = []
 
         # Extended metrics
@@ -218,6 +255,7 @@ class AudioMetrics(BaseMetrics):
             if "bleu" in pred and pred["bleu"] is not None:
                 self.bleu_hyps.append(pred["pred_text"])
                 self.bleu_refs.append(pred["text"])
+                self.bleu_tgt_langs.append(pred["tgt_lang"])
             if "comet" in pred and pred["comet"] is not None:
                 self.comet_scores.append(pred["comet"])
 
@@ -310,9 +348,9 @@ class AudioMetrics(BaseMetrics):
             if self.per_scores:
                 agg_metrics["per"] = round(100.0 * sum(self.per_scores) / len(self.per_scores), 2)
             if self.bleu_refs:
-                from sacrebleu import corpus_bleu
-
-                agg_metrics["bleu"] = round(corpus_bleu(self.bleu_hyps, [self.bleu_refs]).score, 2)
+                agg_metrics["bleu"] = round(
+                    compute_corpus_bleu(self.bleu_hyps, self.bleu_refs, self.bleu_tgt_langs), 2
+                )
             if self.comet_scores:
                 agg_metrics["comet"] = round(100.0 * sum(self.comet_scores) / len(self.comet_scores), 2)
 

--- a/nemo_skills/evaluation/metrics/audio_metrics.py
+++ b/nemo_skills/evaluation/metrics/audio_metrics.py
@@ -216,8 +216,8 @@ class AudioMetrics(BaseMetrics):
             if "per" in pred and pred["per"] is not None:
                 self.per_scores.append(pred["per"])
             if "bleu" in pred and pred["bleu"] is not None:
-                self.bleu_hyps.append(pred.get("pred_text", "") or "")
-                self.bleu_refs.append(pred.get("text", "") or "")
+                self.bleu_hyps.append(pred["pred_text"])
+                self.bleu_refs.append(pred["text"])
             if "comet" in pred and pred["comet"] is not None:
                 self.comet_scores.append(pred["comet"])
 

--- a/nemo_skills/evaluation/metrics/audio_metrics.py
+++ b/nemo_skills/evaluation/metrics/audio_metrics.py
@@ -74,7 +74,13 @@ class AudioMetrics(BaseMetrics):
         self.wer_c_scores = []
         self.wer_pc_scores = []
         self.per_scores = []
+<<<<<<< Updated upstream
         self.bleu_scores = []
+=======
+        self.bleu_hyps: list[str] = []
+        self.bleu_refs: list[str] = []
+        self.comet_scores = []
+>>>>>>> Stashed changes
 
         # Extended metrics
         self.cer_scores = []
@@ -221,7 +227,14 @@ class AudioMetrics(BaseMetrics):
             if "per" in pred and pred["per"] is not None:
                 self.per_scores.append(pred["per"])
             if "bleu" in pred and pred["bleu"] is not None:
+<<<<<<< Updated upstream
                 self.bleu_scores.append(pred["bleu"])
+=======
+                self.bleu_hyps.append(pred.get("pred_text", "") or "")
+                self.bleu_refs.append(pred.get("text", "") or "")
+            if "comet" in pred and pred["comet"] is not None:
+                self.comet_scores.append(pred["comet"])
+>>>>>>> Stashed changes
 
             # Collect extended metrics
             if "cer" in pred and pred["cer"] is not None:
@@ -314,8 +327,17 @@ class AudioMetrics(BaseMetrics):
                 agg_metrics["wer_pc"] = round(100.0 * sum(self.wer_pc_scores) / len(self.wer_pc_scores), 2)
             if self.per_scores:
                 agg_metrics["per"] = round(100.0 * sum(self.per_scores) / len(self.per_scores), 2)
+<<<<<<< Updated upstream
             if self.bleu_scores:
                 agg_metrics["bleu"] = round(100.0 * sum(self.bleu_scores) / len(self.bleu_scores), 2)
+=======
+            if self.bleu_refs:
+                from sacrebleu import corpus_bleu
+
+                agg_metrics["bleu"] = round(corpus_bleu(self.bleu_hyps, [self.bleu_refs]).score, 2)
+            if self.comet_scores:
+                agg_metrics["comet"] = round(100.0 * sum(self.comet_scores) / len(self.comet_scores), 2)
+>>>>>>> Stashed changes
 
             # Add extended metrics if available
             if self.cer_scores:
@@ -390,7 +412,7 @@ class AudioMetrics(BaseMetrics):
             base_metrics["wer_pc"] = as_percentage
         if self.per_scores:
             base_metrics["per"] = as_percentage
-        if self.bleu_scores:
+        if self.bleu_refs:
             base_metrics["bleu"] = as_percentage
 
         # Add extended metrics if they were computed

--- a/nemo_skills/evaluation/metrics/audio_metrics.py
+++ b/nemo_skills/evaluation/metrics/audio_metrics.py
@@ -321,7 +321,7 @@ class AudioMetrics(BaseMetrics):
                 agg_metrics["per"] = round(100.0 * sum(self.per_scores) / len(self.per_scores), 2)
             if self.bleu_refs:
                 from sacrebleu import corpus_bleu
-                
+
                 agg_metrics["bleu"] = round(corpus_bleu(self.bleu_hyps, [self.bleu_refs]).score, 2)
             if self.comet_scores:
                 agg_metrics["comet"] = round(100.0 * sum(self.comet_scores) / len(self.comet_scores), 2)

--- a/nemo_skills/evaluation/metrics/audio_metrics.py
+++ b/nemo_skills/evaluation/metrics/audio_metrics.py
@@ -321,6 +321,7 @@ class AudioMetrics(BaseMetrics):
                 agg_metrics["per"] = round(100.0 * sum(self.per_scores) / len(self.per_scores), 2)
             if self.bleu_refs:
                 from sacrebleu import corpus_bleu
+                
                 agg_metrics["bleu"] = round(corpus_bleu(self.bleu_hyps, [self.bleu_refs]).score, 2)
             if self.comet_scores:
                 agg_metrics["comet"] = round(100.0 * sum(self.comet_scores) / len(self.comet_scores), 2)

--- a/nemo_skills/evaluation/metrics/audio_metrics.py
+++ b/nemo_skills/evaluation/metrics/audio_metrics.py
@@ -74,13 +74,9 @@ class AudioMetrics(BaseMetrics):
         self.wer_c_scores = []
         self.wer_pc_scores = []
         self.per_scores = []
-<<<<<<< Updated upstream
-        self.bleu_scores = []
-=======
         self.bleu_hyps: list[str] = []
         self.bleu_refs: list[str] = []
         self.comet_scores = []
->>>>>>> Stashed changes
 
         # Extended metrics
         self.cer_scores = []
@@ -227,14 +223,10 @@ class AudioMetrics(BaseMetrics):
             if "per" in pred and pred["per"] is not None:
                 self.per_scores.append(pred["per"])
             if "bleu" in pred and pred["bleu"] is not None:
-<<<<<<< Updated upstream
-                self.bleu_scores.append(pred["bleu"])
-=======
                 self.bleu_hyps.append(pred.get("pred_text", "") or "")
                 self.bleu_refs.append(pred.get("text", "") or "")
             if "comet" in pred and pred["comet"] is not None:
                 self.comet_scores.append(pred["comet"])
->>>>>>> Stashed changes
 
             # Collect extended metrics
             if "cer" in pred and pred["cer"] is not None:
@@ -327,17 +319,11 @@ class AudioMetrics(BaseMetrics):
                 agg_metrics["wer_pc"] = round(100.0 * sum(self.wer_pc_scores) / len(self.wer_pc_scores), 2)
             if self.per_scores:
                 agg_metrics["per"] = round(100.0 * sum(self.per_scores) / len(self.per_scores), 2)
-<<<<<<< Updated upstream
-            if self.bleu_scores:
-                agg_metrics["bleu"] = round(100.0 * sum(self.bleu_scores) / len(self.bleu_scores), 2)
-=======
             if self.bleu_refs:
                 from sacrebleu import corpus_bleu
-
                 agg_metrics["bleu"] = round(corpus_bleu(self.bleu_hyps, [self.bleu_refs]).score, 2)
             if self.comet_scores:
                 agg_metrics["comet"] = round(100.0 * sum(self.comet_scores) / len(self.comet_scores), 2)
->>>>>>> Stashed changes
 
             # Add extended metrics if available
             if self.cer_scores:

--- a/nemo_skills/evaluation/metrics/audio_metrics.py
+++ b/nemo_skills/evaluation/metrics/audio_metrics.py
@@ -43,22 +43,19 @@ LOG = logging.getLogger(get_logger_name(__file__))
 def compute_corpus_bleu(
     hyps: list[str],
     refs: list[str],
-    tgt_langs: list[str | None],
+    tokenizes: list[str],
 ) -> float:
-    """Compute corpus BLEU using the same tokenizer that sentence-level BLEU used.
+    """Compute corpus BLEU, bucketing by sacrebleu tokenizer.
 
-    Groups (hyp, ref) pairs by the tokenize resolved from each sample's tgt_lang
-    so ja/zh/ko aren't silently scored under the default 13a tokenizer. With a
-    single language, this is one corpus_bleu call; with mixed languages we
-    weighted-average per-language corpus_bleu scores by sample count.
+    Each (hyp, ref) is grouped by the tokenizer resolved at sentence-BLEU
+    time, so ja/zh/ko aren't silently scored under the default 13a tokenizer.
+    Single-tokenizer runs are one corpus_bleu call; mixed runs weighted-average
+    per-tokenizer corpus_bleu by sample count.
     """
     from sacrebleu import corpus_bleu
 
-    from nemo_skills.evaluation.evaluator.audio import resolve_bleu_tokenize
-
     groups: dict[str, tuple[list[str], list[str]]] = {}
-    for hyp, ref, tgt_lang in zip(hyps, refs, tgt_langs, strict=True):
-        tokenize = resolve_bleu_tokenize(tgt_lang)
+    for hyp, ref, tokenize in zip(hyps, refs, tokenizes, strict=True):
         bucket = groups.setdefault(tokenize, ([], []))
         bucket[0].append(hyp)
         bucket[1].append(ref)
@@ -109,7 +106,7 @@ class AudioMetrics(BaseMetrics):
         self.per_scores = []
         self.bleu_hyps: list[str] = []
         self.bleu_refs: list[str] = []
-        self.bleu_tgt_langs: list[str | None] = []
+        self.bleu_tokenizes: list[str] = []
         self.comet_scores = []
 
         # Extended metrics
@@ -255,7 +252,7 @@ class AudioMetrics(BaseMetrics):
             if "bleu" in pred and pred["bleu"] is not None:
                 self.bleu_hyps.append(pred["pred_text"])
                 self.bleu_refs.append(pred["text"])
-                self.bleu_tgt_langs.append(pred["tgt_lang"])
+                self.bleu_tokenizes.append(pred["bleu_tokenize"])
             if "comet" in pred and pred["comet"] is not None:
                 self.comet_scores.append(pred["comet"])
 
@@ -349,7 +346,7 @@ class AudioMetrics(BaseMetrics):
                 agg_metrics["per"] = round(100.0 * sum(self.per_scores) / len(self.per_scores), 2)
             if self.bleu_refs:
                 agg_metrics["bleu"] = round(
-                    compute_corpus_bleu(self.bleu_hyps, self.bleu_refs, self.bleu_tgt_langs), 2
+                    compute_corpus_bleu(self.bleu_hyps, self.bleu_refs, self.bleu_tokenizes), 2
                 )
             if self.comet_scores:
                 agg_metrics["comet"] = round(100.0 * sum(self.comet_scores) / len(self.comet_scores), 2)

--- a/nemo_skills/evaluation/metrics/translation_metrics.py
+++ b/nemo_skills/evaluation/metrics/translation_metrics.py
@@ -117,7 +117,7 @@ class TranslationMetrics(BaseMetrics):
                 generation = ""
 
             generations.append(generation)
-            ground_truths.append(pred["translation"])
+            ground_truths.append(pred["reference"])
             if "comet" in pred:
                 comets.append(pred["comet"] * 100)
 

--- a/nemo_skills/pipeline/judges/comet_judge.py
+++ b/nemo_skills/pipeline/judges/comet_judge.py
@@ -79,8 +79,6 @@ def create_judge_tasks(
     output_dir_path = judge_pipeline_args.get("output_dir")
     input_file = judge_pipeline_args.get("input_file")
     comet_model_path = judge_pipeline_args.get("judge_model")
-    source_key = judge_pipeline_args.get("source_key", "source")
-    reference_key = judge_pipeline_args.get("reference_key", "reference")
 
     # Determine seeds to check
     if input_file is None:
@@ -104,7 +102,6 @@ def create_judge_tasks(
     # Build command to run xCOMET-XXL judge script
     script_args = [
         f"--output-dir {output_dir_path} --comet-model-path {comet_model_path}",
-        f"--source-key {source_key} --reference-key {reference_key}",
     ]
 
     if input_file is None:

--- a/nemo_skills/prompt/config/multilingual/segment-translation.yaml
+++ b/nemo_skills/prompt/config/multilingual/segment-translation.yaml
@@ -1,3 +1,3 @@
 # Default prompt for text translation.
 
-user: "Translate the following segment into {target_lang_name}, without additional explanation.\n\n{text}"
+user: "Translate the following segment into {target_lang_name}, without additional explanation.\n\n{source}"


### PR DESCRIPTION
Addressing the [issue](https://github.com/NVIDIA-NeMo/Skills/issues/1408) reported by @shuoyangd 

> Sentence-level BLEU was aggregated [here](https://github.com/NVIDIA-NeMo/Skills/blame/6e20e4e4b924288c4d7ec9bd21238b1df37d0bfd/nemo_skills/evaluation/metrics/audio_metrics.py#L311) and used as corpus-level BLEU. This should NEVER be done, because sentence-level BLEU is calculated with aggressive smoothing which is not necessary at corpus-level. Numbers reproduced in this way will be significantly different compared to regular corpus-level BLEU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Audio evaluation now computes corpus BLEU at evaluation time and applies language-aware tokenization.

* **Changes**
  * Standardized dataset export fields to "source" and "reference".
  * Metric aggregation now uses the "reference" field as ground-truth for translation scoring.

* **Removals**
  * Removed a legacy evaluation pipeline configuration constant from several dataset modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->