### PR TITLE
Port Tavily MCP core tools

### DIFF
--- a/nemo_skills/mcp/servers/tavily_search_tool.py
+++ b/nemo_skills/mcp/servers/tavily_search_tool.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import argparse
+import asyncio
 import json
 import logging
 import os
+import re
 from dataclasses import dataclass
 from typing import Annotated, Any
+from urllib.parse import urlparse
 
 import httpx
 from mcp.server.fastmcp import FastMCP
@@ -38,10 +41,15 @@ class ExecutionResult:
 mcp = FastMCP(name="tavily")
 
 # Populated from CLI args in main()
-TAVILY_API_KEY: str | None = None
+TAVILY_API_KEYS: list[str] = []
+TAVILY_REQUEST_COUNT: int = 0
 
-EXCLUDE_DOMAINS: list[str] | None = None
 MAX_NUM_RESULTS: int = 20
+DEFAULT_NUM_RESULTS: int = 10
+DEFAULT_SCROLL_WORDS: int = 2000
+MAX_QUERY_CHARS: int = 400
+MAX_RESULT_CHARS: int = 2000
+PAGE_CACHE: dict[str, str] = {}
 
 STATUS_CODE_ERRORS = {
     429: "Search rate limit exceeded",
@@ -53,6 +61,7 @@ STATUS_CODE_ERRORS = {
 
 # These errors should stop the process - no point continuing with bad credentials
 FATAL_STATUS_CODES = {401, 403}
+RETRY_STATUS_CODES = {408, 409, 429, 500, 502, 503, 504}
 
 
 ## See docs https://docs.tavily.com/documentation/api-reference/endpoint/search
@@ -61,68 +70,241 @@ FATAL_STATUS_CODES = {401, 403}
 async def answer(
     query: Annotated[str, Field(description="Search query.")],
     exclude_domains: Annotated[list[str], Field(description="Domains to exclude from the search.")] = [],
-    num_results: Annotated[int, Field(description="Number of results to return.")] = 10,
+    num_results: Annotated[int, Field(description="Number of results to return.")] = DEFAULT_NUM_RESULTS,
     answer_type: Annotated[
         str,
         Field(
-            description='Type of results to return. Choose "answer" for a concise answer or "results" for a list of results.'
+            description=(
+                'Type of results to return. Choose "formatted" for Gym-style text, '
+                '"answer" for a concise answer, or "results" for raw search results.'
+            )
         ),
-    ] = "answer",
+    ] = "formatted",
 ):
     """Search the web for a query"""
 
-    api_url = "https://api.tavily.com/search"
-
     # Validate inputs
-    if answer_type not in ["answer", "results"]:
-        return {"error": "Invalid answer type. Choose 'answer' or 'results'."}
-    if num_results > MAX_NUM_RESULTS:
-        return {"error": f"Number of results must be less than or equal to {MAX_NUM_RESULTS}."}
+    if query is None:
+        return "Query is none"
+    if len(query) > MAX_QUERY_CHARS:
+        return "Query is too long"
+    if answer_type not in ["answer", "results", "formatted"]:
+        return {"error": "Invalid answer type. Choose 'answer', 'results', or 'formatted'."}
+    if num_results < 1 or num_results > MAX_NUM_RESULTS:
+        return {"error": f"Number of results must be between 1 and {MAX_NUM_RESULTS}."}
 
-    headers = {
-        "Authorization": f"Bearer {TAVILY_API_KEY}",
-        "Content-Type": "application/json",
-    }
-
-    payload = {
-        "query": query,
-        # "auto_parameters": False,
-        "search_depth": "basic",
-        "include_answer": "basic",  ## or advanced.
-        "num_results": num_results,
-        # this should be statically set to the domains we want to exclude
-        "exclude_domains": exclude_domains,
-    }
-
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.post(api_url, headers=headers, json=payload)
-    except httpx.TimeoutException:
-        return {"error": "Search request timed out"}
-    except httpx.RequestError:
-        return {"error": "Search request failed due to network error"}
-
-    # Handle non-200 responses
-    if response.status_code in FATAL_STATUS_CODES:
-        return {"error": "Search authentication failed", "fatal": True}
-    if response.status_code != 200:
-        error_msg = STATUS_CODE_ERRORS.get(
-            response.status_code, f"Search request failed with status {response.status_code}"
-        )
-        return {"error": error_msg}
-
-    # Parse response
-    try:
-        data = response.json()
-    except json.JSONDecodeError:
-        return {"error": "Search returned invalid response"}
-
-    # Extract result
+    data = await _tavily_post(
+        "/search",
+        {
+            "query": query,
+            "search_depth": "advanced",
+            "max_results": num_results,
+            "exclude_domains": exclude_domains,
+        },
+    )
+    if isinstance(data, dict) and data.get("error"):
+        return data
+    if answer_type == "formatted":
+        return _postprocess_search_results(data)
     result = data.get(answer_type)
     if result is None:
         return {"error": "Search response is missing required field"}
-
     return result
+
+
+@mcp.tool(name="find-in-page")
+async def find_in_page(
+    url: Annotated[str, Field(description="URL to fetch.")],
+    query: Annotated[str, Field(description="Term or phrase to find on the page.")],
+    exclude_domains: Annotated[list[str], Field(description="Domains to exclude from page retrieval.")] = [],
+):
+    """Fetch a page and return cleaned, line-numbered content relevant to a query."""
+
+    if url is None:
+        return "URL is none"
+    if query is None:
+        return "Query is none"
+    if _is_url_excluded(url, exclude_domains):
+        return "URL is in excluded domains"
+
+    data = await _tavily_post("/extract", {"urls": url, "query": query})
+    if isinstance(data, dict) and data.get("error"):
+        return data
+
+    raw_content = _extract_first_raw_content(data)
+    if not raw_content:
+        return "No content found."
+
+    domain = _extract_domain(url)
+    cleaned = _clean_text(raw_content)
+    truncated, was_truncated = _truncate_text(cleaned)
+    numbered = _add_line_numbers(truncated)
+
+    header = f'Content from: {domain}\nURL: {url}\nQuery: "{query}"\n========================================\n'
+    footer = "\n[...truncated, use scroll-page for full content]" if was_truncated else ""
+    return header + numbered + footer
+
+
+@mcp.tool(name="scroll-page")
+async def scroll_page(
+    url: Annotated[str, Field(description="URL to fetch.")],
+    start_index: Annotated[int, Field(description="Zero-based word offset to start reading from.")] = 0,
+    n: Annotated[int, Field(description="Number of words to return.")] = DEFAULT_SCROLL_WORDS,
+    exclude_domains: Annotated[list[str], Field(description="Domains to exclude from page retrieval.")] = [],
+):
+    """Fetch a page and return a word-window of cleaned, line-numbered content."""
+
+    if url is None:
+        return {"results_string": "URL is none", "total_words": 0}
+    if _is_url_excluded(url, exclude_domains):
+        return {"results_string": "URL is in excluded domains", "total_words": 0}
+
+    start_index = max(0, int(start_index or 0))
+    n = max(1, int(n or DEFAULT_SCROLL_WORDS))
+
+    if url in PAGE_CACHE:
+        page_content = PAGE_CACHE[url]
+    else:
+        data = await _tavily_post("/extract", {"urls": url})
+        if isinstance(data, dict) and data.get("error"):
+            return data
+        page_content = _extract_first_raw_content(data)
+        PAGE_CACHE[url] = page_content
+
+    words = page_content.split()
+    total_words = len(words)
+    end_index = min(start_index + n, total_words)
+    chunk_text = " ".join(words[start_index:end_index])
+
+    domain = _extract_domain(url)
+    cleaned = _clean_text(chunk_text)
+    numbered = _add_line_numbers(cleaned)
+    header = (
+        f"Page content from: {domain}\n"
+        f"URL: {url}\n"
+        f"Showing words [{start_index}-{end_index}] of {total_words}\n"
+        f"========================================\n"
+    )
+    return {"results_string": header + numbered, "total_words": total_words}
+
+
+async def _tavily_post(endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
+    api_key = _select_tavily_api_key()
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    url = f"https://api.tavily.com{endpoint}"
+
+    max_num_tries = 3
+    tries = 0
+    last_response: httpx.Response | None = None
+    while tries < max_num_tries:
+        tries += 1
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(url, headers=headers, json=payload)
+        except httpx.TimeoutException:
+            return {"error": "Search request timed out"}
+        except httpx.RequestError:
+            return {"error": "Search request failed due to network error"}
+
+        last_response = response
+        if response.status_code in FATAL_STATUS_CODES:
+            return {"error": "Search authentication failed", "fatal": True}
+        if response.status_code in RETRY_STATUS_CODES:
+            if response.status_code == 429:
+                max_num_tries += 1
+            await asyncio.sleep(0.5)
+            continue
+        if response.status_code != 200:
+            error_msg = STATUS_CODE_ERRORS.get(
+                response.status_code, f"Search request failed with status {response.status_code}"
+            )
+            return {"error": error_msg}
+
+        try:
+            return response.json()
+        except json.JSONDecodeError:
+            return {"error": "Search returned invalid response"}
+
+    if last_response is not None:
+        error_msg = STATUS_CODE_ERRORS.get(
+            last_response.status_code, f"Search request failed with status {last_response.status_code}"
+        )
+        return {"error": error_msg}
+    return {"error": "Search request failed"}
+
+
+def _select_tavily_api_key() -> str:
+    global TAVILY_REQUEST_COUNT
+    if not TAVILY_API_KEYS:
+        raise ValueError("Missing Tavily API key.")
+    api_key = TAVILY_API_KEYS[TAVILY_REQUEST_COUNT % len(TAVILY_API_KEYS)]
+    TAVILY_REQUEST_COUNT += 1
+    return api_key
+
+
+def _extract_first_raw_content(data: dict[str, Any]) -> str:
+    results = data.get("results") or []
+    if not results:
+        return ""
+    return results[0].get("raw_content") or ""
+
+
+def _postprocess_search_results(results: dict[str, Any]) -> str:
+    answer_text = results.get("answer")
+    if answer_text is not None:
+        return f"Search Answer\n==============\n{answer_text}\n"
+
+    formatted_results = ["Search Results\n==============\n"]
+    for i, result in enumerate(results.get("results") or [], 1):
+        url = result.get("url", "")
+        domain = _extract_domain(url)
+        snippet = _clean_text(result.get("content", ""))
+        snippet, _ = _truncate_text(snippet)
+        formatted_results.append(
+            f"[{i}] {result.get('title', '')} ({domain})\n    URL: {url}\n    Summary: {snippet}\n\n"
+        )
+    return "".join(formatted_results)
+
+
+def _is_url_excluded(url: str, exclude_domains: list[str]) -> bool:
+    hostname = urlparse(url).hostname or ""
+    return any(hostname == domain or hostname.endswith("." + domain) for domain in exclude_domains)
+
+
+def _extract_domain(url: str) -> str:
+    return urlparse(url).hostname or url
+
+
+def _clean_text(text: str) -> str:
+    text = re.sub(r"\[edit\]", "", text)
+    text = re.sub(r"^\[(?:Jump to content|Search|Read|Edit|View history)[^\]]*\].*$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\[[^\]]+\]\(https?://[a-z]{2,3}\.wikipedia\.org/[^\)]*\)", "", text)
+    text = re.sub(r"^\s*\*\s*\[[^\]]*\]\(#[^\)]*\)\s*$", "", text, flags=re.MULTILINE)
+    text = text.replace("\u200b", "").replace("\u200c", "").replace("\u200d", "").replace("\ufeff", "")
+    text = text.replace("\u3010", "[").replace("\u3011", "]")
+    text = re.sub(r"[ \t]+$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _add_line_numbers(text: str) -> str:
+    lines = text.split("\n")
+    return "\n".join(f"L{i}: {line}" for i, line in enumerate(lines))
+
+
+def _truncate_text(text: str, max_chars: int = MAX_RESULT_CHARS) -> tuple[str, bool]:
+    if len(text) <= max_chars:
+        return text, False
+    cut = text.rfind("\n", 0, max_chars)
+    if cut == -1:
+        cut = max_chars
+    return text[:cut], True
+
+
+def _parse_api_keys(api_key_config: str | None) -> list[str]:
+    if not api_key_config:
+        return []
+    return [key.strip() for key in api_key_config.split(",") if key.strip()]
 
 
 def _parse_exclude_domains(exclude_config: dict) -> list[str]:
@@ -148,8 +330,12 @@ class TavilySearchTool(MCPClientTool):
                 },
                 "hide_args": {
                     "web-search": ["exclude_domains", "num_results", "answer_type"],
+                    "find-in-page": ["exclude_domains"],
+                    "scroll-page": ["exclude_domains"],
                 },
                 "exclude_domains_config": None,
+                "num_results": DEFAULT_NUM_RESULTS,
+                "answer_type": "formatted",
             }
         )
 
