### PR TITLE
sandbox: drop redundant sync after multi-node port-file write

### DIFF
--- a/dockerfiles/sandbox/start-with-nginx.sh
+++ b/dockerfiles/sandbox/start-with-nginx.sh
@@ -562,7 +562,6 @@ if [ "$NODE_COUNT" -gt 1 ]; then
         echo "${i}:${ACTUAL_WORKER_PORTS[$((i-1))]}" >> "$PORTS_FILE"
     done
     echo "PORT_REPORT_COMPLETE" >> "$PORTS_FILE"
-    sync
     echo "[$_H] Port assignments written to $PORTS_FILE"
 fi
 


### PR DESCRIPTION
## Summary

`start-with-nginx.sh` calls `sync` immediately after each node writes its port-coordination file. This sync is redundant:

- Each `echo … >> \"\$PORTS_FILE\"` in bash opens, writes, and closes the file within that statement, so by the time `sync` runs there are no open fds to the port file.
- The cross-node coordination protocol relies on the master node polling for `PORT_REPORT_COMPLETE` in the file. On a POSIX-coherent shared filesystem (e.g. Lustre), the master sees the closed file's contents via the metadata server / distributed lock manager — `close()` already provides that visibility.
- `sync(1)` is also the wrong primitive even if cross-client visibility were the concern: it's process-wide, doesn't target the specific fd, and on distributed filesystems adds no guarantee beyond what `close()` already provides.


```
=== Upstream distribution (nginx access log on master) ===
  4 NODE_A:50003
  4 NODE_B:50004
  3 NODE_B:50003
  3 NODE_B:50002
  2 NODE_A:50004
  2 NODE_A:50002
  2 NODE_A:50001
  1 NODE_B:50001
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the Docker startup script by removing an unnecessary file synchronization operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Skills/pull/1458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->