### PR TITLE
Pin litellm to 1.83.14 and switch installs to uv

### DIFF
--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -42,10 +42,12 @@ jobs:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: |
         cd ${{ github.run_id }}
-        python -m pip install --upgrade pip
-        pip uninstall -y nemo-skills nemo_run
-        pip install -e .
-        pip install -r requirements/common-tests.txt
+        python -m pip install --upgrade pip uv
+        uv pip uninstall --system nemo-skills nemo_run || true
+        # Use `uv pip` so [tool.uv].override-dependencies in pyproject.toml is honored
+        # (relaxes leptonai's httpx==0.27.2 pin so litellm 1.83.x can be installed).
+        uv pip install --system -e .
+        uv pip install --system -r requirements/common-tests.txt
         ns prepare_data gsm8k human-eval mbpp algebra222 mmlu ifeval math-500 amc23 aime24
     - name: Build Docker image
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,8 +31,10 @@ jobs:
         cache: pip
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -e .[dev]
+        python -m pip install --upgrade pip uv
+        # Use `uv pip` so [tool.uv].override-dependencies in pyproject.toml is honored
+        # (relaxes leptonai's httpx==0.27.2 pin so litellm 1.83.x can be installed).
+        uv pip install --system -e .[dev]
     - name: List Checked Files
       run: git diff --name-only ${GITHUB_BASE_REF} HEAD
     - name: Run Pre-Commit Checks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,8 +43,10 @@ jobs:
         cache: pip
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -e .[dev] --extra-index-url https://download.pytorch.org/whl/cpu
+        python -m pip install --upgrade pip uv
+        # Use `uv pip` so [tool.uv].override-dependencies in pyproject.toml is honored
+        # (relaxes leptonai's httpx==0.27.2 pin so litellm 1.83.x can be installed).
+        uv pip install --system -e .[dev] --extra-index-url https://download.pytorch.org/whl/cpu
         # Clear pip cache
         pip cache purge || true
     - name: Build Images

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -22,7 +22,7 @@ iso639-lang
 langcodes
 langdetect
 language-data
-litellm[caching]==1.83.0
+litellm[caching]==1.83.14
 math-verify[antlr4_9_3]
 mcp
 numpy

--- a/dockerfiles/Dockerfile.nemo-skills
+++ b/dockerfiles/Dockerfile.nemo-skills
@@ -62,6 +62,10 @@ COPY core/requirements.txt /opt/NeMo-Skills/core/requirements.txt
 # installing sdp in container only
 RUN pip install git+https://github.com/NVIDIA/NeMo-speech-data-processor@29b9b1ec0ceaf3ffa441c1d01297371b3f8e11d2
 ARG CACHEBUST=4
-RUN pip install --no-cache-dir -r /opt/NeMo-Skills/core/requirements.txt -r /opt/NeMo-Skills/requirements/pipeline.txt
+# Install via `uv pip` from the project directory so [tool.uv].override-dependencies
+# in pyproject.toml (which relaxes leptonai's httpx==0.27.2 pin so litellm 1.83.x
+# can be installed) is picked up. Plain pip ignores [tool.uv] and the resolver fails.
+RUN cd /opt/NeMo-Skills && uv pip install --system --no-cache-dir \
+    -r core/requirements.txt -r requirements/pipeline.txt
 # Fix http mismatch between lepton and dggs by manually downloading dggs here
 RUN pip install ddgs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,22 @@ pipeline = { file = ["requirements/pipeline.txt"] }
 # Dev: development and testing tools
 dev = { file = ["requirements/common-tests.txt", "requirements/common-dev.txt"] }
 
+[tool.uv]
+# Force resolver-wide overrides to break dependency conflicts that come from
+# transitive pins we can't easily change upstream. These are honored by `uv`
+# (uv pip / uv sync) but ignored by plain pip — Dockerfiles using plain pip
+# rely on pip's looser resolver instead.
+override-dependencies = [
+    # leptonai (pulled in by nemo_run) hard-pins httpx[http2]==0.27.2, which
+    # conflicts with litellm==1.83.14's httpx==0.28.1. Relax the pin so the
+    # resolver can pick a single version that satisfies litellm.
+    "httpx[http2]>=0.28.1",
+    # urllib3<2 has open CVEs (e.g. CVE-2024-37891 / CVE-2025-50182). torchx
+    # 0.7.0 (a transitive dep of nemo_run) pins urllib3<1.27, but in practice
+    # urllib3>=2 works at runtime, so override the constraint.
+    "urllib3>=2.6.3",
+]
+
 [tool.pytest.ini_options]
 markers = [
     "gpu: tests that require a GPU to run",


### PR DESCRIPTION
# Pin litellm to 1.83.14 and switch installs to `uv` to satisfy the resolver

## Summary

Bumps `litellm[caching]` from `1.83.0` to `1.83.14` (CVE remediation). That
version pins `httpx==0.28.1`, which conflicts with the `httpx[http2]==0.27.2`
hard pin transitively required by `nemo_run` → `leptonai`. The pip resolver
gives up; uv has the same problem unless we tell it to override the pin.

Fix:

- Add `[tool.uv].override-dependencies` in `pyproject.toml` to relax
  `httpx[http2]` to `>=0.28.1` and `urllib3` to `>=2.6.3` (also a CVE; pinned
  via `torchx 0.7.0`'s `<1.27` constraint).
- Switch the install commands in `dockerfiles/Dockerfile.nemo-skills` and the
  three CI workflows (`lint.yml`, `tests.yml`, `gpu_tests.yml`) from `pip` to
  `uv pip install --system`. `[tool.uv]` is uv-only — plain pip ignores it and
  the resolver fails.

`uv` is already installed in `Dockerfile.nemo-skills`; the CI workflows now
add it alongside the existing `pip install --upgrade pip` step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows (GPU testing, linting, and unit tests) to use uv for faster and more reliable dependency installation.
  * Updated Docker build configuration to use uv pip for consistent dependency management.
  * Added dependency override configuration to resolve compatibility issues across dependencies.
  * Bumped litellm dependency to version 1.83.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->