### PR TITLE
Make python tool timeout in description customizable

### DIFF
--- a/nemo_skills/mcp/servers/python_tool.py
+++ b/nemo_skills/mcp/servers/python_tool.py
@@ -43,18 +43,24 @@ mcp = FastMCP(name="python_tool")
 # Initialized from config in main()
 sandbox = None
 
-# TODO: how should we control timeout in description?
-description = (
-    "Call this function to execute Python code in a stateful Jupyter notebook environment. "
-    "Python will respond with the output of the execution or time out after 120.0 seconds."
-)
+DEFAULT_EXEC_TIMEOUT_S = 10
+
+
+def get_python_tool_description(exec_timeout_s: float = DEFAULT_EXEC_TIMEOUT_S) -> str:
+    return (
+        "Call this function to execute Python code in a stateful Jupyter notebook environment. "
+        f"Python will respond with the output of the execution or time out after {exec_timeout_s:.1f} seconds."
+    )
+
+
+description = get_python_tool_description()
 
 
 @mcp.tool(name="stateful_python_code_exec", description=description)
 async def stateful_python_code_exec(
     code: Annotated[str, Field(description="Code to execute")],
     session_id: Annotated[str | None, Field(description="Session id for session persistence")] = None,
-    timeout: Annotated[float, Field(description="Time in seconds to allow the job to run")] = 10,
+    timeout: Annotated[float, Field(description="Time in seconds to allow the job to run")] = DEFAULT_EXEC_TIMEOUT_S,
 ) -> ExecutionResult:
     language = "ipython"
     try:
@@ -105,7 +111,7 @@ def main():
 
 
 class PythonTool(MCPClientTool):
-    def __init__(self) -> None:
+    def __init__(self, exec_timeout_s: float = DEFAULT_EXEC_TIMEOUT_S) -> None:
         super().__init__()
         # Defaults for stdio Python MCP using explicit client class
         self.apply_config_updates(
@@ -120,10 +126,20 @@ class PythonTool(MCPClientTool):
                 # use explicit Hydra connector built from full context by default
                 "init_hook": "hydra",
                 # execution-specific default
-                "exec_timeout_s": 10,
+                "exec_timeout_s": exec_timeout_s,
             }
         )
         self.requests_to_sessions = defaultdict(lambda: None)
+
+    def _description(self) -> str:
+        return get_python_tool_description(self._config.get("exec_timeout_s", DEFAULT_EXEC_TIMEOUT_S))
+
+    async def list_tools(self) -> List[Dict[str, Any]]:
+        tools = await super().list_tools()
+        return [
+            {**tool, "description": self._description()} if tool.get("name") == "stateful_python_code_exec" else tool
+            for tool in tools
+        ]
 
     async def execute(self, tool_name: str, arguments: Dict[str, Any], extra_args: Dict[str, Any] | None = None):
         # Ensure timeout is sent via extra_args (post-sanitize), not in main arguments
@@ -131,7 +147,7 @@ class PythonTool(MCPClientTool):
         # TODO: error handling?
         request_id = extra_args.pop("request_id")
         merged_extra = dict(extra_args or {})
-        merged_extra.setdefault("timeout", self._config.get("exec_timeout_s", 10))
+        merged_extra.setdefault("timeout", self._config.get("exec_timeout_s", DEFAULT_EXEC_TIMEOUT_S))
         merged_extra["session_id"] = self.requests_to_sessions[request_id]
         result = await self._client.call_tool(tool=tool_name, args=arguments, extra_args=merged_extra)
         self.requests_to_sessions[request_id] = result["session_id"]
