### PR TITLE
Fix graphwalks eval metric

### DIFF
--- a/nemo_skills/evaluation/evaluator/graphwalks.py
+++ b/nemo_skills/evaluation/evaluator/graphwalks.py
@@ -67,7 +67,9 @@ def eval_graphwalks(cfg):
             except (json.JSONDecodeError, TypeError):
                 expected_nodes = set()
 
-            if not expected_nodes and not predicted_nodes:
+            if parse_failed:
+                f1 = 0.0
+            elif not expected_nodes and not predicted_nodes:
                 f1 = 1.0
             elif not predicted_nodes or not expected_nodes:
                 f1 = 0.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed F1 score calculation in graph walk evaluations to correctly report 0.0 when prediction format parsing fails, instead of incorrectly assigning perfect scores in certain empty result scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Skills/pull/1457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->