### PR TITLE
Add Korean benchmarks: KoBALT and CLIcK

### DIFF
--- a/docs/evaluation/multilingual.md
+++ b/docs/evaluation/multilingual.md
@@ -788,7 +788,141 @@ Some reference numbers (%) and commands for reproduction:
         ++inference.top_k=64
     ```
 
-The four MCQ benchmarks (`kmmlu`, `kmmlu-pro`, `kmmlu-redux`, `kormedmcqa`) all use the existing `eval_type=multichoice`; each entry sets a per-sample `extract_regex` that matches the prompt's `정답: A/B/C/D[/E]` answer line. Unlike the other benchmarks on this page, the Korean benchmarks are single-language and do not take a `--languages` flag.
+### kobalt
+
+- Benchmark is defined in [`nemo_skills/dataset/kobalt/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/kobalt/__init__.py)
+- Original benchmark source is [here](https://huggingface.co/datasets/snunlp/KoBALT-700).
+
+Korean-only 10-choice MCQ designed to probe deep linguistic competence across five domains (Syntax, Semantics, Pragmatics, Phonetics/Phonology, Morphology). 700 expert-written items. `subset_for_metrics` is the per-domain `Class` field.
+
+Some reference numbers (symbolic_correct, %) and commands for reproduction:
+
+|                Model                |    Avg    | Syntax | Semantics | Pragmatics | Phonetics/Phonology | Morphology |
+| :---------------------------------- | :-------: | :----: | :-------: | :--------: | :-----------------: | :--------: |
+| Nemotron-Cascade-2-30B-A3B          | **32.29** | 32.00  |   46.05   |   30.86    |        4.84         |    7.14    |
+| kanana-2-30b-a3b-thinking-2601      | **36.14** | 33.00  |   49.30   |   28.40    |        19.35        |   30.95    |
+| gemma-4-26B-A4B-it                  | **69.57** | 75.33  |   71.16   |   60.49    |        54.84        |   59.52    |
+
+=== "Nemotron-Cascade-2-30B-A3B"
+
+    ```bash
+    ns eval \
+        --cluster=[cluster] \
+        --model=nvidia/Nemotron-Cascade-2-30B-A3B \
+        --benchmarks kobalt \
+        --output_dir=[output dir] \
+        --server_type=vllm \
+        --server_gpus=4 \
+        --server_args='--reasoning-parser nemotron_v3' \
+        ++chat_template_kwargs.enable_thinking=true \
+        ++inference.tokens_to_generate=16384 \
+        ++inference.temperature=1.0 \
+        ++inference.top_p=0.95
+    ```
+
+=== "kanana-2-30b-a3b-thinking-2601"
+
+    ```bash
+    ns eval \
+        --cluster=[cluster] \
+        --model=kakaocorp/kanana-2-30b-a3b-thinking-2601 \
+        --benchmarks kobalt \
+        --output_dir=[output dir] \
+        --server_type=vllm \
+        --server_gpus=4 \
+        ++parse_reasoning=true \
+        ++inference.tokens_to_generate=16384 \
+        ++inference.temperature=0.6 \
+        ++inference.top_p=0.95 \
+        ++inference.top_k=20
+    ```
+
+=== "gemma-4-26B-A4B-it"
+
+    ```bash
+    ns eval \
+        --cluster=[cluster] \
+        --model=google/gemma-4-26B-A4B-it \
+        --benchmarks kobalt \
+        --output_dir=[output dir] \
+        --server_type=vllm \
+        --server_gpus=4 \
+        --server_args='--reasoning-parser gemma4' \
+        ++chat_template_kwargs.enable_thinking=true \
+        ++inference.tokens_to_generate=16384 \
+        ++inference.temperature=1.0 \
+        ++inference.top_p=0.95 \
+        ++inference.top_k=64
+    ```
+
+### click
+
+- Benchmark is defined in [`nemo_skills/dataset/click/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/click/__init__.py)
+- Original benchmark source is [here](https://huggingface.co/datasets/EunsuKim/CLIcK).
+
+Korean Cultural and Linguistic Intelligence benchmark (LREC-COLING 2024). 1995 items across 11 subcategories under two broad domains (8 Culture: Economy / Geography / History / Law / Politics / Popular / Society / Tradition; 3 Language: Functional / Grammar / Textual). The HF mirror has no subcategory metadata so the prepare script pulls the per-subcategory JSON files directly from the canonical [GitHub repo](https://github.com/rladmstn1714/CLIcK). Items are a mix of 4- and 5-choice MCQ; the 5-choice prompt covers both.
+
+Some reference numbers (symbolic_correct, %) and commands for reproduction:
+
+|                Model                | symbolic_correct |
+| :---------------------------------- | :--------------: |
+| Nemotron-Cascade-2-30B-A3B          |    **65.81**     |
+| kanana-2-30b-a3b-thinking-2601      |    **73.23**     |
+| gemma-4-26B-A4B-it                  |    **86.77**     |
+
+=== "Nemotron-Cascade-2-30B-A3B"
+
+    ```bash
+    ns eval \
+        --cluster=[cluster] \
+        --model=nvidia/Nemotron-Cascade-2-30B-A3B \
+        --benchmarks click \
+        --output_dir=[output dir] \
+        --server_type=vllm \
+        --server_gpus=4 \
+        --server_args='--reasoning-parser nemotron_v3' \
+        ++chat_template_kwargs.enable_thinking=true \
+        ++inference.tokens_to_generate=16384 \
+        ++inference.temperature=1.0 \
+        ++inference.top_p=0.95
+    ```
+
+=== "kanana-2-30b-a3b-thinking-2601"
+
+    ```bash
+    ns eval \
+        --cluster=[cluster] \
+        --model=kakaocorp/kanana-2-30b-a3b-thinking-2601 \
+        --benchmarks click \
+        --output_dir=[output dir] \
+        --server_type=vllm \
+        --server_gpus=4 \
+        ++parse_reasoning=true \
+        ++inference.tokens_to_generate=16384 \
+        ++inference.temperature=0.6 \
+        ++inference.top_p=0.95 \
+        ++inference.top_k=20
+    ```
+
+=== "gemma-4-26B-A4B-it"
+
+    ```bash
+    ns eval \
+        --cluster=[cluster] \
+        --model=google/gemma-4-26B-A4B-it \
+        --benchmarks click \
+        --output_dir=[output dir] \
+        --server_type=vllm \
+        --server_gpus=4 \
+        --server_args='--reasoning-parser gemma4' \
+        ++chat_template_kwargs.enable_thinking=true \
+        ++inference.tokens_to_generate=16384 \
+        ++inference.temperature=1.0 \
+        ++inference.top_p=0.95 \
+        ++inference.top_k=64
+    ```
+
+The six MCQ benchmarks (`kmmlu`, `kmmlu-pro`, `kmmlu-redux`, `kormedmcqa`, `kobalt`, `click`) all use `eval_type=multichoice`; each entry sets a per-sample `extract_regex` that matches the prompt's `정답: <letter>` answer line. `kobalt` uses a dedicated 10-choice prompt config; the others share the 4-choice and 5-choice prompts. Unlike the other benchmarks on this page, the Korean benchmarks are single-language and do not take a `--languages` flag.
 
 ## Supported translation metrics
 

--- a/docs/evaluation/multilingual.md
+++ b/docs/evaluation/multilingual.md
@@ -858,9 +858,9 @@ Some reference numbers (symbolic_correct, %) and commands for reproduction:
 ### click
 
 - Benchmark is defined in [`nemo_skills/dataset/click/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/click/__init__.py)
-- Original benchmark source is [here](https://huggingface.co/datasets/EunsuKim/CLIcK).
+- Original benchmark source is [here](https://github.com/rladmstn1714/CLIcK) (mirrored to [`bzantium/CLIcK`](https://huggingface.co/datasets/bzantium/CLIcK) with the per-item subcategory labels restored, since the [`EunsuKim/CLIcK`](https://huggingface.co/datasets/EunsuKim/CLIcK) HF mirror drops them).
 
-Korean Cultural and Linguistic Intelligence benchmark (LREC-COLING 2024). 1995 items across 11 subcategories under two broad domains (8 Culture: Economy / Geography / History / Law / Politics / Popular / Society / Tradition; 3 Language: Functional / Grammar / Textual). The HF mirror has no subcategory metadata so the prepare script pulls the per-subcategory JSON files directly from the canonical [GitHub repo](https://github.com/rladmstn1714/CLIcK). Items are a mix of 4- and 5-choice MCQ; the 5-choice prompt covers both.
+Korean Cultural and Linguistic Intelligence benchmark (LREC-COLING 2024). 1995 items across 11 subcategories under two broad domains (8 Culture: Economy / Geography / History / Law / Politics / Popular / Society / Tradition; 3 Language: Functional / Grammar / Textual). Items are a mix of 4- and 5-choice MCQ; the 5-choice prompt covers both.
 
 Some reference numbers (symbolic_correct, %) and commands for reproduction:
 

--- a/nemo_skills/dataset/click/__init__.py
+++ b/nemo_skills/dataset/click/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "multichoice"
+GENERATION_ARGS = "++prompt_config=eval/korean/mcq-5choices ++eval_type=multichoice"

--- a/nemo_skills/dataset/click/prepare.py
+++ b/nemo_skills/dataset/click/prepare.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from tqdm import tqdm
+
+from nemo_skills.dataset.utils import get_mcq_fields
+
+# Matches the '정답: X' answer line the prompt instructs the model to produce.
+# CLIcK mixes 4-choice and 5-choice items; the 5-choice prompt covers both.
+_EXTRACT_REGEX = r"(?i)정답\s*[:：]\s*\**\(?([A-E])\)?\**"
+
+# The CLIcK HF mirror is a single flat split with no category metadata, so we
+# pull the per-subcategory JSON files directly from the canonical GitHub repo
+# (https://github.com/rladmstn1714/CLIcK) to recover the labels used in the
+# LREC-COLING 2024 paper. Each subcategory is split across one or more files
+# named after the source exam (KIIP, Kedu, CSAT, TOPIK, KHB, PSE, PSAT).
+_GITHUB_BASE = "https://raw.githubusercontent.com/rladmstn1714/CLIcK/main/Dataset"
+_SUBDIR = {
+    "Korean Economy": "Culture/Korean Economy",
+    "Korean Geography": "Culture/Korean Geography",
+    "Korean History": "Culture/Korean History",
+    "Korean Law": "Culture/Korean Law",
+    "Korean Politics": "Culture/Korean Politics",
+    "Korean Popular": "Culture/Korean Popular",
+    "Korean Society": "Culture/Korean Society",
+    "Korean Tradition": "Culture/Korean Tradition",
+    "Functional": "Language/Functional",
+    "Grammar": "Language/Grammar",
+    "Textual": "Language/Textual",
+}
+_FILES = {
+    "Korean Economy": ["Economy_KIIP.json", "Economy_Kedu.json"],
+    "Korean Geography": ["Geography_CSAT.json", "Geography_KIIP.json", "Geography_Kedu.json"],
+    "Korean History": ["History_KHB.json", "History_Kedu.json", "History_PSE.json"],
+    "Korean Law": ["Law_KIIP.json", "Law_PSAT.json"],
+    "Korean Politics": ["Politics_KIIP.json", "Politics_Kedu.json"],
+    "Korean Popular": ["Popular_KIIP.json", "Popular_Kedu.json"],
+    "Korean Society": ["Society_KIIP.json", "Society_Kedu.json"],
+    "Korean Tradition": ["Tradition_KIIP.json", "Tradition_Kedu.json"],
+    "Functional": ["Functional_CSAT.json", "Functional_Kedu.json", "Functional_PSE.json"],
+    "Grammar": ["Grammar_CSAT.json", "Grammar_Kedu.json", "Grammar_TOPIK.json"],
+    "Textual": ["Textual_CSAT.json", "Textual_TOPIK.json"],
+}
+
+
+def _fetch(subcategory: str, filename: str):
+    url = f"{_GITHUB_BASE}/{urllib.parse.quote(_SUBDIR[subcategory])}/{filename}"
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def format_entry(entry, subcategory: str):
+    # The HF / GitHub schema stores the answer as the literal text of the
+    # correct choice; map it back to the corresponding letter so the
+    # per-sample regex can match.
+    answer_index = entry["choices"].index(entry["answer"])
+    expected_letter = chr(ord("A") + answer_index)
+
+    # Some items carry an extra `paragraph` context that the question
+    # refers to; prepend it when present.
+    paragraph = entry.get("paragraph", "").strip()
+    question = entry["question"].strip()
+    if paragraph:
+        question = f"{paragraph}\n\n{question}"
+
+    return {
+        "expected_answer": expected_letter,
+        "extract_from_boxed": False,
+        "extract_regex": _EXTRACT_REGEX,
+        "relaxed": False,
+        "subset_for_metrics": subcategory,
+        "id": entry["id"],
+        **get_mcq_fields(question, entry["choices"]),
+    }
+
+
+def main(args):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+    output_file = data_dir / f"{args.split}.jsonl"
+
+    rows = []
+    for subcat, files in tqdm(_FILES.items(), desc="Fetching CLIcK"):
+        for filename in files:
+            for entry in _fetch(subcat, filename):
+                rows.append(format_entry(entry, subcat))
+
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for row in rows:
+            fout.write(json.dumps(row, ensure_ascii=False) + "\n")
+    print(f"wrote {len(rows)} items to {output_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--split", default="test", choices=("test",), help="Dataset split to process.")
+    args = parser.parse_args()
+    main(args)

--- a/nemo_skills/dataset/click/prepare.py
+++ b/nemo_skills/dataset/click/prepare.py
@@ -60,16 +60,25 @@ _FILES = {
 }
 
 
-def _fetch(subcategory: str, filename: str):
-    url = f"{_GITHUB_BASE}/{urllib.parse.quote(_SUBDIR[subcategory])}/{filename}"
-    with urllib.request.urlopen(url, timeout=30) as resp:
-        return json.loads(resp.read())
+def _load_dataset():
+    """Pull every per-subcategory JSON from GitHub and tag each item with its
+    subcategory; returns a flat list of entries ready for format_entry."""
+    entries = []
+    for subcategory, filenames in _FILES.items():
+        for filename in filenames:
+            url = f"{_GITHUB_BASE}/{urllib.parse.quote(_SUBDIR[subcategory])}/{filename}"
+            with urllib.request.urlopen(url, timeout=30) as resp:
+                items = json.loads(resp.read())
+            for item in items:
+                item["subcategory"] = subcategory
+                entries.append(item)
+    return entries
 
 
-def format_entry(entry, subcategory: str):
-    # The HF / GitHub schema stores the answer as the literal text of the
-    # correct choice; map it back to the corresponding letter so the
-    # per-sample regex can match.
+def format_entry(entry):
+    # The schema stores the answer as the literal text of the correct
+    # choice; map it back to the corresponding letter so the per-sample
+    # regex can match.
     answer_index = entry["choices"].index(entry["answer"])
     expected_letter = chr(ord("A") + answer_index)
 
@@ -85,27 +94,25 @@ def format_entry(entry, subcategory: str):
         "extract_from_boxed": False,
         "extract_regex": _EXTRACT_REGEX,
         "relaxed": False,
-        "subset_for_metrics": subcategory,
+        "subset_for_metrics": entry["subcategory"],
         "id": entry["id"],
         **get_mcq_fields(question, entry["choices"]),
     }
 
 
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout, ensure_ascii=False)
+            fout.write("\n")
+
+
 def main(args):
+    dataset = _load_dataset()
     data_dir = Path(__file__).absolute().parent
     data_dir.mkdir(exist_ok=True)
     output_file = data_dir / f"{args.split}.jsonl"
-
-    rows = []
-    for subcat, files in tqdm(_FILES.items(), desc="Fetching CLIcK"):
-        for filename in files:
-            for entry in _fetch(subcat, filename):
-                rows.append(format_entry(entry, subcat))
-
-    with open(output_file, "wt", encoding="utf-8") as fout:
-        for row in rows:
-            fout.write(json.dumps(row, ensure_ascii=False) + "\n")
-    print(f"wrote {len(rows)} items to {output_file}")
+    write_data_to_file(output_file, dataset)
 
 
 if __name__ == "__main__":

--- a/nemo_skills/dataset/click/prepare.py
+++ b/nemo_skills/dataset/click/prepare.py
@@ -14,10 +14,9 @@
 
 import argparse
 import json
-import urllib.parse
-import urllib.request
 from pathlib import Path
 
+from datasets import load_dataset
 from tqdm import tqdm
 
 from nemo_skills.dataset.utils import get_mcq_fields
@@ -25,54 +24,6 @@ from nemo_skills.dataset.utils import get_mcq_fields
 # Matches the '정답: X' answer line the prompt instructs the model to produce.
 # CLIcK mixes 4-choice and 5-choice items; the 5-choice prompt covers both.
 _EXTRACT_REGEX = r"(?i)정답\s*[:：]\s*\**\(?([A-E])\)?\**"
-
-# The CLIcK HF mirror is a single flat split with no category metadata, so we
-# pull the per-subcategory JSON files directly from the canonical GitHub repo
-# (https://github.com/rladmstn1714/CLIcK) to recover the labels used in the
-# LREC-COLING 2024 paper. Each subcategory is split across one or more files
-# named after the source exam (KIIP, Kedu, CSAT, TOPIK, KHB, PSE, PSAT).
-_GITHUB_BASE = "https://raw.githubusercontent.com/rladmstn1714/CLIcK/main/Dataset"
-_SUBDIR = {
-    "Korean Economy": "Culture/Korean Economy",
-    "Korean Geography": "Culture/Korean Geography",
-    "Korean History": "Culture/Korean History",
-    "Korean Law": "Culture/Korean Law",
-    "Korean Politics": "Culture/Korean Politics",
-    "Korean Popular": "Culture/Korean Popular",
-    "Korean Society": "Culture/Korean Society",
-    "Korean Tradition": "Culture/Korean Tradition",
-    "Functional": "Language/Functional",
-    "Grammar": "Language/Grammar",
-    "Textual": "Language/Textual",
-}
-_FILES = {
-    "Korean Economy": ["Economy_KIIP.json", "Economy_Kedu.json"],
-    "Korean Geography": ["Geography_CSAT.json", "Geography_KIIP.json", "Geography_Kedu.json"],
-    "Korean History": ["History_KHB.json", "History_Kedu.json", "History_PSE.json"],
-    "Korean Law": ["Law_KIIP.json", "Law_PSAT.json"],
-    "Korean Politics": ["Politics_KIIP.json", "Politics_Kedu.json"],
-    "Korean Popular": ["Popular_KIIP.json", "Popular_Kedu.json"],
-    "Korean Society": ["Society_KIIP.json", "Society_Kedu.json"],
-    "Korean Tradition": ["Tradition_KIIP.json", "Tradition_Kedu.json"],
-    "Functional": ["Functional_CSAT.json", "Functional_Kedu.json", "Functional_PSE.json"],
-    "Grammar": ["Grammar_CSAT.json", "Grammar_Kedu.json", "Grammar_TOPIK.json"],
-    "Textual": ["Textual_CSAT.json", "Textual_TOPIK.json"],
-}
-
-
-def _load_dataset():
-    """Pull every per-subcategory JSON from GitHub and tag each item with its
-    subcategory; returns a flat list of entries ready for format_entry."""
-    entries = []
-    for subcategory, filenames in _FILES.items():
-        for filename in filenames:
-            url = f"{_GITHUB_BASE}/{urllib.parse.quote(_SUBDIR[subcategory])}/{filename}"
-            with urllib.request.urlopen(url, timeout=30) as resp:
-                items = json.loads(resp.read())
-            for item in items:
-                item["subcategory"] = subcategory
-                entries.append(item)
-    return entries
 
 
 def format_entry(entry):
@@ -84,7 +35,7 @@ def format_entry(entry):
 
     # Some items carry an extra `paragraph` context that the question
     # refers to; prepend it when present.
-    paragraph = entry.get("paragraph", "").strip()
+    paragraph = entry["paragraph"].strip()
     question = entry["question"].strip()
     if paragraph:
         question = f"{paragraph}\n\n{question}"
@@ -108,7 +59,11 @@ def write_data_to_file(output_file, data):
 
 
 def main(args):
-    dataset = _load_dataset()
+    # bzantium/CLIcK is a mirror of the upstream CLIcK dataset
+    # (github.com/rladmstn1714/CLIcK, LREC-COLING 2024) with the per-item
+    # subcategory and broad-category labels that the EunsuKim/CLIcK HF mirror
+    # drops. See the dataset card for details.
+    dataset = load_dataset("bzantium/CLIcK", split="test")
     data_dir = Path(__file__).absolute().parent
     data_dir.mkdir(exist_ok=True)
     output_file = data_dir / f"{args.split}.jsonl"

--- a/nemo_skills/dataset/kobalt/__init__.py
+++ b/nemo_skills/dataset/kobalt/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "multichoice"
+GENERATION_ARGS = "++prompt_config=eval/korean/mcq-10choices ++eval_type=multichoice"

--- a/nemo_skills/dataset/kobalt/prepare.py
+++ b/nemo_skills/dataset/kobalt/prepare.py
@@ -31,10 +31,11 @@ _EXTRACT_REGEX = r"(?i)정답\s*[:：]\s*\**\(?([A-J])\)?\**"
 # same format as the other Korean MCQ benchmarks.
 _OPTION_SPLIT = re.compile(r"\n(?=[A-J][:.\)]\s)")
 _OPTION_PREFIX = re.compile(r"^[A-J][:.\)]\s+")
+_FIRST_OPTION = re.compile(r"\nA[:.\)]\s")
 
 
 def _split_question(question_text: str) -> tuple[str, list[str]]:
-    first_option = re.search(r"\nA[:.\)]\s", question_text)
+    first_option = _FIRST_OPTION.search(question_text)
     stem = question_text[: first_option.start()].rstrip("\n")
     options_block = question_text[first_option.start() + 1 :]
     options = [_OPTION_PREFIX.sub("", o).strip() for o in _OPTION_SPLIT.split(options_block)]

--- a/nemo_skills/dataset/kobalt/prepare.py
+++ b/nemo_skills/dataset/kobalt/prepare.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from nemo_skills.dataset.utils import get_mcq_fields
+
+# Matches the '정답: X' answer line the prompt instructs the model to produce.
+_EXTRACT_REGEX = r"(?i)정답\s*[:：]\s*\**\(?([A-J])\)?\**"
+
+# KoBALT-700 ships each question as a single 'Question' string with the 10
+# options embedded as `A: ...`, `B: ...`, ... `J: ...` lines. We split the
+# stem from the options here so the prompt template can render them in the
+# same format as the other Korean MCQ benchmarks.
+_OPTION_SPLIT = re.compile(r"\n(?=[A-J][:.\)]\s)")
+_OPTION_PREFIX = re.compile(r"^[A-J][:.\)]\s+")
+
+
+def _split_question(question_text: str) -> tuple[str, list[str]]:
+    first_option = re.search(r"\nA[:.\)]\s", question_text)
+    stem = question_text[: first_option.start()].rstrip("\n")
+    options_block = question_text[first_option.start() + 1 :]
+    options = [_OPTION_PREFIX.sub("", o).strip() for o in _OPTION_SPLIT.split(options_block)]
+    return stem, options
+
+
+def format_entry(entry):
+    stem, options = _split_question(entry["Question"])
+    return {
+        "expected_answer": entry["Answer"],
+        "extract_from_boxed": False,
+        "extract_regex": _EXTRACT_REGEX,
+        "relaxed": False,
+        "subset_for_metrics": entry["Class"],
+        **get_mcq_fields(stem, options),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout, ensure_ascii=False)
+            fout.write("\n")
+
+
+def main(args):
+    dataset = load_dataset("snunlp/KoBALT-700", "kobalt_v1", split="raw")
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+    output_file = data_dir / f"{args.split}.jsonl"
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--split", default="test", choices=("test",), help="Dataset split to process.")
+    args = parser.parse_args()
+    main(args)

--- a/nemo_skills/prompt/config/eval/korean/mcq-10choices.yaml
+++ b/nemo_skills/prompt/config/eval/korean/mcq-10choices.yaml
@@ -1,0 +1,6 @@
+# Korean MCQ prompt with 10 answer choices (e.g. KoBALT).
+
+user: |-
+  다음 객관식 질문에 답하시오. 응답의 마지막 줄은 반드시 다음과 같은 형식이어야 합니다: '정답: A/B/C/D/E/F/G/H/I/J' (예시: '정답: A').
+
+  {problem}


### PR DESCRIPTION
## Summary

Adds two more Korean evaluation benchmarks to the multilingual suite, following the same pattern as the six Korean benchmarks added in #1375.

- **KoBALT-700** ([HF](https://huggingface.co/datasets/snunlp/KoBALT-700), [paper](https://arxiv.org/abs/2505.16125)): 700 expert-written 10-choice MCQ items targeting deep Korean linguistic competence across five domains (Syntax 300, Semantics 215, Pragmatics 81, Phonetics/Phonology 62, Morphology 42). The dataset ships each question as one string with the ten options embedded as \`A: ... J: ...\` lines; the prepare script splits these into the standard MCQ fields so the existing \`eval_type=multichoice\` evaluator can be reused. A new 10-choice prompt config (\`eval/korean/mcq-10choices.yaml\`) matches the \`정답: A/B/.../J\` answer format.

- **CLIcK** ([HF](https://huggingface.co/datasets/EunsuKim/CLIcK), [paper](https://arxiv.org/abs/2403.06412), LREC-COLING 2024): 1995 items across 11 paper-defined subcategories under two broad domains (8 Culture: Economy / Geography / History / Law / Politics / Popular / Society / Tradition; 3 Language: Functional / Grammar / Textual). The HF mirror is a single flat split with no subcategory metadata, so the prepare script pulls the per-subcategory JSON files directly from the canonical [GitHub repo](https://github.com/rladmstn1714/CLIcK) and tags each item. Mixes 4- and 5-choice MCQ; the existing 5-choice prompt covers both.

Both benchmarks are single-language Korean and reuse the existing \`multichoice\` evaluator and per-sample \`extract_regex\` matching \`정답: <letter>\`.

## Reference numbers

Validated end to end on three production models (\`ns eval\` on a single 4-GPU node, judge-free MCQ). Numbers also added to \`docs/evaluation/multilingual.md\`.

### KoBALT (symbolic_correct, %)

| Model | Avg | Syntax | Semantics | Pragmatics | Phonetics/Phonology | Morphology |
|---|---:|---:|---:|---:|---:|---:|
| Nemotron-Cascade-2-30B-A3B          | 32.29 | 32.00 | 46.05 | 30.86 |  4.84 |  7.14 |
| kanana-2-30b-a3b-thinking-2601      | 36.14 | 33.00 | 49.30 | 28.40 | 19.35 | 30.95 |
| gemma-4-26B-A4B-it                  | **69.57** | 75.33 | 71.16 | 60.49 | 54.84 | 59.52 |

### CLIcK (symbolic_correct, %)

| Model | Overall |
|---|---:|
| Nemotron-Cascade-2-30B-A3B          | 65.81 |
| kanana-2-30b-a3b-thinking-2601      | 73.23 |
| gemma-4-26B-A4B-it                  | **86.77** |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two Korean MCQ evaluation benchmarks: kobalt (10-choice) and click (5-choice), including prepared test data and evaluation configs.

* **Documentation**
  * Multilingual evaluation docs updated: Korean MCQ list expanded to six; clarified per-option answer extraction behavior, kobalt’s 10-choice prompt usage, and that these benchmarks are single-language (no --languages flag).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Skills/pull/1452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->