### PR TITLE
Add IHEval (Instruction Hierarchy Evaluation) benchmark

### DIFF
--- a/dockerfiles/Dockerfile.nemo-skills
+++ b/dockerfiles/Dockerfile.nemo-skills
@@ -45,6 +45,10 @@ RUN git clone https://github.com/ShishirPatil/gorilla.git /opt/gorilla
 RUN cd /opt/gorilla && git checkout 86d0374d0db52623c5092a73f82c22b87b7e9a25
 RUN cd /opt/gorilla/berkeley-function-call-leaderboard && pip install --no-cache-dir -e . --extra-index-url https://download.pytorch.org/whl/cpu
 
+# iheval (Instruction Hierarchy Evaluation) scoring package
+ARG IHEVAL_COMMIT=4572a71b46abdd5ec3a61553ed2fa91af31827b5
+RUN pip install --no-cache-dir "iheval @ git+https://github.com/bzantium/iheval.git@${IHEVAL_COMMIT}"
+
 RUN apt remove -y python3-blinker
 
 # ifbench

--- a/docs/evaluation/instruction-following.md
+++ b/docs/evaluation/instruction-following.md
@@ -13,3 +13,15 @@ More details are coming soon!
 
 - Benchmark is defined in [`nemo_skills/dataset/ifeval/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/ifeval/__init__.py)
 - Original benchmark source is [here](https://github.com/google-research/google-research/tree/master/instruction_following_eval).
+
+### iheval
+
+IHEval (Instruction Hierarchy Evaluation) measures whether a model respects the
+system > user > tool instruction hierarchy. It is a **benchmark group** with 9
+sub-benchmarks across 4 categories (rule-following, task-execution, safety,
+tool-use), each in `aligned` / `conflict` / `reference` settings.
+
+- Benchmark group is defined in [`nemo_skills/dataset/iheval/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/iheval/__init__.py); run all sub-benchmarks with `--benchmarks iheval` (or a single one, e.g. `iheval.safety_hijack`).
+- Data is downloaded at prepare time from the [`zhihz0535/IHEval`](https://huggingface.co/datasets/zhihz0535/IHEval) HuggingFace mirror (not committed).
+- Rule-based scoring lives in the standalone [`bzantium/iheval`](https://github.com/bzantium/iheval) package — install with `pip install git+https://github.com/bzantium/iheval.git` (already baked into the nemo-skills Docker image).
+- Original benchmark source is [here](https://github.com/ytyz1307zzh/IHEval).

--- a/nemo_skills/dataset/iheval/__init__.py
+++ b/nemo_skills/dataset/iheval/__init__.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# IHEval benchmark group: 9 sub-benchmarks across rule-following, task-execution, safety, tool-use.
+
+SPLITS = [
+    "rule_following_single",
+    "rule_following_multi",
+    "task_execution_verb_extract",
+    "task_execution_translation",
+    "task_execution_lang_detect",
+    "safety_hijack",
+    "safety_extract",
+    "tool_use_webpage",
+    "tool_use_slack_user",
+]
+
+IS_BENCHMARK_GROUP = True
+
+BENCHMARKS = {f"iheval.{split}": {} for split in SPLITS}
+
+SCORE_MODULE = "nemo_skills.dataset.iheval.iheval_score"

--- a/nemo_skills/dataset/iheval/iheval_score.py
+++ b/nemo_skills/dataset/iheval/iheval_score.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IHEval group-level composite score (overall + per-category + per-setting + conflict gap)."""
+
+_CATEGORIES: dict[str, list[str]] = {
+    "rule_following": ["rule_following_single", "rule_following_multi"],
+    "task_execution": [
+        "task_execution_verb_extract",
+        "task_execution_translation",
+        "task_execution_lang_detect",
+    ],
+    "safety": ["safety_hijack", "safety_extract"],
+    "tool_use": ["tool_use_webpage", "tool_use_slack_user"],
+}
+
+_ALL_SUBS: list[str] = [sub for subs in _CATEGORIES.values() for sub in subs]
+
+_SETTINGS: tuple[str, ...] = ("aligned", "conflict", "reference")
+
+
+def _mean(values):
+    valid = [v for v in values if v is not None]
+    return sum(valid) / len(valid) if valid else 0.0
+
+
+def _composite(per_sub: dict) -> dict:
+    """Build the group composite for one aggregation mode from ``{sub: mode_dict}``."""
+    per_category = {
+        category: _mean([per_sub.get(sub, {}).get("symbolic_correct") for sub in subs])
+        for category, subs in _CATEGORIES.items()
+    }
+    per_setting = {
+        setting: _mean([p.get(f"setting_{setting}") for p in per_sub.values() if f"setting_{setting}" in p])
+        for setting in _SETTINGS
+    }
+    return {
+        "num_entries": sum(p.get("num_entries", 0) for p in per_sub.values()),
+        "symbolic_correct": _mean([p.get("symbolic_correct") for p in per_sub.values()]),
+        "aligned_avg": per_setting["aligned"],
+        "conflict_avg": per_setting["conflict"],
+        "reference_avg": per_setting["reference"],
+        "conflict_gap": per_setting["reference"] - per_setting["conflict"],
+        "rule_following_avg": per_category["rule_following"],
+        "task_execution_avg": per_category["task_execution"],
+        "safety_avg": per_category["safety"],
+        "tool_use_avg": per_category["tool_use"],
+    }
+
+
+def compute_score(metrics: dict) -> dict:
+    """Combine per-sub metrics into one ``iheval`` group result, per aggregation mode.
+
+    Handles ``iheval:N`` runs: a composite is produced for every mode present in the
+    sub-benchmarks (``pass@1``, ``pass@1[avg-of-N]``, ``pass@N``, ...), so they all
+    surface in the group ``metrics.json``.
+    """
+    present = {sub: metrics[f"iheval.{sub}"] for sub in _ALL_SUBS if isinstance(metrics.get(f"iheval.{sub}"), dict)}
+
+    # Aggregation modes are the per-sub top-level keys (pass@1, pass@1[avg-of-k], pass@k, ...).
+    modes = list(dict.fromkeys(mode for sub_metrics in present.values() for mode in sub_metrics)) or ["pass@1"]
+
+    result = {}
+    for mode in modes:
+        per_sub = {sub: sm[mode] for sub, sm in present.items() if isinstance(sm.get(mode), dict)}
+        result[mode] = _composite(per_sub)
+    return {"iheval": result}

--- a/nemo_skills/dataset/iheval/prepare.py
+++ b/nemo_skills/dataset/iheval/prepare.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prepare IHEval splits from the zhihz0535/IHEval HF mirror.
+
+Writes one test.jsonl per sub-benchmark; variants are discovered from the repo
+file listing. Data is downloaded at prepare time and is not committed.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+HF_REPO = "zhihz0535/IHEval"
+HF_ROOT = "iheval"  # top-level dir inside the HF dataset repo
+
+# split_name -> (category, task, task_id, category_id)
+# `category` and `task` are the path segments in the HF layout
+# iheval/<category>/<task>/<setting>/<variant>/; `category_id` and `task_id` are
+# the normalized labels written to each row's "category" / "task" fields.
+SUB_BENCHMARKS = {
+    "rule_following_single": ("rule-following", "single-turn", "single", "rule_following"),
+    "rule_following_multi": ("rule-following", "multi-turn", "multi", "rule_following"),
+    "task_execution_verb_extract": ("task-execution", "verb-extract", "verb_extract", "task_execution"),
+    "task_execution_translation": ("task-execution", "translation", "translation", "task_execution"),
+    "task_execution_lang_detect": ("task-execution", "lang-detect", "lang_detect", "task_execution"),
+    "safety_hijack": ("safety", "user-prompt-hijack", "hijack", "safety"),
+    "safety_extract": ("safety", "system-prompt-extract", "extract", "safety"),
+    "tool_use_webpage": ("tool-use", "get-webpage", "webpage", "tool_use"),
+    "tool_use_slack_user": ("tool-use", "slack-user", "slack_user", "tool_use"),
+}
+
+SETTINGS = ("aligned", "conflict", "reference")
+
+
+def list_variants(repo_files, category, task, setting):
+    """Return variant names that have an ``input_data.json`` for this (category, task, setting)."""
+    prefix = f"{HF_ROOT}/{category}/{task}/{setting}/"
+    variants = set()
+    for f in repo_files:
+        if f.startswith(prefix) and f.endswith("/input_data.json"):
+            variant = f[len(prefix) : -len("/input_data.json")]
+            if "/" not in variant:  # exactly one level (the variant dir)
+                variants.add(variant)
+    return sorted(variants)
+
+
+def load_input_data(category, task, setting, variant):
+    """Download + parse one ``input_data.json`` from the HF dataset repo."""
+    from huggingface_hub import hf_hub_download
+
+    rel = f"{HF_ROOT}/{category}/{task}/{setting}/{variant}/input_data.json"
+    local = hf_hub_download(repo_id=HF_REPO, filename=rel, repo_type="dataset")
+    with open(local, "rt", encoding="utf-8") as fin:
+        return json.load(fin)
+
+
+def build_messages(row, category_id, task_id, setting):
+    """Build an OpenAI-style ``messages`` list from one upstream row."""
+    system = row.get("system")
+    instruction = row.get("instruction", "")
+
+    # Multi-turn rule-following with a real dialog history.
+    conv_hist = row.get("conversation_history")
+    if category_id == "rule_following" and task_id == "multi" and isinstance(conv_hist, list) and len(conv_hist) >= 2:
+        messages = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        # conversation_history is [user_turn_1, assistant_turn_1] (possibly more pairs).
+        pairs = list(zip(conv_hist[0::2], conv_hist[1::2], strict=True))
+        for user_msg, assistant_msg in pairs:
+            messages.append({"role": "user", "content": user_msg})
+            messages.append({"role": "assistant", "content": assistant_msg})
+        messages.append({"role": "user", "content": instruction})
+        return messages
+
+    # Tool-use with an upstream-supplied tool call/return.
+    tool = row.get("tool")
+    if category_id == "tool_use" and isinstance(tool, dict) and tool:
+        messages = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": instruction})
+
+        call = tool.get("call") or {}
+        ret = tool.get("return") or {}
+        call_id = call.get("id") or ret.get("id") or "call_0"
+        call_name = call.get("name") or (tool.get("definition") or {}).get("name") or ""
+        call_args = call.get("arguments", {})
+
+        messages.append(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": call_name, "arguments": json.dumps(call_args, ensure_ascii=False)},
+                    }
+                ],
+            }
+        )
+        messages.append(
+            {"role": "tool", "tool_call_id": call_id, "name": call_name, "content": ret.get("content", "")}
+        )
+        return messages
+
+    # Reference setting with no system prompt — single user message.
+    if setting == "reference" or system in (None, ""):
+        return [{"role": "user", "content": instruction}]
+
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": instruction},
+    ]
+
+
+def _last_user_text(messages):
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            content = msg.get("content")
+            if isinstance(content, str):
+                return content
+    return ""
+
+
+def process_sub_benchmark(out_root, repo_files, split_name, spec):
+    category, task, task_id, category_id = spec
+    out_dir = out_root / split_name
+    out_dir.mkdir(parents=True, exist_ok=True)
+    output_file = out_dir / "test.jsonl"
+
+    rows_written = 0
+    with output_file.open("w", encoding="utf-8") as fout:
+        for setting in SETTINGS:
+            for variant in list_variants(repo_files, category, task, setting):
+                data = load_input_data(category, task, setting, variant)
+                for i, row in enumerate(data):
+                    messages = build_messages(row, category_id, task_id, setting)
+                    answer = row.get("answer")
+                    upstream_id = row.get("id", i)
+                    record = {
+                        "id": f"iheval-{task_id}-{setting}-{variant}-{upstream_id}",
+                        "messages": messages,
+                        "question": _last_user_text(messages),
+                        "setting": setting,
+                        "variant": variant,
+                        "category": category_id,
+                        "task": task_id,
+                        "answer": answer,
+                        "expected_answer": answer,
+                    }
+                    fout.write(json.dumps(record, ensure_ascii=False) + "\n")
+                    rows_written += 1
+
+    return output_file, rows_written
+
+
+def main(args):
+    from huggingface_hub import HfApi
+
+    out_root = Path(__file__).absolute().parent
+    repo_files = HfApi().list_repo_files(HF_REPO, repo_type="dataset")
+
+    selected = dict(SUB_BENCHMARKS)
+    if args.only:
+        wanted = set(args.only)
+        missing = wanted.difference(SUB_BENCHMARKS)
+        if missing:
+            raise SystemExit(f"Unknown sub-benchmarks: {sorted(missing)}")
+        selected = {name: SUB_BENCHMARKS[name] for name in wanted}
+
+    for split_name, spec in selected.items():
+        output_file, n = process_sub_benchmark(out_root, repo_files, split_name, spec)
+        print(f"[{split_name}] wrote {n} rows -> {output_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Prepare IHEval test splits from the HuggingFace mirror.")
+    parser.add_argument("--split", default="test", choices=("test",), help="Local split name.")
+    parser.add_argument(
+        "--only", nargs="*", default=None, help="Restrict to these sub-benchmark output dirs (e.g. safety_hijack)."
+    )
+    args = parser.parse_args()
+    main(args)

--- a/nemo_skills/dataset/iheval/rule_following_multi/__init__.py
+++ b/nemo_skills/dataset/iheval/rule_following_multi/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "iheval"
+GENERATION_ARGS = "++prompt_format=openai"
+EVAL_ARGS = "++eval_type=iheval_rule_following"

--- a/nemo_skills/dataset/iheval/rule_following_single/__init__.py
+++ b/nemo_skills/dataset/iheval/rule_following_single/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "iheval"
+GENERATION_ARGS = "++prompt_format=openai"
+EVAL_ARGS = "++eval_type=iheval_rule_following"

--- a/nemo_skills/dataset/iheval/safety_extract/__init__.py
+++ b/nemo_skills/dataset/iheval/safety_extract/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "iheval"
+GENERATION_ARGS = "++prompt_format=openai"
+EVAL_ARGS = "++eval_type=iheval_safety"

--- a/nemo_skills/dataset/iheval/safety_hijack/__init__.py
+++ b/nemo_skills/dataset/iheval/safety_hijack/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "iheval"
+GENERATION_ARGS = "++prompt_format=openai"
+EVAL_ARGS = "++eval_type=iheval_safety"

--- a/nemo_skills/dataset/iheval/task_execution_lang_detect/__init__.py
+++ b/nemo_skills/dataset/iheval/task_execution_lang_detect/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "iheval"
+GENERATION_ARGS = "++prompt_format=openai"
+EVAL_ARGS = "++eval_type=iheval_lang_detect"

--- a/nemo_skills/dataset/iheval/task_execution_translation/__init__.py
+++ b/nemo_skills/dataset/iheval/task_execution_translation/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "iheval"
+GENERATION_ARGS = "++prompt_format=openai"
+EVAL_ARGS = "++eval_type=iheval_translation"

--- a/nemo_skills/dataset/iheval/task_execution_verb_extract/__init__.py
+++ b/nemo_skills/dataset/iheval/task_execution_verb_extract/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "iheval"
+GENERATION_ARGS = "++prompt_format=openai"
+EVAL_ARGS = "++eval_type=iheval_verb_extract"

--- a/nemo_skills/dataset/iheval/tool_use_slack_user/__init__.py
+++ b/nemo_skills/dataset/iheval/tool_use_slack_user/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "iheval"
+GENERATION_ARGS = "++prompt_format=openai"
+EVAL_ARGS = "++eval_type=iheval_slack_user"

--- a/nemo_skills/dataset/iheval/tool_use_webpage/__init__.py
+++ b/nemo_skills/dataset/iheval/tool_use_webpage/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "iheval"
+GENERATION_ARGS = "++prompt_format=openai"
+EVAL_ARGS = "++eval_type=iheval_webpage"

--- a/nemo_skills/evaluation/evaluator/__init__.py
+++ b/nemo_skills/evaluation/evaluator/__init__.py
@@ -43,6 +43,14 @@ _EVALUATOR_MAP_PATHS = {
     "human_eval_infilling": "nemo_skills.evaluation.evaluator.code:eval_human_eval_infilling",
     "mmau-pro": "nemo_skills.evaluation.evaluator.mmau_pro:eval_mmau_pro",
     "specdec": "nemo_skills.evaluation.evaluator.specdec:eval_specdec",
+    # IHEval sub-benchmark scorers (thin wrappers over the external `iheval` package)
+    "iheval_rule_following": "nemo_skills.evaluation.evaluator.iheval:eval_rule_following",
+    "iheval_verb_extract": "nemo_skills.evaluation.evaluator.iheval:eval_verb_extract",
+    "iheval_translation": "nemo_skills.evaluation.evaluator.iheval:eval_translation",
+    "iheval_lang_detect": "nemo_skills.evaluation.evaluator.iheval:eval_lang_detect",
+    "iheval_safety": "nemo_skills.evaluation.evaluator.iheval:eval_safety",
+    "iheval_slack_user": "nemo_skills.evaluation.evaluator.iheval:eval_slack_user",
+    "iheval_webpage": "nemo_skills.evaluation.evaluator.iheval:eval_webpage",
 }
 
 # Class-based evaluators: eval_type -> "module_path:ClassName"

--- a/nemo_skills/evaluation/evaluator/iheval.py
+++ b/nemo_skills/evaluation/evaluator/iheval.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IHEval evaluators — thin wrappers that score the jsonl in place via the external
+``iheval`` package (https://github.com/bzantium/iheval), lazily imported like ``bfcl_eval``."""
+
+import json
+import logging
+
+from nemo_skills.evaluation.evaluator.base import BaseEvaluatorConfig
+from nemo_skills.utils import get_logger_name
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+_INSTALL_HINT = (
+    "The 'iheval' package is required to evaluate IHEval benchmarks. "
+    "Install it with: pip install git+https://github.com/bzantium/iheval.git"
+)
+
+
+def _get_scorer(task: str):
+    try:
+        from iheval import SCORERS
+    except ImportError as exc:
+        raise ImportError(_INSTALL_HINT) from exc
+    return SCORERS[task]
+
+
+def _score_in_place(cfg, task: str):
+    cfg = BaseEvaluatorConfig(**cfg)
+    scorer = _get_scorer(task)
+    jsonl_file = cfg.input_file
+
+    with open(jsonl_file, "rt", encoding="utf-8") as fin:
+        rows = [json.loads(line) for line in fin]
+
+    for row in rows:
+        scorer(row)
+
+    with open(jsonl_file, "wt", encoding="utf-8") as fout:
+        for row in rows:
+            fout.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def eval_rule_following(cfg):
+    _score_in_place(cfg, "rule_following")
+
+
+def eval_verb_extract(cfg):
+    _score_in_place(cfg, "verb_extract")
+
+
+def eval_translation(cfg):
+    _score_in_place(cfg, "translation")
+
+
+def eval_lang_detect(cfg):
+    _score_in_place(cfg, "lang_detect")
+
+
+def eval_safety(cfg):
+    _score_in_place(cfg, "safety")
+
+
+def eval_slack_user(cfg):
+    _score_in_place(cfg, "slack_user")
+
+
+def eval_webpage(cfg):
+    _score_in_place(cfg, "webpage")

--- a/nemo_skills/evaluation/metrics/iheval_metrics.py
+++ b/nemo_skills/evaluation/metrics/iheval_metrics.py
@@ -12,22 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from collections import defaultdict
 
 from nemo_skills.evaluation.metrics.base import BaseMetrics
 
 
 class IHEvalMetrics(BaseMetrics):
-    """Metrics for IHEval sub-benchmarks.
-
-    Uses the base ``_compute_pass_at_k`` machinery so that running ``iheval:N``
-    (N samples per question) yields proper ``pass@1[avg-of-N]`` / ``pass@N``
-    aggregates over the per-row ``symbolic_correct`` score (which may be
-    fractional, e.g. F1/ROUGE-L for the task-execution subs). On top of that it
-    tracks per-``setting`` (aligned/conflict/reference) and per-``variant``
-    breakdowns, averaged over attempts so they remain meaningful for pass@k runs
-    (and match pass@1 when N=1).
-    """
+    """Pass@k over symbolic_correct with per-setting / per-variant breakdowns."""
 
     def _get_score_dict(self, prediction: dict) -> dict[str, float]:
         return {"symbolic_correct": float(prediction.get("symbolic_correct", 0.0))}
@@ -40,36 +32,67 @@ class IHEvalMetrics(BaseMetrics):
     def update(self, predictions):
         super().update(predictions)
         self._compute_pass_at_k(predictions=predictions)
-
-        # Per-setting / per-variant tracking uses avg-over-attempts so it still
-        # works for pass@k-style sampling runs, while matching pass@1 when k=1.
-        scores = [float(p.get("symbolic_correct", 0.0)) for p in predictions]
-        avg = sum(scores) / len(scores)
-
-        setting = predictions[0].get("setting")
-        if setting:
-            self._setting_totals[setting] += 1
-            self._setting_correct[setting] += avg
-
-        variant = predictions[0].get("variant")
-        if variant:
-            self._variant_totals[variant] += 1
-            self._variant_correct[variant] += avg
+        self._sample_scores.append([float(p.get("symbolic_correct", 0.0)) for p in predictions])
+        self._sample_settings.append(predictions[0].get("setting"))
+        self._sample_variants.append(predictions[0].get("variant"))
 
     def get_metrics(self):
         metrics_dict = super().get_metrics()
-        for agg_dict in metrics_dict.values():
-            for setting, total in self._setting_totals.items():
-                if total > 0:
-                    agg_dict[f"setting_{setting}"] = 100.0 * self._setting_correct[setting] / total
-            for variant, total in self._variant_totals.items():
-                if total > 0:
-                    agg_dict[f"variant_{variant}"] = 100.0 * self._variant_correct[variant] / total
+        for mode_key, agg_dict in metrics_dict.items():
+            aggregator = self._mode_aggregator(mode_key)
+            if aggregator is None:
+                continue
+            setting_sums: dict[str, float] = defaultdict(float)
+            setting_counts: dict[str, int] = defaultdict(int)
+            variant_sums: dict[str, float] = defaultdict(float)
+            variant_counts: dict[str, int] = defaultdict(int)
+            for scores, setting, variant in zip(self._sample_scores, self._sample_settings, self._sample_variants):
+                value = aggregator(scores)
+                if setting:
+                    setting_sums[setting] += value
+                    setting_counts[setting] += 1
+                if variant:
+                    variant_sums[variant] += value
+                    variant_counts[variant] += 1
+            for setting, count in setting_counts.items():
+                agg_dict[f"setting_{setting}"] = 100.0 * setting_sums[setting] / count
+            for variant, count in variant_counts.items():
+                agg_dict[f"variant_{variant}"] = 100.0 * variant_sums[variant] / count
         return metrics_dict
+
+    @staticmethod
+    def _mode_aggregator(mode_key: str):
+        # Mirror base._compute_pass_at_k per mode so breakdowns stay consistent with
+        # symbolic_correct. pass@1 has no special case on purpose: base uses the same
+        # probabilistic formula at k=1 for binary scores, which _pass_at_k reproduces.
+        if mode_key.startswith("pass@1[avg-of-") and mode_key.endswith("]"):
+            try:
+                k = int(mode_key[len("pass@1[avg-of-") : -1])
+            except ValueError:
+                return None
+            return lambda scores: sum(scores[:k]) / k if scores else 0.0
+        if mode_key.startswith("pass@"):
+            try:
+                k = int(mode_key[len("pass@") :])
+            except ValueError:
+                return None
+            return lambda scores: _pass_at_k(scores, k)
+        return None
 
     def reset(self):
         super().reset()
-        self._setting_totals: dict[str, int] = defaultdict(int)
-        self._setting_correct: dict[str, float] = defaultdict(float)
-        self._variant_totals: dict[str, int] = defaultdict(int)
-        self._variant_correct: dict[str, float] = defaultdict(float)
+        self._sample_scores: list[list[float]] = []
+        self._sample_settings: list[str | None] = []
+        self._sample_variants: list[str | None] = []
+
+
+def _pass_at_k(scores: list[float], k: int) -> float:
+    if not scores:
+        return 0.0
+    if all(s in (0, 1, True, False) for s in scores):
+        total = len(scores)
+        total_incorrect = total - int(sum(scores))
+        if total_incorrect < k:
+            return 1.0
+        return 1.0 - math.comb(total_incorrect, k) / math.comb(total, k)
+    return max(scores[:k])

--- a/nemo_skills/evaluation/metrics/iheval_metrics.py
+++ b/nemo_skills/evaluation/metrics/iheval_metrics.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+
+from nemo_skills.evaluation.metrics.base import BaseMetrics
+
+
+class IHEvalMetrics(BaseMetrics):
+    """Metrics for IHEval sub-benchmarks.
+
+    Uses the base ``_compute_pass_at_k`` machinery so that running ``iheval:N``
+    (N samples per question) yields proper ``pass@1[avg-of-N]`` / ``pass@N``
+    aggregates over the per-row ``symbolic_correct`` score (which may be
+    fractional, e.g. F1/ROUGE-L for the task-execution subs). On top of that it
+    tracks per-``setting`` (aligned/conflict/reference) and per-``variant``
+    breakdowns, averaged over attempts so they remain meaningful for pass@k runs
+    (and match pass@1 when N=1).
+    """
+
+    def _get_score_dict(self, prediction: dict) -> dict[str, float]:
+        return {"symbolic_correct": float(prediction.get("symbolic_correct", 0.0))}
+
+    def get_incorrect_sample(self, prediction: dict) -> dict:
+        prediction = prediction.copy()
+        prediction["symbolic_correct"] = 0.0
+        return prediction
+
+    def update(self, predictions):
+        super().update(predictions)
+        self._compute_pass_at_k(predictions=predictions)
+
+        # Per-setting / per-variant tracking uses avg-over-attempts so it still
+        # works for pass@k-style sampling runs, while matching pass@1 when k=1.
+        scores = [float(p.get("symbolic_correct", 0.0)) for p in predictions]
+        avg = sum(scores) / len(scores)
+
+        setting = predictions[0].get("setting")
+        if setting:
+            self._setting_totals[setting] += 1
+            self._setting_correct[setting] += avg
+
+        variant = predictions[0].get("variant")
+        if variant:
+            self._variant_totals[variant] += 1
+            self._variant_correct[variant] += avg
+
+    def get_metrics(self):
+        metrics_dict = super().get_metrics()
+        for agg_dict in metrics_dict.values():
+            for setting, total in self._setting_totals.items():
+                if total > 0:
+                    agg_dict[f"setting_{setting}"] = 100.0 * self._setting_correct[setting] / total
+            for variant, total in self._variant_totals.items():
+                if total > 0:
+                    agg_dict[f"variant_{variant}"] = 100.0 * self._variant_correct[variant] / total
+        return metrics_dict
+
+    def reset(self):
+        super().reset()
+        self._setting_totals: dict[str, int] = defaultdict(int)
+        self._setting_correct: dict[str, float] = defaultdict(float)
+        self._variant_totals: dict[str, int] = defaultdict(int)
+        self._variant_correct: dict[str, float] = defaultdict(float)

--- a/nemo_skills/evaluation/metrics/map_metrics.py
+++ b/nemo_skills/evaluation/metrics/map_metrics.py
@@ -37,6 +37,7 @@ from nemo_skills.evaluation.metrics.hleaa_metrics import HLEAAMetrics
 from nemo_skills.evaluation.metrics.hotpotqa_metrics import HotpotQAMetrics
 from nemo_skills.evaluation.metrics.icpc_metrics import ICPCMetrics
 from nemo_skills.evaluation.metrics.if_metrics import IFMetrics
+from nemo_skills.evaluation.metrics.iheval_metrics import IHEvalMetrics
 from nemo_skills.evaluation.metrics.ioi_metrics import IOIMetrics
 from nemo_skills.evaluation.metrics.lean4_metrics import Lean4Metrics
 from nemo_skills.evaluation.metrics.math_metrics import MathMetrics
@@ -103,6 +104,7 @@ METRICS_MAP = {
     "hotpotqa": HotpotQAMetrics,
     "hotpotqa_closedbook": functools.partial(HotpotQAMetrics, closed_book=True),
     "weighted-math": WeightedMathMetrics,
+    "iheval": IHEvalMetrics,
 }
 
 

--- a/tests/test_iheval_metrics.py
+++ b/tests/test_iheval_metrics.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for IHEval metrics aggregation (per-setting / per-variant on top of pass@k)."""
+
+import pytest
+
+from nemo_skills.evaluation.metrics.iheval_metrics import IHEvalMetrics
+
+
+def _row(correct, setting=None, variant=None, tokens=10):
+    r = {"symbolic_correct": correct, "num_generated_tokens": tokens}
+    if setting is not None:
+        r["setting"] = setting
+    if variant is not None:
+        r["variant"] = variant
+    return r
+
+
+def _update_all(m, rows):
+    for row in rows:
+        m.update([row])
+
+
+class TestIHEvalMetricsAllCorrect:
+    def test_all_correct_reports_100_everywhere(self):
+        m = IHEvalMetrics()
+        rows = [
+            _row(1.0, "aligned", "default"),
+            _row(1.0, "aligned", "strong"),
+            _row(1.0, "conflict", "default"),
+            _row(1.0, "conflict", "strong"),
+            _row(1.0, "reference", "default"),
+        ]
+        _update_all(m, rows)
+        out = m.get_metrics()
+        assert "pass@1" in out
+        agg = out["pass@1"]
+        assert agg["symbolic_correct"] == pytest.approx(100.0)
+        assert agg["setting_aligned"] == pytest.approx(100.0)
+        assert agg["setting_conflict"] == pytest.approx(100.0)
+        assert agg["setting_reference"] == pytest.approx(100.0)
+        assert agg["variant_default"] == pytest.approx(100.0)
+        assert agg["variant_strong"] == pytest.approx(100.0)
+        assert agg["num_entries"] == 5
+
+
+class TestIHEvalMetricsMixed:
+    def test_mixed_breakdown(self):
+        m = IHEvalMetrics()
+        rows = []
+        for _ in range(3):
+            rows.append(_row(1.0, "aligned", "default"))
+        for _ in range(2):
+            rows.append(_row(0.0, "aligned", "default"))
+        rows.append(_row(1.0, "conflict", "strong"))
+        for _ in range(4):
+            rows.append(_row(0.0, "conflict", "strong"))
+        for _ in range(3):
+            rows.append(_row(1.0, "reference", "default"))
+        _update_all(m, rows)
+        agg = m.get_metrics()["pass@1"]
+        assert agg["symbolic_correct"] == pytest.approx(100.0 * 7 / 13)
+        assert agg["setting_aligned"] == pytest.approx(60.0)
+        assert agg["setting_conflict"] == pytest.approx(20.0)
+        assert agg["setting_reference"] == pytest.approx(100.0)
+        assert agg["variant_default"] == pytest.approx(75.0)
+        assert agg["variant_strong"] == pytest.approx(20.0)
+        assert agg["num_entries"] == 13
+
+
+class TestIHEvalMetricsMissingKeys:
+    def test_no_reference_rows_omits_reference_key(self):
+        m = IHEvalMetrics()
+        _update_all(m, [_row(1.0, "aligned", "default"), _row(0.0, "conflict", "default")])
+        agg = m.get_metrics()["pass@1"]
+        assert "setting_aligned" in agg
+        assert "setting_conflict" in agg
+        assert "setting_reference" not in agg
+
+    def test_missing_setting_key_omits_setting_breakdown(self):
+        m = IHEvalMetrics()
+        _update_all(m, [_row(1.0, variant="default"), _row(0.0, variant="strong")])
+        agg = m.get_metrics()["pass@1"]
+        assert not any(k.startswith("setting_") for k in agg)
+        assert "variant_default" in agg
+        assert "variant_strong" in agg
+
+    def test_missing_variant_key_omits_variant_breakdown(self):
+        m = IHEvalMetrics()
+        _update_all(m, [_row(1.0, setting="aligned"), _row(0.0, setting="conflict")])
+        agg = m.get_metrics()["pass@1"]
+        assert not any(k.startswith("variant_") for k in agg)
+        assert "setting_aligned" in agg
+        assert "setting_conflict" in agg
+
+    def test_all_missing_still_tracks_overall(self):
+        m = IHEvalMetrics()
+        _update_all(m, [_row(1.0), _row(0.0), _row(1.0)])
+        agg = m.get_metrics()["pass@1"]
+        assert agg["symbolic_correct"] == pytest.approx(100.0 * 2 / 3)
+        assert not any(k.startswith("setting_") for k in agg)
+        assert not any(k.startswith("variant_") for k in agg)
+        assert agg["num_entries"] == 3
+
+
+class TestIHEvalMetricsFloatScores:
+    def test_fractional_symbolic_correct(self):
+        m = IHEvalMetrics()
+        _update_all(
+            m,
+            [
+                _row(0.5, "aligned", "default"),
+                _row(0.25, "aligned", "default"),
+                _row(1.0, "conflict", "strong"),
+            ],
+        )
+        agg = m.get_metrics()["pass@1"]
+        assert agg["symbolic_correct"] == pytest.approx(100.0 * 1.75 / 3)
+        assert agg["setting_aligned"] == pytest.approx(37.5)
+        assert agg["setting_conflict"] == pytest.approx(100.0)
+
+
+class TestIHEvalMetricsPassAtK:
+    def test_iheval_n_yields_pass_at_1_avg_of_n(self):
+        # iheval:N feeds N predictions per question; metrics should expose pass@1[avg-of-N].
+        m = IHEvalMetrics()
+        # one question, 2 samples (one correct, one wrong) -> avg-of-2 = 50%
+        m.update([_row(1.0, "aligned", "default"), _row(0.0, "aligned", "default")])
+        out = m.get_metrics()
+        assert "pass@1[avg-of-2]" in out
+        assert out["pass@1[avg-of-2]"]["symbolic_correct"] == pytest.approx(50.0)
+        # per-setting breakdown uses avg-over-attempts -> also 50%
+        assert out["pass@1[avg-of-2]"]["setting_aligned"] == pytest.approx(50.0)
+
+
+class TestIHEvalMetricsReset:
+    def test_reset_clears_all_state(self):
+        m = IHEvalMetrics()
+        _update_all(m, [_row(1.0, "aligned", "default"), _row(0.0, "conflict", "strong")])
+        assert m.total == 2
+        m.reset()
+        assert m.total == 0
+        assert m._setting_totals == {}
+        assert m._variant_totals == {}
+        assert len(m.eval_dict) == 0

--- a/tests/test_iheval_metrics.py
+++ b/tests/test_iheval_metrics.py
@@ -152,6 +152,61 @@ class TestIHEvalMetricsReset:
         assert m.total == 2
         m.reset()
         assert m.total == 0
-        assert m._setting_totals == {}
-        assert m._variant_totals == {}
+        assert m._sample_scores == []
+        assert m._sample_settings == []
+        assert m._sample_variants == []
         assert len(m.eval_dict) == 0
+
+
+class TestIHEvalMetricsPerModeConsistency:
+    def test_pass_at_n_setting_matches_best_of_n(self):
+        # Codex review regression: pass@N.setting_* used to be avg-over-attempts even
+        # though pass@N.symbolic_correct is best-of-N, making the row inconsistent.
+        m = IHEvalMetrics()
+        # Two samples in 'aligned', each with 2 attempts (one pass / one fail).
+        m.update([_row(1.0, "aligned", "default"), _row(0.0, "aligned", "default")])
+        m.update([_row(0.0, "aligned", "default"), _row(1.0, "aligned", "default")])
+        out = m.get_metrics()
+        # pass@2.symbolic_correct = best-of-2 averaged across samples = (1 + 1) / 2 = 100%
+        assert out["pass@2"]["symbolic_correct"] == pytest.approx(100.0)
+        assert out["pass@2"]["setting_aligned"] == pytest.approx(100.0)
+        # pass@1[avg-of-2].symbolic_correct = mean-over-attempts = (0.5 + 0.5) / 2 = 50%
+        assert out["pass@1[avg-of-2]"]["symbolic_correct"] == pytest.approx(50.0)
+        assert out["pass@1[avg-of-2]"]["setting_aligned"] == pytest.approx(50.0)
+        # pass@1.symbolic_correct uses first attempt only -> (1 + 0) / 2 = 50%
+        assert out["pass@1"]["symbolic_correct"] == pytest.approx(50.0)
+        assert out["pass@1"]["setting_aligned"] == pytest.approx(50.0)
+
+    def test_pass_at_1_binary_matches_base_probabilistic(self):
+        # base's pass@1 for binary scores is the probabilistic estimate over N
+        # attempts (= correct/N), NOT the first attempt. setting_*/variant_* must
+        # follow the same definition or pass@1 becomes internally inconsistent.
+        m = IHEvalMetrics()
+        # One sample, 2 attempts, binary: [1, 0] -> base pass@1 = 0.5 (not scores[0]=1)
+        m.update([_row(1.0, "aligned", "default"), _row(0.0, "aligned", "default")])
+        out = m.get_metrics()
+        assert out["pass@1"]["symbolic_correct"] == pytest.approx(50.0)
+        assert out["pass@1"]["setting_aligned"] == pytest.approx(50.0)
+        assert out["pass@1"]["variant_default"] == pytest.approx(50.0)
+
+    def test_pass_at_1_fractional_uses_first_attempt(self):
+        # Non-binary: base's pass@1 = max(scores[:1]) = scores[0]. Generic _pass_at_k
+        # branch reproduces this.
+        m = IHEvalMetrics()
+        m.update([_row(0.3, "aligned", "default"), _row(0.9, "aligned", "default")])
+        out = m.get_metrics()
+        assert out["pass@1"]["symbolic_correct"] == pytest.approx(30.0)
+        assert out["pass@1"]["setting_aligned"] == pytest.approx(30.0)
+
+    def test_pass_at_n_variant_matches_best_of_n_fractional(self):
+        # Fractional scores: max-of-attempts per sample, then averaged across samples.
+        m = IHEvalMetrics()
+        m.update([_row(0.4, "aligned", "default"), _row(0.9, "aligned", "default")])
+        m.update([_row(0.6, "aligned", "default"), _row(0.2, "aligned", "default")])
+        out = m.get_metrics()
+        # pass@2 (fractional) = max per sample -> 0.9, 0.6 -> avg 0.75
+        assert out["pass@2"]["symbolic_correct"] == pytest.approx(75.0)
+        assert out["pass@2"]["variant_default"] == pytest.approx(75.0)
+        # pass@1[avg-of-2] = avg per sample -> 0.65, 0.4 -> avg 0.525
+        assert out["pass@1[avg-of-2]"]["symbolic_correct"] == pytest.approx(52.5)
+        assert out["pass@1[avg-of-2]"]["variant_default"] == pytest.approx(52.5)

--- a/tests/test_iheval_score.py
+++ b/tests/test_iheval_score.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the IHEval group-level composite score (compute_score)."""
+
+from nemo_skills.dataset.iheval.iheval_score import compute_score
+
+
+def _sub(entries, symbolic, **extra):
+    return {"pass@1": {"num_entries": entries, "symbolic_correct": symbolic, **extra}}
+
+
+def _full_metrics(**overrides):
+    """Construct metrics for all 9 subs, each with a default or overridden value."""
+    defaults = {
+        "rule_following_single": (100, 50.0),
+        "rule_following_multi": (100, 40.0),
+        "task_execution_verb_extract": (250, 60.0),
+        "task_execution_translation": (250, 55.0),
+        "task_execution_lang_detect": (240, 70.0),
+        "safety_hijack": (100, 80.0),
+        "safety_extract": (100, 75.0),
+        "tool_use_webpage": (150, 65.0),
+        "tool_use_slack_user": (100, 45.0),
+    }
+    metrics = {}
+    for sub, (n, s) in defaults.items():
+        extra = overrides.pop(sub, {})
+        metrics[f"iheval.{sub}"] = _sub(n, s, **extra)
+    assert not overrides, f"unused overrides: {overrides}"
+    return metrics
+
+
+class TestComputeScore:
+    def test_shape(self):
+        out = compute_score(_full_metrics())
+        assert list(out.keys()) == ["iheval"]
+        pass1 = out["iheval"]["pass@1"]
+        expected_keys = {
+            "num_entries",
+            "symbolic_correct",
+            "aligned_avg",
+            "conflict_avg",
+            "reference_avg",
+            "conflict_gap",
+            "rule_following_avg",
+            "task_execution_avg",
+            "safety_avg",
+            "tool_use_avg",
+        }
+        assert set(pass1.keys()) == expected_keys
+
+    def test_overall_is_mean_of_subs(self):
+        out = compute_score(_full_metrics())
+        expected = (50 + 40 + 60 + 55 + 70 + 80 + 75 + 65 + 45) / 9
+        assert abs(out["iheval"]["pass@1"]["symbolic_correct"] - expected) < 1e-9
+
+    def test_category_averages(self):
+        pass1 = compute_score(_full_metrics())["iheval"]["pass@1"]
+        assert pass1["rule_following_avg"] == (50 + 40) / 2
+        assert pass1["task_execution_avg"] == (60 + 55 + 70) / 3
+        assert pass1["safety_avg"] == (80 + 75) / 2
+        assert pass1["tool_use_avg"] == (65 + 45) / 2
+
+    def test_total_entries_sum(self):
+        out = compute_score(_full_metrics())
+        assert out["iheval"]["pass@1"]["num_entries"] == 100 + 100 + 250 + 250 + 240 + 100 + 100 + 150 + 100
+
+    def test_per_setting_avgs_and_gap(self):
+        metrics = _full_metrics(
+            rule_following_single={"setting_aligned": 60.0, "setting_conflict": 30.0, "setting_reference": 70.0},
+            rule_following_multi={"setting_aligned": 50.0, "setting_conflict": 20.0, "setting_reference": 60.0},
+            safety_hijack={"setting_aligned": 90.0, "setting_conflict": 70.0},  # no reference
+            safety_extract={"setting_aligned": 85.0, "setting_conflict": 65.0},
+        )
+        out = compute_score(metrics)["iheval"]["pass@1"]
+        assert out["aligned_avg"] == (60 + 50 + 90 + 85) / 4
+        assert out["conflict_avg"] == (30 + 20 + 70 + 65) / 4
+        assert out["reference_avg"] == (70 + 60) / 2
+        assert out["conflict_gap"] == out["reference_avg"] - out["conflict_avg"]
+
+    def test_missing_sub_treated_as_skipped(self):
+        metrics = _full_metrics()
+        del metrics["iheval.safety_hijack"]  # simulate failed sub
+        pass1 = compute_score(metrics)["iheval"]["pass@1"]
+        expected_overall = (50 + 40 + 60 + 55 + 70 + 75 + 65 + 45) / 8
+        assert abs(pass1["symbolic_correct"] - expected_overall) < 1e-9
+        assert pass1["safety_avg"] == 75.0
+
+    def test_empty_metrics(self):
+        pass1 = compute_score({})["iheval"]["pass@1"]
+        assert pass1["num_entries"] == 0
+        assert pass1["symbolic_correct"] == 0.0
+        assert pass1["conflict_gap"] == 0.0
+
+    def test_symbolic_correct_is_representative_key(self):
+        # aggregate_metrics picks `symbolic_correct` as the representative pass@1 value.
+        pass1 = compute_score(_full_metrics())["iheval"]["pass@1"]
+        assert "symbolic_correct" in pass1
+        assert isinstance(pass1["symbolic_correct"], float)
+
+    def test_pass_at_k_modes_are_aggregated(self):
+        # iheval:N -> each sub reports extra agg modes; the group composite must surface them all.
+        metrics = _full_metrics()
+        for name, sub in metrics.items():
+            base = sub["pass@1"]["symbolic_correct"]
+            sub["pass@4"] = {"num_entries": sub["pass@1"]["num_entries"], "symbolic_correct": base + 10}
+            sub["pass@1[avg-of-4]"] = {"num_entries": sub["pass@1"]["num_entries"], "symbolic_correct": base - 5}
+        out = compute_score(metrics)["iheval"]
+        assert set(out.keys()) == {"pass@1", "pass@4", "pass@1[avg-of-4]"}
+        base_overall = (50 + 40 + 60 + 55 + 70 + 80 + 75 + 65 + 45) / 9
+        assert out["pass@1"]["symbolic_correct"] == base_overall
+        assert out["pass@4"]["symbolic_correct"] == base_overall + 10
+        assert out["pass@1[avg-of-4]"]["symbolic_correct"] == base_overall - 5


### PR DESCRIPTION
Closes #1463.

Adds **IHEval** (Instruction Hierarchy Evaluation) — measures whether a model respects the **system > user > tool** instruction hierarchy. It is a benchmark **group** with 9 sub-benchmarks across 4 categories (rule-following, task-execution, safety, tool-use), each in `aligned` / `conflict` / `reference` settings.

## What's included

- **`nemo_skills/dataset/iheval/`** — benchmark group (mirrors the `mmau-pro` pattern): group `__init__.py` (`IS_BENCHMARK_GROUP` + 9 sub-benchmarks + `SCORE_MODULE`), HF-based `prepare.py`, `iheval_score.py` group composite, and 9 sub-benchmark configs.
- **`prepare.py`** downloads per-variant `input_data.json` from the [`zhihz0535/IHEval`](https://huggingface.co/datasets/zhihz0535/IHEval) HF mirror via `hf_hub_download`; the generated `test.jsonl` is gitignored (not committed). Rows carry a pre-built OpenAI-style `messages` list (multi-turn + tool_calls / tool results), so generation uses `++prompt_format=openai`.
- **Scoring** lives in the standalone Apache-2.0 package [`bzantium/iheval`](https://github.com/bzantium/iheval); `evaluation/evaluator/iheval.py` is a thin lazy-import wrapper (same pattern as `bfcl_eval`), pinned in the Dockerfile. Rationale: upstream IHEval is CC BY-NC-ND with no installable package; the rule-following checkers derive from Google IFEval (Apache-2.0), the rest are independent re-implementations of the documented rule-based metrics.
- **`IHEvalMetrics`** builds on the base pass@k machinery, so `iheval:N` yields `pass@1[avg-of-N]` (per-mode composites at the group level too), with per-`setting` (aligned/conflict/reference) and per-`variant` breakdowns.
- Registered `iheval_*` eval types + the `iheval` metrics key; documented under instruction-following.

## Usage

```bash
ns eval --benchmarks iheval ...            # all 9 sub-benchmarks
ns eval --benchmarks iheval.safety_hijack  # a single sub-benchmark
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IHEval benchmark support: dataset preparation, nine sub-benchmarks, per-task evaluation entrypoints, and group-level score aggregation and metrics.

* **Documentation**
  * Added IHEval docs describing benchmark structure, categories, settings, and resources.

* **Tests**
  * Added comprehensive tests validating metrics aggregation, per-setting/variant breakdowns, and group scoring behavior.

* **Chores**
  * Updated Docker build to install the IHEval scoring package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->