### PR TITLE
Allow separate sbatch_kwargs for judge / summarize_results

### DIFF
--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -46,6 +46,12 @@ class SingleNodeMode(str, enum.Enum):
     parallel = "parallel"
 
 
+def _resolve_child_sbatch_kwargs(sbatch_kwargs, child_sbatch_kwargs):
+    if child_sbatch_kwargs is None:
+        return sbatch_kwargs
+    return parse_kwargs(child_sbatch_kwargs)
+
+
 def _create_llm_judge_tasks(
     ctx,
     expname,
@@ -327,6 +333,16 @@ def eval(
         "",
         help="Additional sbatch kwargs to pass to the job scheduler. Values should be provided as a JSON string or as a `dict` if invoking from code.",
     ),
+    judge_sbatch_kwargs: str = typer.Option(
+        None,
+        help="Additional sbatch kwargs for judge tasks. Defaults to sbatch_kwargs when unset. "
+        "Values should be provided as a JSON string or as a `dict` if invoking from code.",
+    ),
+    summarize_sbatch_kwargs: str = typer.Option(
+        None,
+        help="Additional sbatch kwargs for summarize-results tasks. Defaults to sbatch_kwargs when unset. "
+        "Values should be provided as a JSON string or as a `dict` if invoking from code.",
+    ),
     extra_benchmark_map: str = typer.Option(
         None,
         help="Path to a JSON file mapping benchmark short names to directory paths. "
@@ -464,6 +480,8 @@ def eval(
     )
 
     sbatch_kwargs = parse_kwargs(sbatch_kwargs, exclusive=exclusive, qos=qos, time_min=time_min)
+    judge_sbatch_kwargs = _resolve_child_sbatch_kwargs(sbatch_kwargs, judge_sbatch_kwargs)
+    summarize_sbatch_kwargs = _resolve_child_sbatch_kwargs(sbatch_kwargs, summarize_sbatch_kwargs)
 
     has_tasks = False
     job_id_to_tasks = {}
@@ -613,6 +631,7 @@ def eval(
                     commands=group0_components,
                     hardware=HardwareConfig(
                         partition=partition,
+                        account=account,
                         num_gpus=group_gpus,
                         num_nodes=group_nodes,
                         num_tasks=group_tasks,
@@ -640,6 +659,7 @@ def eval(
                         ],
                         hardware=HardwareConfig(
                             partition=partition,
+                            account=account,
                             num_gpus=int(server_gpus_list[model_idx]),
                             num_nodes=int(server_nodes_list[model_idx]),
                             num_tasks=int(srv.num_tasks),
@@ -753,7 +773,7 @@ def eval(
                     _task_dependencies=_task_dependencies,
                     installation_command=installation_command,
                     skip_hf_home_check=skip_hf_home_check,
-                    sbatch_kwargs=sbatch_kwargs,
+                    sbatch_kwargs=judge_sbatch_kwargs,
                 )
             else:
                 # Use default LLM judge pipeline
@@ -783,7 +803,7 @@ def eval(
                     reuse_code=reuse_code,
                     exclusive=exclusive,
                     installation_command=installation_command,
-                    sbatch_kwargs=sbatch_kwargs,
+                    sbatch_kwargs=judge_sbatch_kwargs,
                     exp=exp,
                     cluster_config=cluster_config,
                     dependent_tasks=dependent_tasks,
@@ -850,12 +870,13 @@ def eval(
                     run_after=run_after,
                     reuse_code_exp=reuse_code_exp,
                     reuse_code=reuse_code,
+                    account=account,
                     task_dependencies=(
                         dependent_tasks if cluster_config["executor"] == "slurm" else all_tasks + _task_dependencies
                     ),
                     installation_command=installation_command,
                     skip_hf_home_check=skip_hf_home_check,
-                    sbatch_kwargs=sbatch_kwargs,
+                    sbatch_kwargs=summarize_sbatch_kwargs,
                 )
                 all_tasks.append(summarize_task)
                 if benchmark_args.benchmark_group:
@@ -884,12 +905,13 @@ def eval(
                     run_after=run_after,
                     reuse_code_exp=reuse_code_exp,
                     reuse_code=reuse_code,
+                    account=account,
                     task_dependencies=(
                         group_tasks[group] if cluster_config["executor"] == "slurm" else all_tasks + _task_dependencies
                     ),
                     installation_command=installation_command,
                     skip_hf_home_check=skip_hf_home_check,
-                    sbatch_kwargs=sbatch_kwargs,
+                    sbatch_kwargs=summarize_sbatch_kwargs,
                 )
                 all_tasks.append(score_task)
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -17,12 +17,22 @@ import os
 import shlex
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import nemo_skills.pipeline.utils.scripts.eval as eval_scripts
+from nemo_skills.pipeline import eval as eval_pipeline
 from nemo_skills.pipeline.utils import eval as eval_utils
 from nemo_skills.pipeline.utils.scripts import EvalClientScript
+
+
+class FakeExp:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
 
 
 def test_eval_client_script_parallel_fails_if_any_unit_fails(monkeypatch, tmp_path):
@@ -104,6 +114,133 @@ def test_prepare_eval_commands_propagates_cli_with_sandbox_to_generation_cmd(mon
     client_script.inline()
 
     assert captured["with_sandbox"] is True
+
+
+def test_resolve_child_sbatch_kwargs_inherits_or_overrides():
+    parent = {"segment": 4, "qos": "batch"}
+
+    assert eval_pipeline._resolve_child_sbatch_kwargs(parent, None) is parent
+    assert eval_pipeline._resolve_child_sbatch_kwargs(parent, {}) is None
+    assert eval_pipeline._resolve_child_sbatch_kwargs(parent, '{"segment": 1}') == {"segment": 1}
+
+
+def _patch_eval_for_sbatch_tests(monkeypatch, benchmark_args):
+    cluster_config = {"executor": "slurm", "containers": {"nemo-skills": "nemo-skills-container"}}
+
+    monkeypatch.setattr(eval_pipeline.pipeline_utils, "get_cluster_config", lambda *args, **kwargs: cluster_config)
+    monkeypatch.setattr(eval_pipeline.pipeline_utils, "resolve_mount_paths", lambda config, *args, **kwargs: config)
+    monkeypatch.setattr(eval_pipeline.pipeline_utils, "get_env_variables", lambda config: {})
+    monkeypatch.setattr(
+        eval_pipeline.pipeline_utils,
+        "check_mounts",
+        lambda config, log_dir, mount_map, check_mounted_paths: (
+            next(iter(mount_map.keys())),
+            list(mount_map.keys())[1],
+            log_dir,
+        ),
+    )
+    monkeypatch.setattr(eval_pipeline.pipeline_utils, "get_exp", lambda *args, **kwargs: FakeExp())
+    monkeypatch.setattr(eval_pipeline.pipeline_utils, "run_exp", lambda *args, **kwargs: None)
+    monkeypatch.setattr(eval_pipeline, "prepare_eval_commands", lambda **kwargs: ({"gsm8k": benchmark_args()}, []))
+
+
+@pytest.mark.parametrize(
+    "summarize_sbatch_kwargs,expected_sbatch_kwargs",
+    [
+        (None, {"segment": 4, "qos": "main"}),
+        ({}, None),
+        ({"segment": 1}, {"segment": 1}),
+    ],
+)
+def test_eval_summarize_sbatch_kwargs_and_account(
+    monkeypatch, tmp_path, summarize_sbatch_kwargs, expected_sbatch_kwargs
+):
+    def benchmark_args():
+        return eval_utils.BenchmarkArgs(
+            name="gsm8k",
+            input_file="/tmp/gsm8k.jsonl",
+            generation_args="",
+            judge_args="",
+            judge_pipeline_args={},
+            requires_sandbox=False,
+            keep_mounts_for_sandbox=False,
+            generation_module="nemo_skills.inference.generate",
+            num_samples=0,
+            num_chunks=None,
+            eval_subfolder="eval-results/gsm8k",
+            metrics_type="math",
+        )
+
+    _patch_eval_for_sbatch_tests(monkeypatch, benchmark_args)
+    captured = []
+
+    def fake_add_task(*args, **kwargs):
+        captured.append(kwargs)
+        return f"task-{len(captured)}"
+
+    monkeypatch.setattr(eval_pipeline.pipeline_utils, "add_task", fake_add_task)
+
+    eval_pipeline.eval(
+        ctx=SimpleNamespace(args=[]),
+        cluster="test-cluster",
+        output_dir=str(tmp_path),
+        benchmarks="gsm8k",
+        model="model",
+        server_type="openai",
+        server_address="http://server",
+        account="acct",
+        sbatch_kwargs={"segment": 4, "qos": "main"},
+        summarize_sbatch_kwargs=summarize_sbatch_kwargs,
+    )
+
+    assert len(captured) == 1
+    assert captured[0]["account"] == "acct"
+    assert captured[0]["sbatch_kwargs"] == expected_sbatch_kwargs
+
+
+def test_eval_judge_sbatch_kwargs_override(monkeypatch, tmp_path):
+    def benchmark_args():
+        return eval_utils.BenchmarkArgs(
+            name="gsm8k",
+            input_file="/tmp/gsm8k.jsonl",
+            generation_args="",
+            judge_args="++judge=True",
+            judge_pipeline_args={},
+            requires_sandbox=False,
+            keep_mounts_for_sandbox=False,
+            generation_module="nemo_skills.inference.generate",
+            num_samples=0,
+            num_chunks=None,
+            eval_subfolder="tmp-eval-results/gsm8k",
+            metrics_type="math",
+        )
+
+    _patch_eval_for_sbatch_tests(monkeypatch, benchmark_args)
+    captured = {}
+
+    def fake_generate(**kwargs):
+        captured["sbatch_kwargs"] = kwargs["sbatch_kwargs"]
+        captured["account"] = kwargs["account"]
+        return ["judge-task"]
+
+    monkeypatch.setattr(eval_pipeline, "_generate", fake_generate)
+
+    eval_pipeline.eval(
+        ctx=SimpleNamespace(args=[]),
+        cluster="test-cluster",
+        output_dir=str(tmp_path),
+        benchmarks="gsm8k",
+        model="model",
+        server_type="openai",
+        server_address="http://server",
+        account="acct",
+        sbatch_kwargs={"segment": 4, "qos": "main"},
+        judge_sbatch_kwargs={"segment": 1},
+        auto_summarize_results=False,
+    )
+
+    assert captured["account"] == "acct"
+    assert captured["sbatch_kwargs"] == {"segment": 1}
 
 
 @pytest.mark.timeout(300)


### PR DESCRIPTION
This is useful when setting segment, e.g. if main generation uses 2 nodes but judge 1, currently code fails if {segment: 2} is used in sbatch_kwargs. New parameters allow to override that.

Also fix a bug with summarize_results not propagating account parameter. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--judge-sbatch-kwargs` and `--summarize-sbatch-kwargs` CLI options for configuring separate Slurm batch job parameters at the judge and summarize-results pipeline stages, enabling independent resource allocation per stage while maintaining default inheritance behavior.

* **Tests**
  * New tests validate Slurm configuration inheritance and overrides across evaluation stages, ensuring proper configuration propagation and account preservation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Skills/pull/1441)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->