### PR TITLE
Standardize audio manifest container paths

### DIFF
--- a/docs/evaluation/speech-audio.md
+++ b/docs/evaluation/speech-audio.md
@@ -178,7 +178,7 @@ eval(benchmarks="mmau-pro.closed_form", ...)
         --model=/workspace/path/to/checkpoint \
         --server_entrypoint=/workspace/megatron-lm/server.py \
         --server_container=/path/to/container.sqsh \
-        --data_dir=/dataset \
+        --data_dir=/data \
         --installation_command="pip install sacrebleu"
     ```
 
@@ -562,7 +562,7 @@ used directly. If the file is missing, data is downloaded there automatically.
 To use a custom audio path prefix (e.g., for container mount points):
 
 ```bash
-ns prepare_data contextasr-bench --data_dir=/path/to/ContextASR-Bench --audio-prefix /data/contextasr
+ns prepare_data contextasr-bench --data_dir=/path/to/ContextASR-Bench --audio-prefix /data
 ```
 
 ### Running ContextASR-Bench Evaluation

--- a/docs/evaluation/speech-audio.md
+++ b/docs/evaluation/speech-audio.md
@@ -37,12 +37,40 @@ MMAU-Pro (Multimodal Audio Understanding - Pro) is a comprehensive benchmark for
 
 These benchmarks require audio files for meaningful evaluation. **Audio files are downloaded by default** to ensure proper evaluation.
 
+### Audio path convention
+
+Prepared audio manifests should write audio paths using the in-container audio
+root, not the host filesystem path. The default in-container root is `/data`.
+Override it with `--audio-prefix` when a different mount point is needed; if
+`--audio-prefix` is omitted, prepare scripts fall back to
+`NEMO_SKILLS_AUDIO_ROOT` and then `/data`.
+
+`--audio-prefix` is the global in-container audio root. Do not include the
+benchmark name in it; the prepare script appends the benchmark directory.
+For example, use `--audio-prefix /data`, not
+`--audio-prefix /data/contextasr-bench`.
+
+For example, preparing data with `--audio-prefix /data` writes manifest paths
+like:
+
+```text
+/data/asr-leaderboard/...
+/data/contextasr-bench/...
+```
+
+At evaluation time, mount the host prepared-data directory to the same
+in-container root:
+
+```bash
+ns eval ... --data_dir=/lustre/.../skills_data --mount-paths=/lustre/.../skills_data:/data
+```
+
 ### Data Preparation
 
 To prepare the dataset with audio files:
 
 ```bash
-ns prepare_data asr-leaderboard --data_dir=/path/to/data --cluster=<cluster>
+ns prepare_data asr-leaderboard --data_dir=/path/to/data --cluster=<cluster> --audio-prefix=/data
 ```
 
 Prepare specific datasets only:
@@ -74,7 +102,7 @@ eval(
     model="/workspace/checkpoint",
     server_entrypoint="/workspace/megatron-lm/server.py",
     server_container="/path/to/container.sqsh",
-    data_dir="/dataset",
+    data_dir="/data",
     installation_command="pip install -r requirements/audio.txt",
     server_args="--inference-max-requests 1 --model-config /workspace/checkpoint/config.yaml",
 )
@@ -98,7 +126,7 @@ eval(benchmarks="asr-leaderboard", split="librispeech_clean", ...)
         --model=/workspace/path/to/checkpoint \
         --server_entrypoint=/workspace/megatron-lm/server.py \
         --server_container=/path/to/container.sqsh \
-        --data_dir=/dataset \
+        --data_dir=/data \
         --installation_command="pip install -r requirements/audio.txt"
     ```
 
@@ -120,7 +148,7 @@ eval(
     model="/workspace/checkpoint",
     server_entrypoint="/workspace/megatron-lm/server.py",
     server_container="/path/to/container.sqsh",
-    data_dir="/dataset",
+    data_dir="/data",
     installation_command="pip install sacrebleu",
     server_args="--inference-max-requests 1 --model-config /workspace/checkpoint/config.yaml",
 )

--- a/nemo_skills/dataset/asr-leaderboard/prepare.py
+++ b/nemo_skills/dataset/asr-leaderboard/prepare.py
@@ -166,6 +166,15 @@ def main():
         help="Datasets to prepare (default: all)",
     )
     parser.add_argument(
+        "--data_dir",
+        type=str,
+        default=None,
+        help=(
+            "Output directory. If provided, outputs go under <data_dir>/asr-leaderboard. "
+            "If omitted, writes into this package's dataset directory."
+        ),
+    )
+    parser.add_argument(
         "--no-audio",
         action="store_true",
         help="Skip saving audio files (JSONL still includes audio paths)",
@@ -178,7 +187,10 @@ def main():
     )
     args = parser.parse_args()
 
-    output_dir = Path(__file__).parent
+    if args.data_dir:
+        output_dir = Path(args.data_dir) / "asr-leaderboard"
+    else:
+        output_dir = Path(__file__).parent
     output_dir.mkdir(parents=True, exist_ok=True)
 
     with_audio = not args.no_audio

--- a/nemo_skills/dataset/asr-leaderboard/prepare.py
+++ b/nemo_skills/dataset/asr-leaderboard/prepare.py
@@ -19,7 +19,7 @@ test-only sorted dataset (hf-audio/esb-datasets-test-only-sorted). This is the
 same data source used by the official leaderboard and the offline NeMo eval
 pipeline, ensuring apples-to-apples WER comparison.
 
-Audio paths in JSONL: /dataset/asr-leaderboard/data/{dataset}/{sample_id}.flac
+Audio paths in JSONL: {audio_prefix}/asr-leaderboard/data/{dataset}/{sample_id}.flac
 
 Usage:
     ns prepare_data asr-leaderboard
@@ -35,6 +35,8 @@ from pathlib import Path
 import soundfile as sf
 from datasets import load_dataset
 from tqdm import tqdm
+
+from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
 
 SYSTEM_MESSAGE = "You are a helpful assistant. /no_think"
 MIN_AUDIO_DURATION = 0.1  # Skip audio shorter than this (causes mel spectrogram errors)