@@ -168,9 +354,10 @@ class TavilySearchTool(MCPClientTool):
         if not hasattr(self, "exclude_domains"):
             raise ValueError("exclude_domains_config is not set")
         merged_extra["exclude_domains"] = self.exclude_domains
-        for key in ["num_results", "answer_type"]:
-            if key in self._config:
-                merged_extra[key] = self._config[key]
+        if tool_name == "web-search":
+            for key in ["num_results", "answer_type"]:
+                if key in self._config:
+                    merged_extra[key] = self._config[key]
         result = await self._client.call_tool(tool=tool_name, args=arguments, extra_args=merged_extra)
 
         # Check for fatal errors that should stop the process
@@ -188,8 +375,8 @@ def main():
     if not args.api_key:
         raise ValueError("Missing Tavily API key.")
 
-    global TAVILY_API_KEY
-    TAVILY_API_KEY = args.api_key
+    global TAVILY_API_KEYS
+    TAVILY_API_KEYS = _parse_api_keys(args.api_key)
 
     mcp.run(transport="stdio")
 

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import types
 
 import pytest
@@ -1180,6 +1181,103 @@ class TestWikipediaTool:
             await tool.execute("wikipedia-query-summary", {"title": "Hydrogen", "query": "isotope"})
             == "query-summary:Hydrogen:isotope:2500"
         )