@@ -159,11 +175,11 @@ class DirectPythonTool(Tool):
         tool_modules=["nemo_skills.mcp.servers.python_tool::DirectPythonTool"]
     """
 
-    def __init__(self) -> None:
+    def __init__(self, exec_timeout_s: float = DEFAULT_EXEC_TIMEOUT_S) -> None:
         self._config: Dict[str, Any] = {
             # Same keys/defaults as PythonTool (minus MCP-specific: client, client_params, init_hook)
             "hide_args": {"stateful_python_code_exec": ["session_id", "timeout"]},
-            "exec_timeout_s": 10,
+            "exec_timeout_s": exec_timeout_s,
             "sandbox": {},
         }
         self._sandbox = None
@@ -193,7 +209,7 @@ class DirectPythonTool(Tool):
         return [
             {
                 "name": "stateful_python_code_exec",
-                "description": description,
+                "description": get_python_tool_description(self._config.get("exec_timeout_s", DEFAULT_EXEC_TIMEOUT_S)),
                 "input_schema": {
                     "type": "object",
                     "properties": {
@@ -213,7 +229,7 @@ class DirectPythonTool(Tool):
 
         extra_args = dict(extra_args or {})
         request_id = extra_args.pop("request_id", None)
-        timeout = extra_args.get("timeout", self._config.get("exec_timeout_s", 10))
+        timeout = extra_args.get("timeout", self._config.get("exec_timeout_s", DEFAULT_EXEC_TIMEOUT_S))
         session_id = self.requests_to_sessions[request_id] if request_id is not None else None
 
         # Validate required `code` argument. The MCP path gets this via Pydantic at the FastMCP

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -929,6 +929,108 @@ def _direct_tool_with_stub(stub):
     return tool
 
 
+def test_python_tools_accept_exec_timeout_argument():
+    from nemo_skills.mcp.servers.python_tool import DEFAULT_EXEC_TIMEOUT_S, DirectPythonTool, PythonTool
+
+    assert PythonTool().default_config()["exec_timeout_s"] == DEFAULT_EXEC_TIMEOUT_S
+    assert DirectPythonTool().default_config()["exec_timeout_s"] == DEFAULT_EXEC_TIMEOUT_S
+    assert PythonTool(exec_timeout_s=42).default_config()["exec_timeout_s"] == 42
+    assert DirectPythonTool(exec_timeout_s=42).default_config()["exec_timeout_s"] == 42
+
+
+@pytest.mark.asyncio
+async def test_python_tool_description_uses_exec_timeout_override():
+    from nemo_skills.mcp.servers.python_tool import PythonTool
+
+    class FakeClient:
+        async def list_tools(self):
+            return [
+                {
+                    "name": "stateful_python_code_exec",
+                    "description": "stale server description",
+                    "input_schema": {"type": "object", "properties": {"code": {"type": "string"}}},
+                }
+            ]
+
+    tool = PythonTool()
+    tool.configure(
+        overrides={"client": FakeClient, "client_params": {}, "exec_timeout_s": 37, "init_hook": None},
+        context={},
+    )
+
+    tools = await tool.list_tools()
+
+    assert "37.0 seconds" in tools[0]["description"]
+    assert "10.0 seconds" not in tools[0]["description"]
+
+
+@pytest.mark.asyncio
+async def test_python_tool_uses_exec_timeout_argument():
+    from nemo_skills.mcp.servers.python_tool import PythonTool
+
+    class FakeClient:
+        def __init__(self):
+            self.extra_args = None
+
+        async def list_tools(self):
+            return [
+                {
+                    "name": "stateful_python_code_exec",
+                    "description": "stale server description",
+                    "input_schema": {"type": "object", "properties": {"code": {"type": "string"}}},
+                }
+            ]
+
+        async def call_tool(self, tool, args, extra_args=None):
+            self.extra_args = extra_args
+            return {"session_id": "session", "output_dict": {"stdout": "done\n", "stderr": ""}}
+
+    fake_client = FakeClient()
+    tool = PythonTool(exec_timeout_s=42)
+    tool._client = fake_client
+
+    result = await tool.execute(
+        "stateful_python_code_exec",
+        {"code": "print('done')"},
+        extra_args={"request_id": "timeout-arg"},
+    )
+
+    assert result == "done"
+    assert fake_client.extra_args["timeout"] == 42
+
+    tools = await tool.list_tools()
+    assert "42.0 seconds" in tools[0]["description"]
+    assert "10.0 seconds" not in tools[0]["description"]
+
+
+@pytest.mark.asyncio
+async def test_direct_python_tool_uses_exec_timeout_argument():
+    from nemo_skills.mcp.servers.python_tool import DirectPythonTool
+
+    seen = {}
+
+    async def record_execute(code, language, timeout, session_id):
+        seen["timeout"] = timeout
+        return {"process_status": "completed", "stdout": "done\n", "stderr": ""}, session_id
+
+    tool = DirectPythonTool(exec_timeout_s=42)
+    tool._sanitize_keys = {"stateful_python_code_exec": {"session_id", "timeout"}}
+    tool._sandbox = _StubSandbox(execute_code=record_execute)
+
+    tools = await tool.list_tools()
+    assert "42.0 seconds" in tools[0]["description"]
+    assert "10.0 seconds" not in tools[0]["description"]
+
+    result = await tool.execute(
+        "stateful_python_code_exec",
+        {"code": "print('done')"},
+        extra_args={"request_id": "timeout-arg"},
+    )
+
+    assert result == "done"
+    assert seen["timeout"] == 42
+
+
 @pytest.mark.asyncio
 async def test_direct_python_tool_missing_code_returns_error_not_raise():
     """A tool call without 'code' must return a sandbox-shaped error, not crash the run."""


### PR DESCRIPTION
Also changes default to align description with actual default code behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Python code execution tools now support fully configurable execution timeouts. Users can specify custom maximum execution durations when creating tools, with improved consistency through a unified default timeout approach working across all tool implementations.

* **Tests**
  * Added comprehensive test coverage validating timeout configuration, validation, and correct propagation through tool listing and execution workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Skills/pull/1440)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->