@@ -53,7 +55,14 @@ DATASET_CONFIGS = {
 
 
 def save_audio_and_format_entry(
-    entry, dataset_name, audio_dir, sample_idx, text_field="text", id_field="id", with_audio=True
+    entry,
+    dataset_name,
+    audio_dir,
+    sample_idx,
+    text_field="text",
+    id_field="id",
+    with_audio=True,
+    audio_root="/data",
 ):
     """Format a dataset entry and optionally save audio file."""
     text = entry[text_field].strip()
@@ -77,7 +86,11 @@ def save_audio_and_format_entry(
         if with_audio:
             sf.write(str(audio_dir / audio_filename), audio_array, sampling_rate)
 
-    audio_meta = {"path": f"/dataset/asr-leaderboard/data/{dataset_name}/{audio_filename}"}
+    audio_meta = {
+        "path": build_container_audio_path(
+            "asr-leaderboard", "data", dataset_name, audio_filename, audio_prefix=audio_root
+        )
+    }
     if duration is not None:
         audio_meta["duration"] = float(duration)
     user_message["audio"] = audio_meta
@@ -96,7 +109,7 @@ def save_audio_and_format_entry(
     return formatted_entry
 
 
-def prepare_dataset(dataset_name, output_dir, with_audio=True):
+def prepare_dataset(dataset_name, output_dir, with_audio=True, audio_root="/data"):
     """Prepare a single ASR dataset."""
     if dataset_name not in DATASET_CONFIGS:
         raise ValueError(f"Unknown dataset: {dataset_name}. Available: {list(DATASET_CONFIGS.keys())}")
@@ -120,7 +133,14 @@ def prepare_dataset(dataset_name, output_dir, with_audio=True):
     with open(output_file, "w", encoding="utf-8") as fout:
         for idx, entry in enumerate(tqdm(dataset, desc=dataset_name)):
             formatted = save_audio_and_format_entry(
-                entry, dataset_name, audio_dir, idx, text_field=text_field, id_field=id_field, with_audio=with_audio
+                entry,
+                dataset_name,
+                audio_dir,
+                idx,
+                text_field=text_field,
+                id_field=id_field,
+                with_audio=with_audio,
+                audio_root=audio_root,
             )
             if formatted is None:
                 skipped += 1
@@ -150,24 +170,31 @@ def main():
         action="store_true",
         help="Skip saving audio files (JSONL still includes audio paths)",
     )
+    parser.add_argument(
+        "--audio-prefix",
+        type=str,
+        default=None,
+        help="In-container audio root written into JSONL paths. Defaults to $NEMO_SKILLS_AUDIO_ROOT or /data.",
+    )
     args = parser.parse_args()
 
-    data_dir = Path("/dataset/asr-leaderboard")
-    output_dir = data_dir if data_dir.exists() else Path(__file__).parent
+    output_dir = Path(__file__).parent
     output_dir.mkdir(parents=True, exist_ok=True)
 
     with_audio = not args.no_audio
+    audio_root = get_container_audio_root(args.audio_prefix)
 
     if args.no_audio:
         print("Running without saving audio files.")
     else:
         print("Running with audio. Saving to data/{dataset}/")
+    print(f"Audio paths in JSONL will use: {audio_root}/asr-leaderboard/data/...")
 
     datasets_to_prepare = list(DATASET_CONFIGS.keys()) if "all" in args.datasets else args.datasets
 
     total_samples = 0
     for dataset_name in datasets_to_prepare:
-        total_samples += prepare_dataset(dataset_name, output_dir, with_audio=with_audio)
+        total_samples += prepare_dataset(dataset_name, output_dir, with_audio=with_audio, audio_root=audio_root)
 
     # Combine all dataset JSONLs into test.jsonl
     combined_file = output_dir / "test.jsonl"

--- a/nemo_skills/dataset/asr-leaderboard/prepare.py
+++ b/nemo_skills/dataset/asr-leaderboard/prepare.py
@@ -36,7 +36,11 @@ import soundfile as sf
 from datasets import load_dataset
 from tqdm import tqdm
 
-from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+from nemo_skills.dataset.utils import (
+    DEFAULT_CONTAINER_AUDIO_ROOT,
+    build_container_audio_path,
+    get_container_audio_root,
+)
 
 SYSTEM_MESSAGE = "You are a helpful assistant. /no_think"
 MIN_AUDIO_DURATION = 0.1  # Skip audio shorter than this (causes mel spectrogram errors)
@@ -62,7 +66,7 @@ def save_audio_and_format_entry(
     text_field="text",
     id_field="id",
     with_audio=True,
-    audio_root="/data",
+    audio_root=DEFAULT_CONTAINER_AUDIO_ROOT,
 ):
     """Format a dataset entry and optionally save audio file."""
     text = entry[text_field].strip()
@@ -109,7 +113,7 @@ def save_audio_and_format_entry(
     return formatted_entry
 
 
-def prepare_dataset(dataset_name, output_dir, with_audio=True, audio_root="/data"):
+def prepare_dataset(dataset_name, output_dir, with_audio=True, audio_root=DEFAULT_CONTAINER_AUDIO_ROOT):
     """Prepare a single ASR dataset."""
     if dataset_name not in DATASET_CONFIGS:
         raise ValueError(f"Unknown dataset: {dataset_name}. Available: {list(DATASET_CONFIGS.keys())}")

--- a/nemo_skills/dataset/audiobench/prepare.py
+++ b/nemo_skills/dataset/audiobench/prepare.py
@@ -35,6 +35,8 @@ import numpy as np
 import soundfile as sf
 from tqdm import tqdm
 
+from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+
 # AudioBench datasets categorized by evaluation type
 JUDGE_DATASETS = [
     "alpaca_audio_test",
@@ -140,6 +142,7 @@ def create_manifest_entry(
     dataset_name: str,
     sample_id: int,
     category: str,
+    audio_root: str = "/data",
 ) -> Dict:
     """Create a nemo-skills compatible manifest entry.
 
@@ -158,9 +161,9 @@ def create_manifest_entry(
     reference = sample.get("reference", sample.get("answer", ""))
     task_type = sample.get("task_type", "unknown")
 
-    # Create absolute audio path with /data/ prefix for cluster deployment
-    # Format: /data/audiobench/{category}/audio/{dataset_name}/{filename}
-    audio_rel_path = f"/data/audiobench/{category}/audio/{dataset_name}/{audio_filename}"
+    audio_rel_path = build_container_audio_path(
+        "audiobench", category, "audio", dataset_name, audio_filename, audio_prefix=audio_root
+    )
 
     # Create audio metadata (both singular and plural forms for compatibility)
     audio_metadata = {"path": audio_rel_path, "duration": duration}
@@ -209,6 +212,7 @@ def process_dataset(
     save_audio: bool = True,
     split: str = "test",
     max_samples: int = -1,
+    audio_root: str = "/data",
 ) -> tuple[int, List[Dict]]:
     """Process a single AudioBench dataset.
 
@@ -459,6 +463,7 @@ def process_dataset(
                 dataset_name=dataset_name,
                 sample_id=idx,
                 category=category,
+                audio_root=audio_root,
             )
 
             manifest_entries.append(entry)
@@ -519,6 +524,12 @@ def main():
         default=-1,
         help="Maximum number of samples to process per dataset (-1 for all)",
     )
+    parser.add_argument(
+        "--audio-prefix",
+        type=str,
+        default=None,
+        help="In-container audio root written into JSONL paths. Defaults to $NEMO_SKILLS_AUDIO_ROOT or /data.",
+    )
     parser.set_defaults(save_audio=True)
 
     args = parser.parse_args()
@@ -531,6 +542,7 @@ def main():
         output_dir = Path(__file__).parent
 
     output_dir.mkdir(parents=True, exist_ok=True)
+    audio_root = get_container_audio_root(args.audio_prefix)
 
     print("\n" + "=" * 60)
     print("AudioBench Dataset Preparation")
@@ -539,6 +551,7 @@ def main():
     print(f"Output directory: {output_dir}")
     print(f"Save audio files: {args.save_audio}")
     print(f"Split: {args.split}")
+    print(f"Audio paths in JSONL will use: {audio_root}/audiobench/...")
     print("=" * 60 + "\n")
 
     # Determine which datasets to process
@@ -585,6 +598,7 @@ def main():
                 save_audio=args.save_audio,
                 split=args.split,
                 max_samples=args.max_samples,
+                audio_root=audio_root,
             )
             total_samples += num_samples
             total_datasets += 1

--- a/nemo_skills/dataset/audiobench/prepare.py
+++ b/nemo_skills/dataset/audiobench/prepare.py
@@ -35,7 +35,11 @@ import numpy as np
 import soundfile as sf
 from tqdm import tqdm
 
-from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+from nemo_skills.dataset.utils import (
+    DEFAULT_CONTAINER_AUDIO_ROOT,
+    build_container_audio_path,
+    get_container_audio_root,
+)
 
 # AudioBench datasets categorized by evaluation type
 JUDGE_DATASETS = [
@@ -142,7 +146,7 @@ def create_manifest_entry(
     dataset_name: str,
     sample_id: int,
     category: str,
-    audio_root: str = "/data",
+    audio_root: str = DEFAULT_CONTAINER_AUDIO_ROOT,
 ) -> Dict:
     """Create a nemo-skills compatible manifest entry.
 
@@ -212,7 +216,7 @@ def process_dataset(
     save_audio: bool = True,
     split: str = "test",
     max_samples: int = -1,
-    audio_root: str = "/data",
+    audio_root: str = DEFAULT_CONTAINER_AUDIO_ROOT,
 ) -> tuple[int, List[Dict]]:
     """Process a single AudioBench dataset.
 

--- a/nemo_skills/dataset/contextasr-bench/prepare.py
+++ b/nemo_skills/dataset/contextasr-bench/prepare.py
@@ -39,6 +39,9 @@ import json
 import tarfile
 from pathlib import Path
 
+from nemo_skills.dataset.utils import build_container_audio_path
+
+BENCHMARK_NAME = "contextasr-bench"
 HF_REPO_ID = "MrSupW/ContextASR-Bench"
 JSONL_FILENAME = "ContextASR-Speech_English.jsonl"
 AUDIO_TAR_PREFIX = "audio/ContextASR-Speech/English/ContextASR-Speech_English"
@@ -142,6 +145,11 @@ def build_messages(prompt_text, audio_path, duration):
     ]
 
 
+def resolve_audio_prefix(audio_prefix: str | None = None) -> str:
+    """Return the in-container ContextASR audio prefix used in JSONL paths."""
+    return build_container_audio_path(BENCHMARK_NAME, audio_prefix=audio_prefix)
+
+
 def format_entry(sample, mode, audio_prefix):
     """Format a single dataset sample into a JSONL record for a given mode."""
     audio_path = f"{audio_prefix}/{sample['audio']}"
@@ -191,8 +199,9 @@ def main():
         default=None,
         help=(
             "Override audio path prefix written into JSONL files. "
-            "Defaults to the data_dir value. Useful for container mount points "
-            "(e.g., --audio-prefix /data/contextasr-bench)."
+            "This is the global in-container audio root; the script appends "
+            f"{BENCHMARK_NAME}/. Defaults to $NEMO_SKILLS_AUDIO_ROOT or /data "
+            f"(e.g., --audio-prefix /data writes /data/{BENCHMARK_NAME}/...)."
         ),
     )
     parser.add_argument(
@@ -220,8 +229,7 @@ def main():
         print(f"Data not found at {data_dir}. Downloading there...")
         download_dataset(data_dir)
 
-    audio_prefix = args.audio_prefix if args.audio_prefix else str(data_dir)
-    audio_prefix = audio_prefix.rstrip("/")
+    audio_prefix = resolve_audio_prefix(args.audio_prefix)
 
     jsonl_path = data_dir / JSONL_FILENAME
 
@@ -236,14 +244,15 @@ def main():
     print(f"Loaded {len(samples)} samples")
 
     if not args.no_audio:
-        sample_audio = Path(audio_prefix) / samples[0]["audio"]
+        sample_audio = data_dir / samples[0]["audio"]
         if not sample_audio.exists():
             print(
                 f"WARNING: Sample audio file not found at {sample_audio}. "
-                f"Audio paths may need adjustment via --audio-prefix."
+                f"Audio paths may need adjustment via --data_dir."
             )
         else:
             print(f"Audio files verified (sample check: {sample_audio})")
+    print(f"Audio paths in JSONL will use: {audio_prefix}/...")
 
     modes = {
         "contextless": output_dir / "contextless" / "test.jsonl",

--- a/nemo_skills/dataset/covost2/prepare.py
+++ b/nemo_skills/dataset/covost2/prepare.py
@@ -25,6 +25,8 @@ from pathlib import Path
 import soundfile as sf
 from tqdm import tqdm
 
+from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+
 COVOST_URL_TEMPLATE = "https://dl.fbaipublicfiles.com/covost/covost_v2.{src_lang}_{tgt_lang}.tsv.tar.gz"
 SPLITS = ["validation", "test"]
 
@@ -144,8 +146,8 @@ def get_audio_duration(audio_file: str) -> float:
     return float(info.frames / info.samplerate)
 
 
-def get_container_audio_path(src_lang: str, split: str, audio_id: str) -> str:
-    return f"/dataset/covost2/audio/{src_lang}/{split}/{audio_id}.wav"
+def get_container_audio_path(src_lang: str, split: str, audio_id: str, audio_root: str) -> str:
+    return build_container_audio_path("covost2", "audio", src_lang, split, f"{audio_id}.wav", audio_prefix=audio_root)
 
 
 def copy_audio_file(src_wav: Path, audio_dir: Path, src_lang: str, split: str) -> Path:
@@ -196,6 +198,7 @@ def prepare_covost2(
     cv_data_dir: Path,
     validated_tsv: Path,
     task_type: str,
+    audio_root: str = "/data",
 ) -> None:
     if not languages:
         raise ValueError("No languages to process")
@@ -231,7 +234,7 @@ def prepare_covost2(
                     sentence = sentences[(wav_file.name, split, src_lang)]
                     duration = get_audio_duration(str(wav_file))
                     copy_audio_file(wav_file, audio_dir, src_lang, split)
-                    cpath = get_container_audio_path(src_lang, split, wav_file.stem)
+                    cpath = get_container_audio_path(src_lang, split, wav_file.stem, audio_root=audio_root)
                     record = _build_record(
                         expected_answer=sentence,
                         instruction=get_asr_instruction(),
@@ -253,7 +256,7 @@ def prepare_covost2(
                 for item in tqdm(dataset, desc=tag):
                     duration = get_audio_duration(item["audio_file"])
                     copy_audio_file(Path(item["audio_file"]), audio_dir, src_lang, split)
-                    cpath = get_container_audio_path(src_lang, split, item["id"])
+                    cpath = get_container_audio_path(src_lang, split, item["id"], audio_root=audio_root)
                     record = _build_record(
                         expected_answer=item["translation"],
                         instruction=get_ast_instruction(tgt_lang),
@@ -316,6 +319,12 @@ def main():
         choices=["ASR", "AST", "asr", "ast"],
         help="Task to prepare. ASR: speech recognition, AST: speech translation.",
     )
+    parser.add_argument(
+        "--audio-prefix",
+        type=str,
+        default=None,
+        help="In-container audio root written into JSONL paths. Defaults to $NEMO_SKILLS_AUDIO_ROOT or /data.",
+    )
     args = parser.parse_args()
 
     if args.data_dir:
@@ -323,6 +332,8 @@ def main():
     else:
         data_dir = Path(__file__).parent
     data_dir.mkdir(parents=True, exist_ok=True)
+    audio_root = get_container_audio_root(args.audio_prefix)
+    print(f"Audio paths in JSONL will use: {audio_root}/covost2/audio/...")
 
     prepare_covost2(
         data_dir=data_dir,
@@ -331,6 +342,7 @@ def main():
         cv_data_dir=Path(args.cv_data_dir),
         validated_tsv=Path(args.validated_tsv),
         task_type=args.task.upper(),
+        audio_root=audio_root,
     )
 
 

--- a/nemo_skills/dataset/covost2/prepare.py
+++ b/nemo_skills/dataset/covost2/prepare.py
@@ -25,7 +25,11 @@ from pathlib import Path
 import soundfile as sf
 from tqdm import tqdm
 
-from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+from nemo_skills.dataset.utils import (
+    DEFAULT_CONTAINER_AUDIO_ROOT,
+    build_container_audio_path,
+    get_container_audio_root,
+)
 
 COVOST_URL_TEMPLATE = "https://dl.fbaipublicfiles.com/covost/covost_v2.{src_lang}_{tgt_lang}.tsv.tar.gz"
 SPLITS = ["validation", "test"]
@@ -198,7 +202,7 @@ def prepare_covost2(
     cv_data_dir: Path,
     validated_tsv: Path,
     task_type: str,
-    audio_root: str = "/data",
+    audio_root: str = DEFAULT_CONTAINER_AUDIO_ROOT,
 ) -> None:
     if not languages:
         raise ValueError("No languages to process")

--- a/nemo_skills/dataset/fleurs/prepare.py
+++ b/nemo_skills/dataset/fleurs/prepare.py
@@ -25,6 +25,8 @@ import soundfile as sf
 from huggingface_hub import hf_hub_download
 from tqdm import tqdm
 
+from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+
 
 def load_fleurs_module():
     """Download and dynamically import google/fleurs/fleurs.py from HuggingFace."""
@@ -125,8 +127,8 @@ def prepare_audio(item: dict) -> tuple[np.ndarray, int, float]:
     return y, sr, duration
 
 
-def get_container_audio_path(locale: str, wav_filename: str) -> str:
-    return f"/dataset/fleurs/audio/{locale}/{wav_filename}"
+def get_container_audio_path(locale: str, wav_filename: str, audio_root: str) -> str:
+    return build_container_audio_path("fleurs", "audio", locale, wav_filename, audio_prefix=audio_root)
 
 
 def save_audio(y: np.ndarray, sr: int, wav_path: Path) -> None:
@@ -167,7 +169,14 @@ def _build_record(
     }
 
 
-def prepare_fleurs(data_dir: Path, split: str, languages: list[str], no_audio: bool, task_type: str) -> None:
+def prepare_fleurs(
+    data_dir: Path,
+    split: str,
+    languages: list[str],
+    no_audio: bool,
+    task_type: str,
+    audio_root: str = "/data",
+) -> None:
     if not languages:
         raise ValueError("No languages to process")
 
@@ -221,7 +230,7 @@ def prepare_fleurs(data_dir: Path, split: str, languages: list[str], no_audio: b
                 y, sr, duration = prepare_audio(source_row)
                 wav_filename = source_row["wav_filename"]
                 wav_path = locale_audio_dir / wav_filename
-                cpath = get_container_audio_path(src_locale, wav_filename)
+                cpath = get_container_audio_path(src_locale, wav_filename, audio_root=audio_root)
                 if not no_audio:
                     save_audio(y, sr, wav_path)
 
@@ -292,6 +301,12 @@ def main():
         action="store_true",
         help="Skip saving audio files (only create manifests)",
     )
+    parser.add_argument(
+        "--audio-prefix",
+        type=str,
+        default=None,
+        help="In-container audio root written into JSONL paths. Defaults to $NEMO_SKILLS_AUDIO_ROOT or /data.",
+    )
     args = parser.parse_args()
 
     unknown = set(args.languages) - LOCALES
@@ -303,6 +318,8 @@ def main():
     else:
         data_dir = Path(__file__).parent
     data_dir.mkdir(parents=True, exist_ok=True)
+    audio_root = get_container_audio_root(args.audio_prefix)
+    print(f"Audio paths in JSONL will use: {audio_root}/fleurs/audio/...")
 
     prepare_fleurs(
         data_dir=data_dir,
@@ -310,6 +327,7 @@ def main():
         languages=args.languages,
         no_audio=args.no_audio,
         task_type=args.task.upper(),
+        audio_root=audio_root,
     )
 
 

--- a/nemo_skills/dataset/fleurs/prepare.py
+++ b/nemo_skills/dataset/fleurs/prepare.py
@@ -25,7 +25,11 @@ import soundfile as sf
 from huggingface_hub import hf_hub_download
 from tqdm import tqdm
 
-from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+from nemo_skills.dataset.utils import (
+    DEFAULT_CONTAINER_AUDIO_ROOT,
+    build_container_audio_path,
+    get_container_audio_root,
+)
 
 
 def load_fleurs_module():
@@ -175,7 +179,7 @@ def prepare_fleurs(
     languages: list[str],
     no_audio: bool,
     task_type: str,
-    audio_root: str = "/data",
+    audio_root: str = DEFAULT_CONTAINER_AUDIO_ROOT,
 ) -> None:
     if not languages:
         raise ValueError("No languages to process")

--- a/nemo_skills/dataset/librispeech-pc/prepare.py
+++ b/nemo_skills/dataset/librispeech-pc/prepare.py
@@ -33,7 +33,11 @@ from pathlib import Path
 
 from tqdm import tqdm
 
-from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+from nemo_skills.dataset.utils import (
+    DEFAULT_CONTAINER_AUDIO_ROOT,
+    build_container_audio_path,
+    get_container_audio_root,
+)
 
 
 def download_with_progress(url: str, output_path: Path, desc: str):
@@ -102,7 +106,13 @@ def download_audio(split: str, audio_dir: Path):
     os.remove(tar_path)
 
 
-def process_split(split: str, data_dir: Path, audio_dir: Path, with_audio: bool, audio_root: str = "/data") -> int:
+def process_split(
+    split: str,
+    data_dir: Path,
+    audio_dir: Path,
+    with_audio: bool,
+    audio_root: str = DEFAULT_CONTAINER_AUDIO_ROOT,
+) -> int:
     """Process one LibriSpeech-PC split into nemo-skills format."""
 
     output_file = data_dir / f"{split}.jsonl"

--- a/nemo_skills/dataset/librispeech-pc/prepare.py
+++ b/nemo_skills/dataset/librispeech-pc/prepare.py
@@ -227,7 +227,9 @@ def main():
     download_manifests(data_dir)
 
     splits = ["test-clean", "test-other"] if args.split == "all" else [args.split]
-    total = sum(process_split(split, data_dir, audio_dir, not args.no_audio, audio_root=audio_root) for split in splits)
+    total = sum(
+        process_split(split, data_dir, audio_dir, not args.no_audio, audio_root=audio_root) for split in splits
+    )
 
     print(f"\n✓ Complete: {total} samples")
 

--- a/nemo_skills/dataset/librispeech-pc/prepare.py
+++ b/nemo_skills/dataset/librispeech-pc/prepare.py
@@ -33,6 +33,8 @@ from pathlib import Path
 
 from tqdm import tqdm
 
+from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+
 
 def download_with_progress(url: str, output_path: Path, desc: str):
     """Download file with tqdm progress bar."""
@@ -100,7 +102,7 @@ def download_audio(split: str, audio_dir: Path):
     os.remove(tar_path)
 
 
-def process_split(split: str, data_dir: Path, audio_dir: Path, with_audio: bool) -> int:
+def process_split(split: str, data_dir: Path, audio_dir: Path, with_audio: bool, audio_root: str = "/data") -> int:
     """Process one LibriSpeech-PC split into nemo-skills format."""
 
     output_file = data_dir / f"{split}.jsonl"
@@ -129,11 +131,12 @@ def process_split(split: str, data_dir: Path, audio_dir: Path, with_audio: bool)
 
             audio_id = Path(audio_filepath).stem
 
-            audio_root = os.getenv("NEMO_SKILLS_AUDIO_ROOT", "/data")
             rel_audio_path = audio_filepath.lstrip("/")
             if rel_audio_path.startswith("LibriSpeech/"):
                 rel_audio_path = rel_audio_path[len("LibriSpeech/") :]
-            container_path = f"{audio_root}/librispeech-pc/LibriSpeech/{rel_audio_path}"
+            container_path = build_container_audio_path(
+                "librispeech-pc", "LibriSpeech", rel_audio_path, audio_prefix=audio_root
+            )
 
             user_message = {
                 "role": "user",
@@ -185,6 +188,12 @@ def main():
         action="store_true",
         help="Skip audio download",
     )
+    parser.add_argument(
+        "--audio-prefix",
+        type=str,
+        default=None,
+        help="In-container audio root written into JSONL paths. Defaults to $NEMO_SKILLS_AUDIO_ROOT or /data.",
+    )
     args = parser.parse_args()
 
     if args.data_dir:
@@ -202,11 +211,13 @@ def main():
 
     audio_dir = data_dir
     audio_dir.mkdir(parents=True, exist_ok=True)
+    audio_root = get_container_audio_root(args.audio_prefix)
+    print(f"Audio paths in JSONL will use: {audio_root}/librispeech-pc/LibriSpeech/...")
 
     download_manifests(data_dir)
 
     splits = ["test-clean", "test-other"] if args.split == "all" else [args.split]
-    total = sum(process_split(split, data_dir, audio_dir, not args.no_audio) for split in splits)
+    total = sum(process_split(split, data_dir, audio_dir, not args.no_audio, audio_root=audio_root) for split in splits)
 
     print(f"\n✓ Complete: {total} samples")
 

--- a/nemo_skills/dataset/mmau-pro/prepare.py
+++ b/nemo_skills/dataset/mmau-pro/prepare.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from datasets import load_dataset
 from tqdm import tqdm
 
-from nemo_skills.dataset.utils import get_mcq_fields
+from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root, get_mcq_fields
 
 
 def download_mmau_data(download_dir, hf_token):
@@ -56,7 +56,20 @@ def download_mmau_data(download_dir, hf_token):
     return extracted_data_dir
 
 
-def format_entry(entry, with_audio=False):
+def _normalize_audio_path(path: str, audio_root: str) -> str:
+    """Convert a dataset audio path into the configured in-container path.
+
+    Preserves the dataset's relative layout (e.g. ``data/<uuid>.wav``) verbatim
+    so the JSONL path matches where files actually live after ``cp -r``. The
+    HF MMAU-Pro dataset records audio entries as ``data/<uuid>.wav`` and that
+    ``data/`` is the subdir its zip extracts into; stripping it here would
+    produce JSONL paths that fail to resolve against the on-disk layout.
+    """
+    rel_path = str(path).lstrip("/")
+    return build_container_audio_path("mmau-pro", rel_path, audio_prefix=audio_root)
+
+
+def format_entry(entry, with_audio=False, audio_root="/data"):
     """Format entry for nemo-skills with OpenAI messages and audio support."""
     choices = entry.get("choices", []) or []
 
@@ -86,8 +99,12 @@ def format_entry(entry, with_audio=False):
         audio_path = entry["audio_path"]
 
         if isinstance(audio_path, list) and audio_path:
-            user_message["audios"] = [{"path": path, "duration": 10.0} for path in audio_path]
+            audio_paths = [_normalize_audio_path(path, audio_root) for path in audio_path]
+            formatted_entry["audio_path"] = audio_paths
+            user_message["audios"] = [{"path": path, "duration": 10.0} for path in audio_paths]
         elif isinstance(audio_path, str):
+            audio_path = _normalize_audio_path(audio_path, audio_root)
+            formatted_entry["audio_path"] = audio_path
             user_message["audio"] = {"path": audio_path, "duration": 10.0}
 
     formatted_entry["messages"] = [user_message]
@@ -102,9 +119,17 @@ def main():
         action="store_true",
         help="Skip downloading audio files",
     )
+    parser.add_argument(
+        "--audio-prefix",
+        type=str,
+        default=None,
+        help="In-container audio root written into JSONL paths. Defaults to $NEMO_SKILLS_AUDIO_ROOT or /data.",
+    )
     args = parser.parse_args()
 
     data_dir = Path(__file__).parent
+    audio_root = get_container_audio_root(args.audio_prefix)
+    print(f"Audio paths in JSONL will use: {audio_root}/mmau-pro/...")
 
     # Download audio by default unless --no-audio is specified
     if not args.no_audio:
@@ -136,7 +161,7 @@ def main():
 
     try:
         for entry in tqdm(dataset):
-            formatted_entry = format_entry(entry, with_audio=not args.no_audio)
+            formatted_entry = format_entry(entry, with_audio=not args.no_audio, audio_root=audio_root)
             category = entry.get("category", "closed_form")
 
             # Map category to file

--- a/nemo_skills/dataset/mmau-pro/prepare.py
+++ b/nemo_skills/dataset/mmau-pro/prepare.py
@@ -22,7 +22,12 @@ from pathlib import Path
 from datasets import load_dataset
 from tqdm import tqdm
 
-from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root, get_mcq_fields
+from nemo_skills.dataset.utils import (
+    DEFAULT_CONTAINER_AUDIO_ROOT,
+    build_container_audio_path,
+    get_container_audio_root,
+    get_mcq_fields,
+)
 
 
 def download_mmau_data(download_dir, hf_token):
@@ -69,7 +74,7 @@ def _normalize_audio_path(path: str, audio_root: str) -> str:
     return build_container_audio_path("mmau-pro", rel_path, audio_prefix=audio_root)
 
 
-def format_entry(entry, with_audio=False, audio_root="/data"):
+def format_entry(entry, with_audio=False, audio_root=DEFAULT_CONTAINER_AUDIO_ROOT):
     """Format entry for nemo-skills with OpenAI messages and audio support."""
     choices = entry.get("choices", []) or []
 

--- a/nemo_skills/dataset/musan/prepare.py
+++ b/nemo_skills/dataset/musan/prepare.py
@@ -40,6 +40,8 @@ import numpy as np
 import soundfile as sf
 from tqdm import tqdm
 
+from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+
 # HuggingFace dataset label mappings
 CATEGORY_LABELS = {
     "noise": 0,
@@ -166,10 +168,10 @@ def create_manifest_entry(
     category: str,
     sample_id: int,
     label: str,
+    audio_root: str = "/data",
 ) -> Dict:
     """Create nemo-skills manifest entry."""
-    audio_root = os.getenv("NEMO_SKILLS_AUDIO_ROOT", "/data")
-    audio_rel_path = f"{audio_root}/musan/{category}/audio/{audio_filename}"
+    audio_rel_path = build_container_audio_path("musan", category, "audio", audio_filename, audio_prefix=audio_root)
     audio_metadata = {"path": audio_rel_path, "duration": duration}
 
     # Instruction for transcription (expects empty response for non-speech audio)
@@ -207,6 +209,7 @@ def process_category_from_files(
     save_audio: bool = True,
     split: str = "train",
     max_samples: int = -1,
+    audio_root: str = "/data",
 ) -> tuple[int, List[Dict]]:
     """Process MUSAN category from WAV files (Kaggle/OpenSLR format)."""
     category_path = dataset_path / category
@@ -253,6 +256,7 @@ def process_category_from_files(
                 category=category,
                 sample_id=idx,
                 label=wav_path.stem,
+                audio_root=audio_root,
             )
 
             manifest_entries.append(entry)
@@ -283,6 +287,7 @@ def process_category(
     save_audio: bool = True,
     split: str = "train",
     max_samples: int = -1,
+    audio_root: str = "/data",
 ) -> tuple[int, List[Dict]]:
     """Process a single MUSAN category."""
     print(f"\n{'=' * 60}")
@@ -297,6 +302,7 @@ def process_category(
             save_audio=save_audio,
             split=split,
             max_samples=max_samples,
+            audio_root=audio_root,
         )
 
     elif source_type != "huggingface":
@@ -372,6 +378,7 @@ def process_category(
                 category=category,
                 sample_id=idx,
                 label=str(label),
+                audio_root=audio_root,
             )
 
             manifest_entries.append(entry)
@@ -412,6 +419,12 @@ def main():
     )
     parser.add_argument("--no-audio", dest="save_audio", action="store_false")
     parser.add_argument("--max-samples", type=int, default=-1)
+    parser.add_argument(
+        "--audio-prefix",
+        type=str,
+        default=None,
+        help="In-container audio root written into JSONL paths. Defaults to $NEMO_SKILLS_AUDIO_ROOT or /data.",
+    )
     parser.set_defaults(save_audio=True)
 
     args = parser.parse_args()
@@ -422,12 +435,14 @@ def main():
         output_dir = Path(__file__).parent
 
     output_dir.mkdir(parents=True, exist_ok=True)
+    audio_root = get_container_audio_root(args.audio_prefix)
 
     print("\n" + "=" * 60)
     print("MUSAN Dataset Preparation")
     print("=" * 60)
     print(f"Source: {args.source}")
     print(f"Output: {output_dir}")
+    print(f"Audio paths in JSONL will use: {audio_root}/musan/...")
     print(f"Categories: {', '.join(args.categories)}")
     print("=" * 60 + "\n")
 
@@ -452,6 +467,7 @@ def main():
                 save_audio=args.save_audio,
                 split=args.split,
                 max_samples=args.max_samples,
+                audio_root=audio_root,
             )
             total_samples += num_samples
             successful_categories.append(category)

--- a/nemo_skills/dataset/musan/prepare.py
+++ b/nemo_skills/dataset/musan/prepare.py
@@ -40,7 +40,11 @@ import numpy as np
 import soundfile as sf
 from tqdm import tqdm
 
-from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+from nemo_skills.dataset.utils import (
+    DEFAULT_CONTAINER_AUDIO_ROOT,
+    build_container_audio_path,
+    get_container_audio_root,
+)
 
 # HuggingFace dataset label mappings
 CATEGORY_LABELS = {
@@ -168,7 +172,7 @@ def create_manifest_entry(
     category: str,
     sample_id: int,
     label: str,
-    audio_root: str = "/data",
+    audio_root: str = DEFAULT_CONTAINER_AUDIO_ROOT,
 ) -> Dict:
     """Create nemo-skills manifest entry."""
     audio_rel_path = build_container_audio_path("musan", category, "audio", audio_filename, audio_prefix=audio_root)
@@ -209,7 +213,7 @@ def process_category_from_files(
     save_audio: bool = True,
     split: str = "train",
     max_samples: int = -1,
-    audio_root: str = "/data",
+    audio_root: str = DEFAULT_CONTAINER_AUDIO_ROOT,
 ) -> tuple[int, List[Dict]]:
     """Process MUSAN category from WAV files (Kaggle/OpenSLR format)."""
     category_path = dataset_path / category
@@ -287,7 +291,7 @@ def process_category(
     save_audio: bool = True,
     split: str = "train",
     max_samples: int = -1,
-    audio_root: str = "/data",
+    audio_root: str = DEFAULT_CONTAINER_AUDIO_ROOT,
 ) -> tuple[int, List[Dict]]:
     """Process a single MUSAN category."""
     print(f"\n{'=' * 60}")

--- a/nemo_skills/dataset/numb3rs/prepare.py
+++ b/nemo_skills/dataset/numb3rs/prepare.py
@@ -30,10 +30,10 @@ Output structure:
 Usage:
     ns prepare_data numb3rs --no-audio
     ns prepare_data numb3rs --categories CARDINAL DATE MONEY --no-audio
-    ns prepare_data numb3rs --no-audio --audio-prefix /data/numb3rs
+    ns prepare_data numb3rs --no-audio --audio-prefix /data
 
-Audio path in JSONL files: {audio_prefix}/Numb3rs/{CATEGORY}/{name}.wav
-Default audio_prefix: /data/numb3rs (maps to container mount)
+Audio path in JSONL files: {audio_prefix}/numb3rs/Numb3rs/{CATEGORY}/{name}.wav
+Default audio_prefix: $NEMO_SKILLS_AUDIO_ROOT or /data (maps to container mount)
 """
 
 import argparse
@@ -43,6 +43,8 @@ from pathlib import Path
 import soundfile as sf
 from datasets import load_dataset
 from tqdm import tqdm
+
+from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
 
 SYSTEM_MESSAGE = "You are a helpful assistant. /no_think"
 
@@ -72,15 +74,15 @@ def build_messages_with_prompt(audio_metadata, prompt_text):
     return [system_message, user_message]
 
 
-def save_audio_and_format_entry(entry, category, audio_dir, sample_idx, with_audio=True, audio_prefix="/data/numb3rs"):
+def save_audio_and_format_entry(entry, category, audio_dir, sample_idx, with_audio=True, audio_root="/data"):
     """Format a dataset entry and optionally save audio file.
 
     Returns a base entry dict with audio metadata. Messages are added separately
     based on prompt variant when writing to files.
 
     Args:
-        audio_prefix: Prefix for audio paths in the generated JSONL files.
-                      Default is '/data/numb3rs' which maps to container mount.
+        audio_root: In-container root for generated audio paths.
+                    Default is '/data' which maps to container mount.
                       Set to your local audio storage path as needed.
     """
     # Extract fields from Numb3rs dataset
@@ -110,10 +112,7 @@ def save_audio_and_format_entry(entry, category, audio_dir, sample_idx, with_aud
         audio_file_path = audio_dir / audio_filename
         sf.write(str(audio_file_path), audio_array, sampling_rate)
 
-    # Container path for evaluation
-    # Use audio_prefix to set the base path (e.g., /data/numb3rs or full cluster path)
-    # Audio files are organized as: {audio_prefix}/Numb3rs/{category}/{filename}.wav
-    audio_filepath = f"{audio_prefix}/Numb3rs/{category}/{audio_filename}"
+    audio_filepath = build_container_audio_path("numb3rs", "Numb3rs", category, audio_filename, audio_prefix=audio_root)
 
     # Build audio metadata (to be embedded in messages later)
     audio_metadata = {
@@ -137,7 +136,7 @@ def save_audio_and_format_entry(entry, category, audio_dir, sample_idx, with_aud
     return formatted_entry
 
 
-def prepare_category(category, dataset, output_dir, with_audio=True, audio_prefix="/data/numb3rs"):
+def prepare_category(category, dataset, output_dir, with_audio=True, audio_root="/data"):
     """Prepare a single category from the Numb3rs dataset.
 
     Generates 3 files per category in categories/ subfolder:
@@ -146,7 +145,7 @@ def prepare_category(category, dataset, output_dir, with_audio=True, audio_prefi
     - categories/{category}_itn.jsonl
 
     Args:
-        audio_prefix: Prefix for audio paths in the generated JSONL files.
+        audio_root: In-container root for generated audio paths.
     """
     print(f"\nProcessing category: {category}")
 
@@ -175,7 +174,7 @@ def prepare_category(category, dataset, output_dir, with_audio=True, audio_prefi
 
     for idx, entry in enumerate(tqdm(category_samples, desc=f"Processing {category}")):
         formatted = save_audio_and_format_entry(
-            entry, category, audio_dir, idx, with_audio=with_audio, audio_prefix=audio_prefix
+            entry, category, audio_dir, idx, with_audio=with_audio, audio_root=audio_root
         )
         if formatted is None:
             skipped += 1
@@ -232,9 +231,8 @@ def main():
     )
     parser.add_argument(
         "--audio-prefix",
-        default="/data/numb3rs",
-        help="Prefix for audio paths in JSONL files (default: /data/numb3rs). "
-        "Examples: /data/numb3rs, /dataset/numb3rs",
+        default=None,
+        help="In-container audio root written into JSONL paths. Defaults to $NEMO_SKILLS_AUDIO_ROOT or /data.",
     )
     args = parser.parse_args()
 
@@ -242,10 +240,10 @@ def main():
     output_dir.mkdir(parents=True, exist_ok=True)
 
     with_audio = not args.no_audio
-    audio_prefix = args.audio_prefix.rstrip("/")  # Remove trailing slash if present
+    audio_root = get_container_audio_root(args.audio_prefix)
 
-    print(f"Audio path prefix: {audio_prefix}")
-    print(f"Audio paths in JSONL: {audio_prefix}/Numb3rs/{{CATEGORY}}/{{name}}.wav")
+    print(f"Audio path root: {audio_root}")
+    print(f"Audio paths in JSONL: {audio_root}/numb3rs/Numb3rs/{{CATEGORY}}/{{name}}.wav")
     if args.no_audio:
         print("Running without saving audio files.")
     else:
@@ -280,7 +278,7 @@ def main():
     total_samples = 0
     for category in categories_to_prepare:
         total_samples += prepare_category(
-            category, dataset, output_dir, with_audio=with_audio, audio_prefix=audio_prefix
+            category, dataset, output_dir, with_audio=with_audio, audio_root=audio_root
         )
 
     # Combine all category variant files into test variant files

--- a/nemo_skills/dataset/numb3rs/prepare.py
+++ b/nemo_skills/dataset/numb3rs/prepare.py
@@ -44,7 +44,11 @@ import soundfile as sf
 from datasets import load_dataset
 from tqdm import tqdm
 
-from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+from nemo_skills.dataset.utils import (
+    DEFAULT_CONTAINER_AUDIO_ROOT,
+    build_container_audio_path,
+    get_container_audio_root,
+)
 
 SYSTEM_MESSAGE = "You are a helpful assistant. /no_think"
 
@@ -74,7 +78,14 @@ def build_messages_with_prompt(audio_metadata, prompt_text):
     return [system_message, user_message]
 
 
-def save_audio_and_format_entry(entry, category, audio_dir, sample_idx, with_audio=True, audio_root="/data"):
+def save_audio_and_format_entry(
+    entry,
+    category,
+    audio_dir,
+    sample_idx,
+    with_audio=True,
+    audio_root=DEFAULT_CONTAINER_AUDIO_ROOT,
+):
     """Format a dataset entry and optionally save audio file.
 
     Returns a base entry dict with audio metadata. Messages are added separately
@@ -136,7 +147,7 @@ def save_audio_and_format_entry(entry, category, audio_dir, sample_idx, with_aud
     return formatted_entry
 
 
-def prepare_category(category, dataset, output_dir, with_audio=True, audio_root="/data"):
+def prepare_category(category, dataset, output_dir, with_audio=True, audio_root=DEFAULT_CONTAINER_AUDIO_ROOT):
     """Prepare a single category from the Numb3rs dataset.
 
     Generates 3 files per category in categories/ subfolder:

--- a/nemo_skills/dataset/numb3rs/prepare.py
+++ b/nemo_skills/dataset/numb3rs/prepare.py
@@ -123,7 +123,9 @@ def save_audio_and_format_entry(
         audio_file_path = audio_dir / audio_filename
         sf.write(str(audio_file_path), audio_array, sampling_rate)
 
-    audio_filepath = build_container_audio_path("numb3rs", "Numb3rs", category, audio_filename, audio_prefix=audio_root)
+    audio_filepath = build_container_audio_path(
+        "numb3rs", "Numb3rs", category, audio_filename, audio_prefix=audio_root
+    )
 
     # Build audio metadata (to be embedded in messages later)
     audio_metadata = {
@@ -288,9 +290,7 @@ def main():
     # Process each category
     total_samples = 0
     for category in categories_to_prepare:
-        total_samples += prepare_category(
-            category, dataset, output_dir, with_audio=with_audio, audio_root=audio_root
-        )
+        total_samples += prepare_category(category, dataset, output_dir, with_audio=with_audio, audio_root=audio_root)
 
     # Combine all category variant files into test variant files
     print("\nCreating combined test files for each variant...")

--- a/nemo_skills/dataset/utils.py
+++ b/nemo_skills/dataset/utils.py
@@ -26,6 +26,8 @@ from urllib.error import URLError
 
 from nemo_skills.evaluation.math_grader import extract_answer
 
+DEFAULT_CONTAINER_AUDIO_ROOT = "/data"
+
 
 def locate(path):
     """Import an object by path using ``::`` or dotted notation.
@@ -96,6 +98,23 @@ def get_dataset_name(dataset):
     if "/" in dataset:
         return Path(dataset).name
     return dataset
+
+
+def get_container_audio_root(audio_prefix: str | None = None) -> str:
+    """Return the in-container root used for generated audio paths.
+
+    ``--audio-prefix`` is the explicit override. ``NEMO_SKILLS_AUDIO_ROOT`` is
+    the process-wide default used by cluster wrappers. ``/data`` matches the
+    standard evaluation mount convention.
+    """
+    return (audio_prefix or os.getenv("NEMO_SKILLS_AUDIO_ROOT", DEFAULT_CONTAINER_AUDIO_ROOT)).rstrip("/")
+
+
+def build_container_audio_path(benchmark: str, *parts: str, audio_prefix: str | None = None) -> str:
+    """Build an in-container audio path to write into prepared JSONL manifests."""
+    root = get_container_audio_root(audio_prefix)
+    path_parts = [benchmark.strip("/"), *(str(part).strip("/") for part in parts)]
+    return "/".join([root, *path_parts])
 
 
 def get_dataset_path(dataset, extra_benchmark_map=None):

--- a/tests/test_audio_path_prefix.py
+++ b/tests/test_audio_path_prefix.py
@@ -110,10 +110,7 @@ def test_asr_leaderboard_audio_prefix(monkeypatch, tmp_path):
         audio_root="/data",
     )
 
-    assert (
-        formatted["messages"][1]["audio"]["path"]
-        == "/data/asr-leaderboard/data/librispeech_clean/sample_001.flac"
-    )
+    assert formatted["messages"][1]["audio"]["path"] == "/data/asr-leaderboard/data/librispeech_clean/sample_001.flac"
     _assert_clean_audio_paths(formatted, "/data/asr-leaderboard/")
 
 
@@ -136,9 +133,7 @@ def test_asr_leaderboard_end_to_end(monkeypatch, tmp_path):
     ]
     monkeypatch.setattr(prepare, "load_dataset", lambda *args, **kwargs: fake_dataset)
 
-    count = prepare.prepare_dataset(
-        "librispeech_clean", tmp_path, with_audio=False, audio_root="/data"
-    )
+    count = prepare.prepare_dataset("librispeech_clean", tmp_path, with_audio=False, audio_root="/data")
 
     assert count == 2
     _assert_clean_audio_paths(tmp_path / "librispeech_clean.jsonl", "/data/asr-leaderboard/")

--- a/tests/test_audio_path_prefix.py
+++ b/tests/test_audio_path_prefix.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+def _stub_audio_prepare_deps(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "latex2sympy2_extended",
+        types.SimpleNamespace(NormalizationConfig=object, normalize_latex=lambda value, **kwargs: value),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "math_verify",
+        types.SimpleNamespace(
+            LatexExtractionConfig=object,
+            StringExtractionConfig=object,
+            parse=lambda *args, **kwargs: [],
+            verify=lambda *args, **kwargs: False,
+        ),
+    )
+    soundfile = types.SimpleNamespace(
+        write=lambda *args, **kwargs: None,
+        info=lambda *args, **kwargs: types.SimpleNamespace(frames=16000, samplerate=16000),
+    )
+    monkeypatch.setitem(sys.modules, "soundfile", soundfile)
+    monkeypatch.setitem(sys.modules, "datasets", types.SimpleNamespace(load_dataset=lambda *args, **kwargs: []))
+    monkeypatch.setitem(sys.modules, "tqdm", types.SimpleNamespace(tqdm=lambda iterable, **kwargs: iterable))
+
+
+def test_container_audio_path_helpers(monkeypatch):
+    _stub_audio_prepare_deps(monkeypatch)
+    from nemo_skills.dataset.utils import build_container_audio_path, get_container_audio_root
+
+    assert get_container_audio_root("/dataset/") == "/dataset"
+    monkeypatch.setenv("NEMO_SKILLS_AUDIO_ROOT", "/mnt/audio")
+    assert get_container_audio_root() == "/mnt/audio"
+    assert (
+        build_container_audio_path("asr-leaderboard", "data", "sample.flac", audio_prefix="/data/")
+        == "/data/asr-leaderboard/data/sample.flac"
+    )
+
+
+def test_asr_leaderboard_audio_prefix(monkeypatch, tmp_path):
+    _stub_audio_prepare_deps(monkeypatch)
+    prepare = importlib.import_module("nemo_skills.dataset.asr-leaderboard.prepare")
+    entry = {
+        "id": "sample/001",
+        "text": "hello world",
+        "audio": {"array": [0.0] * 1600, "sampling_rate": 16000},
+    }
+
+    formatted = prepare.save_audio_and_format_entry(
+        entry,
+        dataset_name="librispeech_clean",
+        audio_dir=tmp_path,
+        sample_idx=0,
+        with_audio=False,
+        audio_root="/data",
+    )
+
+    assert (
+        formatted["messages"][1]["audio"]["path"]
+        == "/data/asr-leaderboard/data/librispeech_clean/sample_001.flac"
+    )
+
+
+def test_fleurs_audio_prefix(monkeypatch, tmp_path):
+    _stub_audio_prepare_deps(monkeypatch)
+    module_path = tmp_path / "fleurs.py"
+    module_path.write_text(
+        "_FLEURS_LANG = {'en_us'}\n"
+        "_FLEURS_LANG_TO_LONG = {'en_us': 'English'}\n"
+        "_FLEURS_LANG_TO_GROUP = {'en_us': 'western'}\n"
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        types.SimpleNamespace(hf_hub_download=lambda **kwargs: str(module_path)),
+    )
+    sys.modules.pop("nemo_skills.dataset.fleurs.prepare", None)
+    prepare = importlib.import_module("nemo_skills.dataset.fleurs.prepare")
+
+    assert prepare.get_container_audio_path("en_us", "audio.wav", audio_root="/data") == (
+        "/data/fleurs/audio/en_us/audio.wav"
+    )
+
+
+def test_covost2_audio_prefix(monkeypatch):
+    _stub_audio_prepare_deps(monkeypatch)
+    prepare = importlib.import_module("nemo_skills.dataset.covost2.prepare")
+
+    assert prepare.get_container_audio_path("fr", "test", "common_voice_fr_123", audio_root="/data") == (
+        "/data/covost2/audio/fr/test/common_voice_fr_123.wav"
+    )
+
+
+def test_librispeech_pc_audio_prefix(monkeypatch, tmp_path):
+    _stub_audio_prepare_deps(monkeypatch)
+    prepare = importlib.import_module("nemo_skills.dataset.librispeech-pc.prepare")
+    manifest = tmp_path / "test-clean.json"
+    manifest.write_text(
+        '{"audio_filepath": "LibriSpeech/test-clean/1089/134686/1089-134686-0000.flac", "text": "Hello world."}\n'
+    )
+
+    count = prepare.process_split("test-clean", tmp_path, tmp_path, with_audio=False, audio_root="/data")
+
+    assert count == 1
+    row = (tmp_path / "test-clean.jsonl").read_text()
+    assert "/data/librispeech-pc/LibriSpeech/test-clean/1089/134686/1089-134686-0000.flac" in row
+
+
+def test_contextasr_audio_prefix(monkeypatch):
+    _stub_audio_prepare_deps(monkeypatch)
+    prepare = importlib.import_module("nemo_skills.dataset.contextasr-bench.prepare")
+    sample = {
+        "audio": "audio/ContextASR-Speech/English/sample.wav",
+        "duration": 1.25,
+        "entity_list": ["Aspirin"],
+        "domain_label": "Medical",
+        "text": "take aspirin daily",
+        "uniq_id": "sample",
+    }
+
+    assert prepare.resolve_audio_prefix("/data") == "/data/contextasr-bench"
+    monkeypatch.setenv("NEMO_SKILLS_AUDIO_ROOT", "/mnt/audio")
+    assert prepare.resolve_audio_prefix() == "/mnt/audio/contextasr-bench"
+
+    formatted = prepare.format_entry(sample, "fine", "/data/contextasr-bench")
+
+    assert formatted["audio_filepath"] == "/data/contextasr-bench/audio/ContextASR-Speech/English/sample.wav"
+    assert formatted["messages"][0]["audio"]["path"] == (
+        "/data/contextasr-bench/audio/ContextASR-Speech/English/sample.wav"
+    )

--- a/tests/test_audio_path_prefix.py
+++ b/tests/test_audio_path_prefix.py
@@ -13,9 +13,45 @@
 # limitations under the License.
 
 import importlib
+import json
 import sys
 import types
 from pathlib import Path
+
+AUDIO_EXTS = (".wav", ".flac", ".mp3", ".ogg", ".opus")
+
+
+def _walk_strings(value):
+    """Yield every string leaf in a nested JSON-style value."""
+    if isinstance(value, dict):
+        for v in value.values():
+            yield from _walk_strings(v)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_strings(item)
+    elif isinstance(value, str):
+        yield value
+
+
+def _assert_clean_audio_paths(payload, expected_prefix):
+    """Assert no stale `/dataset/` paths and every audio path uses the expected prefix.
+
+    `payload` may be a dict (single record), a list of dicts, or a `Path` to a JSONL file.
+    """
+    if isinstance(payload, Path):
+        records = [json.loads(line) for line in payload.read_text().splitlines() if line.strip()]
+    elif isinstance(payload, list):
+        records = payload
+    else:
+        records = [payload]
+
+    for idx, record in enumerate(records):
+        for s in _walk_strings(record):
+            assert "/dataset/" not in s, f"record {idx}: stale '/dataset/' substring in {s!r}"
+            if s.endswith(AUDIO_EXTS):
+                assert s.startswith(expected_prefix), (
+                    f"record {idx}: audio path {s!r} does not start with {expected_prefix!r}"
+                )
 
 
 def _stub_audio_prepare_deps(monkeypatch):
@@ -78,10 +114,38 @@ def test_asr_leaderboard_audio_prefix(monkeypatch, tmp_path):
         formatted["messages"][1]["audio"]["path"]
         == "/data/asr-leaderboard/data/librispeech_clean/sample_001.flac"
     )
+    _assert_clean_audio_paths(formatted, "/data/asr-leaderboard/")
 
 
-def test_fleurs_audio_prefix(monkeypatch, tmp_path):
+def test_asr_leaderboard_end_to_end(monkeypatch, tmp_path):
+    """Run prepare_dataset against a stubbed HF source and assert the full JSONL is clean."""
     _stub_audio_prepare_deps(monkeypatch)
+    prepare = importlib.import_module("nemo_skills.dataset.asr-leaderboard.prepare")
+
+    fake_dataset = [
+        {
+            "id": "sample/001",
+            "text": "hello world",
+            "audio": {"array": [0.0] * 1600, "sampling_rate": 16000},
+        },
+        {
+            "id": "sample/002",
+            "text": "foo bar",
+            "audio": {"array": [0.0] * 1600, "sampling_rate": 16000},
+        },
+    ]
+    monkeypatch.setattr(prepare, "load_dataset", lambda *args, **kwargs: fake_dataset)
+
+    count = prepare.prepare_dataset(
+        "librispeech_clean", tmp_path, with_audio=False, audio_root="/data"
+    )
+
+    assert count == 2
+    _assert_clean_audio_paths(tmp_path / "librispeech_clean.jsonl", "/data/asr-leaderboard/")
+
+
+def _load_fleurs_prepare(monkeypatch, tmp_path):
+    """Stub HF download for the FLEURS metadata module and return the prepare module."""
     module_path = tmp_path / "fleurs.py"
     module_path.write_text(
         "_FLEURS_LANG = {'en_us'}\n"
@@ -94,11 +158,53 @@ def test_fleurs_audio_prefix(monkeypatch, tmp_path):
         types.SimpleNamespace(hf_hub_download=lambda **kwargs: str(module_path)),
     )
     sys.modules.pop("nemo_skills.dataset.fleurs.prepare", None)
-    prepare = importlib.import_module("nemo_skills.dataset.fleurs.prepare")
+    return importlib.import_module("nemo_skills.dataset.fleurs.prepare")
+
+
+def test_fleurs_audio_prefix(monkeypatch, tmp_path):
+    _stub_audio_prepare_deps(monkeypatch)
+    prepare = _load_fleurs_prepare(monkeypatch, tmp_path)
 
     assert prepare.get_container_audio_path("en_us", "audio.wav", audio_root="/data") == (
         "/data/fleurs/audio/en_us/audio.wav"
     )
+
+
+def test_fleurs_end_to_end(monkeypatch, tmp_path):
+    """Run prepare_fleurs against a stubbed loader and assert the full JSONL is clean."""
+    _stub_audio_prepare_deps(monkeypatch)
+    prepare = _load_fleurs_prepare(monkeypatch, tmp_path)
+
+    fake_rows = [
+        {
+            "id": 1,
+            "wav_filename": "001.wav",
+            "transcription": "hello world",
+            "raw_transcription": "Hello, world.",
+            "audio": {"array": [0.0] * 1600, "sampling_rate": 16000},
+        },
+        {
+            "id": 2,
+            "wav_filename": "002.wav",
+            "transcription": "foo bar",
+            "raw_transcription": "Foo bar.",
+            "audio": {"array": [0.0] * 1600, "sampling_rate": 16000},
+        },
+    ]
+    monkeypatch.setattr(prepare, "load_fleurs", lambda locale, split, local_dir: list(fake_rows))
+
+    data_dir = tmp_path / "fleurs"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    prepare.prepare_fleurs(
+        data_dir=data_dir,
+        split="test",
+        languages=["en_us"],
+        no_audio=True,
+        task_type="ASR",
+        audio_root="/data",
+    )
+
+    _assert_clean_audio_paths(data_dir / "test-asr.jsonl", "/data/fleurs/")
 
 
 def test_covost2_audio_prefix(monkeypatch):
@@ -108,6 +214,40 @@ def test_covost2_audio_prefix(monkeypatch):
     assert prepare.get_container_audio_path("fr", "test", "common_voice_fr_123", audio_root="/data") == (
         "/data/covost2/audio/fr/test/common_voice_fr_123.wav"
     )
+
+
+def test_covost2_end_to_end(monkeypatch, tmp_path):
+    """Run prepare_covost2 ASR with fixture WAVs and TSV; assert the full JSONL is clean."""
+    _stub_audio_prepare_deps(monkeypatch)
+    prepare = importlib.import_module("nemo_skills.dataset.covost2.prepare")
+
+    cv_data_dir = tmp_path / "cv"
+    audio_split_dir = cv_data_dir / "fr" / "test"
+    audio_split_dir.mkdir(parents=True, exist_ok=True)
+    (audio_split_dir / "common_voice_fr_001.wav").touch()
+    (audio_split_dir / "common_voice_fr_002.wav").touch()
+
+    validated_tsv = tmp_path / "validated.tsv"
+    validated_tsv.write_text(
+        "path\tsplit\tlang\tsentence\n"
+        "common_voice_fr_001.wav\ttest\tfr\tbonjour le monde\n"
+        "common_voice_fr_002.wav\ttest\tfr\tau revoir\n"
+    )
+
+    data_dir = tmp_path / "out"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    prepare.prepare_covost2(
+        data_dir=data_dir,
+        split="test",
+        languages=["fr"],
+        cv_data_dir=cv_data_dir,
+        validated_tsv=validated_tsv,
+        task_type="ASR",
+        audio_root="/data",
+    )
+
+    _assert_clean_audio_paths(data_dir / "test-asr.jsonl", "/data/covost2/")
 
 
 def test_librispeech_pc_audio_prefix(monkeypatch, tmp_path):
@@ -123,6 +263,106 @@ def test_librispeech_pc_audio_prefix(monkeypatch, tmp_path):
     assert count == 1
     row = (tmp_path / "test-clean.jsonl").read_text()
     assert "/data/librispeech-pc/LibriSpeech/test-clean/1089/134686/1089-134686-0000.flac" in row
+    _assert_clean_audio_paths(tmp_path / "test-clean.jsonl", "/data/librispeech-pc/")
+
+
+def test_audiobench_audio_prefix(monkeypatch):
+    _stub_audio_prepare_deps(monkeypatch)
+    prepare = importlib.import_module("nemo_skills.dataset.audiobench.prepare")
+    entry = {
+        "instruction": "Transcribe this.",
+        "reference": "hello",
+        "task_type": "asr",
+    }
+
+    formatted = prepare.create_manifest_entry(
+        sample=entry,
+        audio_filename="sample.wav",
+        duration=1.0,
+        dataset_name="librispeech_test_clean",
+        sample_id=0,
+        category="nonjudge",
+        audio_root="/data",
+    )
+
+    assert formatted["audio_path"] == ["/data/audiobench/nonjudge/audio/librispeech_test_clean/sample.wav"]
+    assert formatted["messages"][1]["audio"]["path"] == (
+        "/data/audiobench/nonjudge/audio/librispeech_test_clean/sample.wav"
+    )
+    _assert_clean_audio_paths(formatted, "/data/audiobench/")
+
+
+def test_musan_audio_prefix(monkeypatch):
+    _stub_audio_prepare_deps(monkeypatch)
+    prepare = importlib.import_module("nemo_skills.dataset.musan.prepare")
+
+    formatted = prepare.create_manifest_entry(
+        audio_filename="noise.wav",
+        duration=1.0,
+        category="noise",
+        sample_id=0,
+        label="noise",
+        audio_root="/data",
+    )
+
+    assert formatted["audio_path"] == ["/data/musan/noise/audio/noise.wav"]
+    assert formatted["messages"][1]["audio"]["path"] == "/data/musan/noise/audio/noise.wav"
+    _assert_clean_audio_paths(formatted, "/data/musan/")
+
+
+def test_numb3rs_audio_prefix(monkeypatch, tmp_path):
+    _stub_audio_prepare_deps(monkeypatch)
+    prepare = importlib.import_module("nemo_skills.dataset.numb3rs.prepare")
+    entry = {
+        "original_text": "$12.00",
+        "text": "twelve dollars",
+        "file_name": "MONEY/MONEY_001.wav",
+        "duration": 1.0,
+        "audio": {"array": [0.0] * 1600, "sampling_rate": 16000},
+    }
+
+    formatted = prepare.save_audio_and_format_entry(
+        entry,
+        category="MONEY",
+        audio_dir=tmp_path,
+        sample_idx=0,
+        with_audio=False,
+        audio_root="/data",
+    )
+
+    assert formatted["audio_filepath"] == "/data/numb3rs/Numb3rs/MONEY/MONEY_001.wav"
+    assert formatted["audio_metadata"]["path"] == "/data/numb3rs/Numb3rs/MONEY/MONEY_001.wav"
+    _assert_clean_audio_paths(formatted, "/data/numb3rs/")
+
+
+def test_mmau_pro_audio_prefix(monkeypatch):
+    """Cover the actual MMAU-Pro audio_path shape.
+
+    The HF dataset records ``data/<uuid>.wav`` (the ``data/`` is the
+    subdirectory in the dataset's zip layout), and after ``cp -r`` the
+    file lives at ``<data_dir>/mmau-pro/data/<uuid>.wav``. The JSONL path
+    must mirror that on-disk layout, so we keep the ``data/`` segment
+    rather than stripping it.
+    """
+    _stub_audio_prepare_deps(monkeypatch)
+    prepare = importlib.import_module("nemo_skills.dataset.mmau-pro.prepare")
+    entry = {
+        "answer": "A",
+        "question": "What do you hear?",
+        "choices": ["speech", "music"],
+        "category": "closed_form",
+        "audio_path": ["data/c93e3644-5227-4710-b27b-5c46750afbff.wav", "/already/absolute.wav"],
+    }
+
+    formatted = prepare.format_entry(entry, with_audio=True, audio_root="/data")
+
+    assert formatted["audio_path"] == [
+        "/data/mmau-pro/data/c93e3644-5227-4710-b27b-5c46750afbff.wav",
+        "/data/mmau-pro/already/absolute.wav",
+    ]
+    assert formatted["messages"][0]["audios"][0]["path"] == (
+        "/data/mmau-pro/data/c93e3644-5227-4710-b27b-5c46750afbff.wav"
+    )
 
 
 def test_contextasr_audio_prefix(monkeypatch):


### PR DESCRIPTION
## Summary
- Add shared helpers for writing prepared audio manifests with in-container paths rooted at `/data` by default.
- Thread `--audio-prefix` through audio benchmark prepare scripts so manifests consistently use `/data/<benchmark>/...` instead of mixed `/dataset` or host paths.
- Document the prepare/eval mount contract and update stale examples to use `/data`.

## Behavior change
- `contextasr-bench --audio-prefix` now means the global in-container audio root. For example, use `--audio-prefix /data`; the script appends `contextasr-bench` itself.

## Known existing issue / TODO
- Real Draco prep surfaced a pre-existing `numb3rs/prepare.py` issue: the current `nvidia/Numb3rs` test split rows do not have a `category` key, so full real-data Numb3rs prep fails with `KeyError: 'category'`. This is unrelated to the audio-path change and remains tracked as a separate TODO; this PR only covers the path convention.

## Test plan
- `python -m pytest tests/test_audio_path_prefix.py -q` (`13 passed`)
- `python -m compileall -q` on changed Python files
- `git diff --check`
- Real prepared-data checks on Draco for completed benchmarks: ASR leaderboard, CoVoST2, and MMAU-Pro paths resolve under `/data` with no stale `/dataset` paths.
- Not run: `ruff` / `pre-commit` locally because neither command is installed in the active environment.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized "Audio path convention" guidance, clarified --audio-prefix behavior and fallback to environment or /data, and updated examples to use /data.

* **New Features**
  * Added consistent, configurable in-container audio-root handling across dataset prepare tools and a shared audio-path helper.
  * Added --audio-prefix option to dataset CLIs; manifests now reference consistent container-relative audio locations.

* **Tests**
  * Added tests validating manifest audio paths are clean and correctly prefixed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->