### PR TITLE
fix(ray): honor run_after in the Ray-executor branch of add_task

### DIFF
--- a/nemo_skills/pipeline/utils/exp.py
+++ b/nemo_skills/pipeline/utils/exp.py
@@ -614,6 +614,23 @@ def add_task(
                     f"add_task() call under cluster_config.executor='ray'."
                 )
             ray_dependencies.append(dep)
+        # Also honor run_after on the Ray path. In this codepath
+        # expname == task_name == submission_id by construction
+        # (this function returns submission_id and downstream callers
+        # pass it back as run_after), so each entry maps directly to
+        # a Ray submission_id without needing get_exp_handles().
+        if run_after is not None:
+            if isinstance(run_after, (str, run.Experiment)):
+                run_after = [run_after]
+            for dep_expname in run_after:
+                if not isinstance(dep_expname, str):
+                    raise NotImplementedError(
+                        f"Ray executor run_after entries must be Ray submission IDs (str); "
+                        f"got {type(dep_expname).__name__}. nemo-run Experiment objects "
+                        f"are valid on the slurm path but not under cluster_config.executor='ray'."
+                    )
+                if dep_expname not in ray_dependencies:
+                    ray_dependencies.append(dep_expname)
         ray_cluster_config = cluster_config.get("ray", {})
         # default_num_cpus is per-node; multiply by num_nodes to get the per-job total.
         ray_default_cpus_per_node = ray_cluster_config.get("default_num_cpus", 8)


### PR DESCRIPTION
## Problem

The Ray-executor branch of `add_task` (added in #1435) builds
`ray_dependencies` only from `task_dependencies` and ignores `run_after`.

The existing `run_after`→dependencies translation at
[`nemo_skills/pipeline/utils/exp.py:532`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/pipeline/utils/exp.py#L532)
is gated on `cluster_config["executor"] == "slurm"`, so it silently
no-ops when callers run under `executor: ray`.

**Result:** any pipeline that chains stages via
`run_after=[upstream_expname]` — the standard nemo-skills chaining
pattern — submits **all** stages simultaneously on the Ray path.
Downstream Ray actors race past upstream actors and fail with
`FileNotFoundError` on each upstream stage's expected output.

## Reproducer (real-world)

Finance SFT pipeline running on a Ray-on-Slurm cluster (nvflow on draco-oci-iad, `nemo-rl-v0.6.0.sqsh` container, nemo-skills @ `bd3ff708`):

```
sft-data_transformation       SUCCEEDED
sft-prepare_for_sft           FAILED — FileNotFoundError on data_transformation output
sft-train_validation_split    FAILED — FileNotFoundError on prepare_for_sft output
sft-sequence_length_grouping  FAILED — FileNotFoundError on train_validation_split output
sft-training                  FAILED — FileNotFoundError on sequence_length_grouping output
```

All four downstream stages started concurrently with `data_transformation`. Driver-side `run_cmd` calls passed `run_after=[upstream_expname]` consistently; the bug is purely the translation gap in `add_task`.

## Fix

After the existing `task_dependencies` loop populates `ray_dependencies`, also append entries from `run_after`. In this codepath `expname == task_name == submission_id` by construction (the function returns `submission_id` and downstream callers pass it back as `run_after`), so each entry maps directly to a Ray submission_id without needing `get_exp_handles()`.

Mirrors the existing `task_dependencies` fail-fast pattern: non-string `run_after` entries (e.g., `nemo-run` `Experiment` objects, which are valid on the slurm path) raise `NotImplementedError` under `executor=ray` rather than being silently dropped.

17 lines, fully contained to the Ray-executor branch. No change to the slurm path or any other executor.

## Verification

Applied locally as an in-place patch on the same pipeline:

```
[16:28:52] INFO  ✓ Dependent job sft-data_transformation       completed successfully
[16:33:52] INFO  ✓ Dependent job sft-prepare_for_sft           completed successfully
[16:34:22] INFO  ✓ Dependent job sft-train_validation_split    completed successfully
[16:34:53] INFO  ✓ Dependent job sft-sequence_length_grouping  completed successfully
```

`RayJobClient._wait_for_dependencies` serializes prep stages correctly with the fix; all four prep stages SUCCEEDED in order before the training stage was submitted.

Happy to add a unit test in this PR if reviewers point me at the right test scaffold — the in-tree Ray executor tests I found (`tests/slurm-tests/qwen3_4b_ray_executor/`) look integration-shaped, and a unit-level test for this would belong elsewhere.

## Reviewer

cc @gwarmstrong (PR #1435 author/merger) — same Ray-executor area.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced task dependency processing for Ray executor to properly handle task ordering specifications. Dependency configurations are now validated more robustly, duplicate dependencies are automatically prevented, and type checking is improved to ensure correct execution order and reliable distributed job execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Skills/pull/1453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->