### PR TITLE
fix: allow whitespace in MMLU-ProX answer extraction

### DIFF
--- a/nemo_skills/dataset/mmlu-prox/prepare.py
+++ b/nemo_skills/dataset/mmlu-prox/prepare.py
@@ -103,7 +103,7 @@ def format_entry(entry: dict, language: str, lang_libs: dict, lang_subjects: dic
             **options_dict,
         }
 
-    extract_regex = lang_libs[language][5].replace("({})", r"\(?([ABCDEFGHIJ])\)?")
+    extract_regex = lang_libs[language][5].replace("({})", r"\(?([ABCDEFGHIJ])\)?\s*")
     if language == "en":
         extract_regex = extract_regex.lstrip("the").strip()
         extract_regex = extract_regex.replace("\\(", "\\**\\(")


### PR DESCRIPTION
Fix MMLU-ProX answer extraction to allow whitespace after the multiple-choice answer marker.

We found this with Qwen/Qwen3.5-397B-A17B on Korean MMLU-ProX: the model follows the localized instruction and responds with forms like:

답은 (I) 입니다

The existing regex handled `답은 (I)입니다` but not the whitespace variant, which caused `predicted_answer` to be empty even when the answer was present.

This keeps the existing strict localized suffix behavior and only allows optional whitespace after the answer marker, covering:

- `...(I)...`
- `...(I) ...`
- `... (I)...`
- `... (I) ...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved answer extraction in dataset preparation to better handle formatting variations with whitespace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Skills/pull/1462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->