### PR TITLE
COMET bugfix

### DIFF
--- a/nemo_skills/evaluation/evaluator/comet.py
+++ b/nemo_skills/evaluation/evaluator/comet.py
@@ -89,7 +89,7 @@ def process_file(
                 {
                     "src": _get_nested(sample, source_key),
                     "mt": _get_nested(sample, "generation"),
-                    "gt": _get_nested(sample, reference_key),
+                    "ref": _get_nested(sample, reference_key),
                 }
             )
         except KeyError as e:
@@ -160,7 +160,7 @@ def main():
         "--reference-key",
         type=str,
         default="reference",
-        help="Sample field (supports dotted paths) holding the reference translation passed as COMET 'gt'",
+        help="Sample field (supports dotted paths) holding the reference translation passed as COMET 'ref'",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Fixed a bug where COMET reference translation was passed incorrectly (via `gt` key instead of correct `ref`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected COMET evaluator reference field mapping to use the proper identifier
  
* **Documentation**
  * Updated CLI help text for the reference key argument to align with the reference field naming used in evaluation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->