### PR TITLE
Patch PackageKit CVE and pin uv to clear rustls-webpki advisory

### DIFF
--- a/dockerfiles/Dockerfile.nemo-skills
+++ b/dockerfiles/Dockerfile.nemo-skills
@@ -14,7 +14,7 @@ RUN apt-get update && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip setuptools uv
+RUN pip install --upgrade pip setuptools "uv>=0.11.10"
 
 # Update package lists and install apptainer for arm64
 # https://apptainer.org/docs/admin/1.1/installation.html
@@ -24,6 +24,16 @@ RUN apt update && \
     apt update && apt -y install apptainer && \
     add-apt-repository -y ppa:apptainer/ppa && \
     apt update && apt install -y apptainer-suid && \
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+
+# Apply security patches for PackageKit, pulled in transitively by software-properties-common.
+# Ubuntu 22.04 has published 1.2.5-2ubuntu3.1 with the fix for the local privilege escalation CVE.
+RUN apt-get update && \
+    apt-get upgrade -y \
+        packagekit \
+        packagekit-tools \
+        libpackagekit-glib2-18 \
+        gir1.2-packagekitglib-1.0 && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 # for ifeval benchmark

--- a/dockerfiles/Dockerfile.nemo-skills
+++ b/dockerfiles/Dockerfile.nemo-skills
@@ -29,7 +29,7 @@ RUN apt update && \
 # Apply security patches for PackageKit, pulled in transitively by software-properties-common.
 # Ubuntu 22.04 has published 1.2.5-2ubuntu3.1 with the fix for the local privilege escalation CVE.
 RUN apt-get update && \
-    apt-get upgrade -y \
+    apt-get install --only-upgrade -y \
         packagekit \
         packagekit-tools \
         libpackagekit-glib2-18 \


### PR DESCRIPTION
## Summary

Patches two High-severity CVEs flagged at the OS/binary layer of the `nemo-skills` container image. Dockerfile-only change; no Python deps touched.

- **PackageKit local privilege escalation** — `packagekit*` packages are pulled in transitively by `software-properties-common` (apptainer install step). Adds an `apt-get upgrade` step to pick up Ubuntu's published `1.2.5-2ubuntu3.1`.
- **GHSA-82j2-j2ch-gfr8 (rustls-webpki DoS)** — flagged at `/usr/local/bin/uv` and `/usr/local/bin/uvx`. The vulnerable `rustls-webpki 0.103.10` is statically bundled inside the `uv` binary. Pin `uv>=0.11.10`, whose `Cargo.lock` ships the patched `rustls-webpki 0.103.13`.

## Test plan

- [ ] CPU tests workflow builds the image and runs the test suite
- [ ] (Optional) GPU tests workflow via `run GPU tests` label
- [ ] Re-scan rebuilt image — CVEs related to packagekit and rustls should drop off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Security**
  * Applied security updates to package management components (PackageKit-related packages) to improve system stability and reduce vulnerabilities.

* **Chores**
  * Pinned a Python tooling dependency to a minimum version to ensure consistent builds.
  * Added package upgrade and cache cleanup steps to make image builds more reliable and compact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->