### PR TITLE
Enable local gym packaging to work by default

### DIFF
--- a/nemo_skills/pipeline/nemo_gym_rollouts.py
+++ b/nemo_skills/pipeline/nemo_gym_rollouts.py
@@ -119,9 +119,10 @@ def nemo_gym_rollouts(
         "cluster_config['containers']['nemo-gym'] when present, otherwise falls back to "
         "cluster_config['containers']['nemo-rl'].",
     ),
-    gym_path: str = typer.Option(
-        "/opt/NeMo-RL/3rdparty/Gym-workspace/Gym",
-        help="Path to NeMo Gym installation. Defaults to container built-in. Use for mounted/custom Gym.",
+    gym_path: str | None = typer.Option(
+        None,
+        help="Path to NeMo Gym installation. If omitted, resolves from importable nemo_gym package "
+        "(e.g. packaged /nemo_run/code) and falls back to the container built-in path.",
     ),
     policy_api_key: str = typer.Option(
         "dummy",

--- a/nemo_skills/pipeline/utils/scripts/nemo_gym.py
+++ b/nemo_skills/pipeline/utils/scripts/nemo_gym.py
@@ -22,7 +22,7 @@ from nemo_skills.pipeline.utils.scripts.base import BaseJobScript
 from nemo_skills.pipeline.utils.scripts.server import SandboxScript, ServerScript
 from nemo_skills.utils import get_server_wait_cmd
 
-DEFAULT_GYM_PATH = "/opt/NeMo-RL/3rdparty/Gym-workspace/Gym"
+DEFAULT_GYM_PATH = "/opt/Gym"
 
 
 @dataclass(kw_only=True)

--- a/nemo_skills/pipeline/utils/scripts/nemo_gym.py
+++ b/nemo_skills/pipeline/utils/scripts/nemo_gym.py
@@ -14,12 +14,15 @@
 
 """NeMo Gym rollout collection script for NeMo-Skills pipeline."""
 
+import shlex
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
 from nemo_skills.pipeline.utils.scripts.base import BaseJobScript
 from nemo_skills.pipeline.utils.scripts.server import SandboxScript, ServerScript
 from nemo_skills.utils import get_server_wait_cmd
+
+DEFAULT_GYM_PATH = "/opt/NeMo-RL/3rdparty/Gym-workspace/Gym"
 
 
 @dataclass(kw_only=True)
@@ -40,7 +43,8 @@ class NemoGymRolloutsScript(BaseJobScript):
         server: Optional ServerScript reference for policy model server
         server_address: Optional pre-hosted server address
         sandbox: Optional SandboxScript reference for sandbox port
-        gym_path: Path to NeMo Gym installation
+        gym_path: Path to NeMo Gym installation. If unset, resolve from importable nemo_gym package first,
+            then fall back to the container default.
         policy_api_key: API key for policy server
         policy_model_name: Model name override for policy server
         log_prefix: Prefix for log files (default: "nemo_gym")
@@ -53,7 +57,7 @@ class NemoGymRolloutsScript(BaseJobScript):
     server: Optional["ServerScript"] = None
     server_address: Optional[str] = None
     sandbox: Optional["SandboxScript"] = None
-    gym_path: str = "/opt/NeMo-RL/3rdparty/Gym-workspace/Gym"
+    gym_path: Optional[str] = None
     policy_api_key: str = "dummy"
     policy_model_name: Optional[str] = None
 
@@ -116,6 +120,24 @@ class NemoGymRolloutsScript(BaseJobScript):
             else:
                 server_wait_cmd = ""
 
+            if self.gym_path is None:
+                resolve_gym_path = f"""GYM_PATH=$(python - <<'PY'
+from importlib.util import find_spec
+from pathlib import Path
+
+spec = find_spec("nemo_gym")
+if spec is not None:
+    for candidate in Path(spec.origin).resolve().parents:
+        if (candidate / "pyproject.toml").is_file():
+            print(candidate)
+            raise SystemExit(0)
+
+print({DEFAULT_GYM_PATH!r})
+PY
+)"""
+            else:
+                resolve_gym_path = f"GYM_PATH={shlex.quote(str(self.gym_path))}"
+
             cmd = f"""set -e
 set -o pipefail
 
@@ -124,7 +146,11 @@ set -o pipefail
 # the mounted directory may not have a .venv. The --allow-existing flag makes
 # this fast (~1s) when the venv already exists and is up to date.
 echo "=== Installing NeMo Gym ==="
-cd {self.gym_path} || {{ echo "ERROR: Failed to cd to Gym directory"; exit 1; }}
+# Prefer a packaged/editable Gym checkout when it is importable; otherwise use
+# the prebaked container checkout.
+{resolve_gym_path}
+echo "Using NeMo Gym path: $GYM_PATH"
+cd "$GYM_PATH" || {{ echo "ERROR: Failed to cd to Gym directory: $GYM_PATH"; exit 1; }}
 uv venv --python 3.12 --allow-existing .venv || {{ echo "ERROR: Failed to create venv"; exit 1; }}
 source .venv/bin/activate || {{ echo "ERROR: Failed to activate venv"; exit 1; }}
 uv sync --active --extra dev || {{ echo "ERROR: Failed to sync dependencies"; exit 1; }}


### PR DESCRIPTION
With this change, if commands are launched from gym repo, it's automatically used by default without need for special mounting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `--gym-path` CLI option is now optional and can be left unset.
  * When omitted, the rollout tooling will try to locate the NeMo Gym workspace automatically (via installed packages) and otherwise fall back to a container default.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Skills/pull/1445)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->