+
+
+# -- Tavily direct tool tests -----------------------------------------------
+
+
+class TestTavilySearchTool:
+    def test_tavily_postprocess_search_results(self):
+        from nemo_skills.mcp.servers import tavily_search_tool
+
+        formatted = tavily_search_tool._postprocess_search_results(
+            {
+                "results": [
+                    {
+                        "url": "https://example.com/page",
+                        "title": "Example Page",
+                        "content": "Hello [edit] world",
+                        "score": 0.99,
+                        "raw_content": "raw",
+                    }
+                ]
+            }
+        )
+
+        assert "Search Results" in formatted
+        assert "[1] Example Page (example.com)" in formatted
+        assert "URL: https://example.com/page" in formatted
+        assert "Hello  world" in formatted
+        assert "0.99" not in formatted
+        assert "raw" not in formatted
+
+    def test_tavily_url_exclusion_matches_subdomains(self):
+        from nemo_skills.mcp.servers import tavily_search_tool
+
+        excluded = ["blacklisteddomain.com"]
+        assert tavily_search_tool._is_url_excluded("https://blacklisteddomain.com/page", excluded) is True
+        assert tavily_search_tool._is_url_excluded("https://sub.blacklisteddomain.com/page", excluded) is True
+        assert tavily_search_tool._is_url_excluded("https://example.com/page", excluded) is False
+
+    def test_tavily_page_tools_format_extract_results(self, monkeypatch):
+        from nemo_skills.mcp.servers import tavily_search_tool
+
+        async def fake_tavily_post(endpoint, payload):
+            assert endpoint == "/extract"
+            assert payload == {"urls": "https://example.com/page", "query": "needle"}
+            return {"results": [{"raw_content": "first line\n[Jump to content]\nsecond needle line"}]}
+
+        monkeypatch.setattr(tavily_search_tool, "_tavily_post", fake_tavily_post)
+
+        result = asyncio.run(tavily_search_tool.find_in_page("https://example.com/page", "needle"))
+
+        assert "Content from: example.com" in result
+        assert 'Query: "needle"' in result
+        assert "L0: first line" in result
+        assert "L2: second needle line" in result
+
+    def test_tavily_scroll_page_uses_cache(self, monkeypatch):
+        from nemo_skills.mcp.servers import tavily_search_tool
+
+        tavily_search_tool.PAGE_CACHE.clear()
+        calls = []
+
+        async def fake_tavily_post(endpoint, payload):
+            calls.append((endpoint, payload))
+            return {"results": [{"raw_content": "zero one two three four five"}]}
+
+        monkeypatch.setattr(tavily_search_tool, "_tavily_post", fake_tavily_post)
+
+        first = asyncio.run(tavily_search_tool.scroll_page("https://example.com/page", start_index=1, n=3))
+        second = asyncio.run(tavily_search_tool.scroll_page("https://example.com/page", start_index=3, n=2))
+
+        assert first["total_words"] == 6
+        assert "Showing words [1-4] of 6" in first["results_string"]
+        assert "L0: one two three" in first["results_string"]
+        assert "Showing words [3-5] of 6" in second["results_string"]
+        assert calls == [("/extract", {"urls": "https://example.com/page"})]
+
+    def test_tavily_tool_execute_injects_hidden_defaults(self):
+        from nemo_skills.mcp.servers.tavily_search_tool import TavilySearchTool
+
+        class DummyClient:
+            async def call_tool(self, tool, args, extra_args=None):
+                return {"tool": tool, "args": args, "extra_args": extra_args}
+
+        tool = TavilySearchTool()
+        tool.exclude_domains = ["blacklisteddomain.com"]
+        tool._client = DummyClient()
+
+        result = asyncio.run(tool.execute("web-search", {"query": "nvidia"}))
+
+        assert result["tool"] == "web-search"
+        assert result["args"] == {"query": "nvidia"}
+        assert result["extra_args"]["exclude_domains"] == ["blacklisteddomain.com"]
+        assert result["extra_args"]["num_results"] == 10
+        assert result["extra_args"]["answer_type"] == "formatted"
+
+        page_result = asyncio.run(tool.execute("find-in-page", {"url": "https://example.com/page", "query": "needle"}))
+        assert page_result["extra_args"] == {"exclude_domains": ["blacklisteddomain.com"]}
 
 
 # -- ArXiv direct tool tests ------------------------------------------------


### PR DESCRIPTION
Migrate content, prompt and design from [Gym](https://github.com/NVIDIA-NeMo/Gym/blob/main/resources_servers/tavily_search/app.py) for Tavily

  - Keeps web-search, now returning Gym-style formatted output by default.
  - Adds find-in-page and scroll-page MCP tools backed by Tavily /extract.
  - Adds page text cleanup, truncation, line numbers, scroll windows, and page caching.
  - Preserves domain exclusion handling, including subdomain matching.
  - Adds retry handling, fatal auth error propagation, and comma-separated Tavily API key rotation.
  - Hides internal exclude_domains for all Tavily tools.
  - Injects num_results / answer_type only for web-search.
  - Adds focused tests for formatting, exclusions, page extraction, scroll cache behavior, and wrapper argument injection.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiple Tavily API key support with automatic failover and retry handling
  * New page extraction tools: `find-in-page` and `scroll-page` for targeted content searching
  * Enhanced web-search with configurable result limits and answer formatting options

* **Improvements**
  * Robust retry logic for rate-limited and transient API errors
  * Stricter input validation for search queries and parameters
  * In-memory page caching for improved performance on repeated content extractions

* **Tests**
  * Added comprehensive test suite for search tool functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->