### PR TITLE
Warn on risky hosted server allocations

### DIFF
--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -545,14 +545,6 @@ def generate(
                     exclusive,
                     pipeline_utils.get_cluster_gpus_per_node(cluster_config),
                 )
-                pipeline_utils.warn_hosted_server_allocation(
-                    server_gpus=server_gpus_list[model_idx],
-                    exclusive=exclusive,
-                    gpus_per_node=pipeline_utils.get_cluster_gpus_per_node(cluster_config),
-                    get_random_port=get_random_port_for_server,
-                    server_port=None,
-                    context="ns generate",
-                )
 
                 srv_config, srv_address, srv_extra_args = pipeline_utils.configure_client(
                     model=models_list[model_idx],

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -541,7 +541,17 @@ def generate(
 
             for model_idx in range(num_models):
                 get_random_port_for_server = pipeline_utils.should_get_random_port(
-                    server_gpus_list[model_idx], exclusive
+                    server_gpus_list[model_idx],
+                    exclusive,
+                    pipeline_utils.get_cluster_gpus_per_node(cluster_config),
+                )
+                pipeline_utils.warn_hosted_server_allocation(
+                    server_gpus=server_gpus_list[model_idx],
+                    exclusive=exclusive,
+                    gpus_per_node=pipeline_utils.get_cluster_gpus_per_node(cluster_config),
+                    get_random_port=get_random_port_for_server,
+                    server_port=None,
+                    context="ns generate",
                 )
 
                 srv_config, srv_address, srv_extra_args = pipeline_utils.configure_client(

--- a/nemo_skills/pipeline/nemo_rl/grpo.py
+++ b/nemo_skills/pipeline/nemo_rl/grpo.py
@@ -27,6 +27,7 @@ from nemo_skills.pipeline.utils import (
     check_if_mounted,
     check_mounts,
     get_cluster_config,
+    get_cluster_gpus_per_node,
     get_env_variables,
     get_exp,
     get_mounted_path,
@@ -37,6 +38,7 @@ from nemo_skills.pipeline.utils import (
     run_exp,
     should_get_random_port,
     temporary_env_update,
+    warn_hosted_server_allocation,
 )
 from nemo_skills.pipeline.utils.server import SupportedServers, get_free_port
 from nemo_skills.utils import (
@@ -439,7 +441,16 @@ def grpo_nemo_rl(
     # Server configuration for LLM-as-a-judge
     server_config = None
     if server_type is not None:
-        get_random_port = should_get_random_port(server_gpus, exclusive)
+        gpus_per_node = get_cluster_gpus_per_node(cluster_config)
+        get_random_port = should_get_random_port(server_gpus, exclusive, gpus_per_node)
+        warn_hosted_server_allocation(
+            server_gpus=server_gpus,
+            exclusive=exclusive,
+            gpus_per_node=gpus_per_node,
+            get_random_port=get_random_port,
+            server_port=None,
+            context="ns nemo-rl grpo",
+        )
         if server_address is None:  # we need to host the model
             assert server_gpus is not None, "Need to specify server_gpus if hosting the model"
             server_port = get_free_port(strategy="random") if get_random_port else 5000

--- a/nemo_skills/pipeline/nemo_rl/grpo.py
+++ b/nemo_skills/pipeline/nemo_rl/grpo.py
@@ -38,7 +38,6 @@ from nemo_skills.pipeline.utils import (
     run_exp,
     should_get_random_port,
     temporary_env_update,
-    warn_hosted_server_allocation,
 )
 from nemo_skills.pipeline.utils.server import SupportedServers, get_free_port
 from nemo_skills.utils import (
@@ -443,14 +442,6 @@ def grpo_nemo_rl(
     if server_type is not None:
         gpus_per_node = get_cluster_gpus_per_node(cluster_config)
         get_random_port = should_get_random_port(server_gpus, exclusive, gpus_per_node)
-        warn_hosted_server_allocation(
-            server_gpus=server_gpus,
-            exclusive=exclusive,
-            gpus_per_node=gpus_per_node,
-            get_random_port=get_random_port,
-            server_port=None,
-            context="ns nemo-rl grpo",
-        )
         if server_address is None:  # we need to host the model
             assert server_gpus is not None, "Need to specify server_gpus if hosting the model"
             server_port = get_free_port(strategy="random") if get_random_port else 5000

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -35,7 +35,6 @@ from nemo_skills.pipeline.utils import (
     resolve_mount_paths,
     set_python_path_and_wait_for_server,
     should_get_random_port,
-    warn_hosted_server_allocation,
 )
 from nemo_skills.utils import get_logger_name, setup_logging
 
@@ -156,20 +155,15 @@ def launch_server(
     log_dir = check_mounts(cluster_config, log_dir, check_mounted_paths=check_mounted_paths)
 
     gpus_per_node = get_cluster_gpus_per_node(cluster_config)
-    if get_random_port is None:
-        get_random_port = should_get_random_port(
-            server_gpus=server_gpus,
-            exclusive=(sbatch_kwargs or {}).get("exclusive") if isinstance(sbatch_kwargs, dict) else None,
-            gpus_per_node=gpus_per_node,
-        )
-    warn_hosted_server_allocation(
+    exclusive = (sbatch_kwargs or {}).get("exclusive")
+    resolved_random_port = should_get_random_port(
         server_gpus=server_gpus,
-        exclusive=(sbatch_kwargs or {}).get("exclusive") if isinstance(sbatch_kwargs, dict) else None,
+        exclusive=exclusive,
         gpus_per_node=gpus_per_node,
-        get_random_port=get_random_port,
         server_port=server_port,
-        context="ns start_server",
     )
+    if get_random_port is None:
+        get_random_port = resolved_random_port
 
     if server_port is None:
         server_port = get_free_port(strategy="random") if get_random_port else 5000
@@ -284,20 +278,13 @@ def start_server(
     """Self-host a model server."""
     cluster_config = get_cluster_config(cluster, config_dir)
     gpus_per_node = get_cluster_gpus_per_node(cluster_config)
-    if get_random_port is None:
-        get_random_port = should_get_random_port(
-            server_gpus=server_gpus,
-            exclusive=exclusive,
-            gpus_per_node=gpus_per_node,
-        )
-    warn_hosted_server_allocation(
+    resolved_random_port = should_get_random_port(
         server_gpus=server_gpus,
         exclusive=exclusive,
         gpus_per_node=gpus_per_node,
-        get_random_port=get_random_port,
-        server_port=None,
-        context="ns start_server",
     )
+    if get_random_port is None:
+        get_random_port = resolved_random_port
 
     server_port = get_free_port(strategy="random") if get_random_port else 5000
     sandbox_port = get_free_port(strategy="random") if get_random_port else 6000

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -28,11 +28,14 @@ from nemo_skills.pipeline.utils import (
     add_task,
     check_mounts,
     get_cluster_config,
+    get_cluster_gpus_per_node,
     get_exp,
     get_free_port,
     parse_kwargs,
     resolve_mount_paths,
     set_python_path_and_wait_for_server,
+    should_get_random_port,
+    warn_hosted_server_allocation,
 )
 from nemo_skills.utils import get_logger_name, setup_logging
 
@@ -121,7 +124,7 @@ def launch_server(
     config_dir=None,
     log_dir=None,
     mount_paths=None,
-    get_random_port=False,
+    get_random_port=None,
     check_mounted_paths=False,
     tail_logs=False,
     cmd="",
@@ -151,6 +154,22 @@ def launch_server(
         pass
 
     log_dir = check_mounts(cluster_config, log_dir, check_mounted_paths=check_mounted_paths)
+
+    gpus_per_node = get_cluster_gpus_per_node(cluster_config)
+    if get_random_port is None:
+        get_random_port = should_get_random_port(
+            server_gpus=server_gpus,
+            exclusive=(sbatch_kwargs or {}).get("exclusive") if isinstance(sbatch_kwargs, dict) else None,
+            gpus_per_node=gpus_per_node,
+        )
+    warn_hosted_server_allocation(
+        server_gpus=server_gpus,
+        exclusive=(sbatch_kwargs or {}).get("exclusive") if isinstance(sbatch_kwargs, dict) else None,
+        gpus_per_node=gpus_per_node,
+        get_random_port=get_random_port,
+        server_port=server_port,
+        context="ns start_server",
+    )
 
     if server_port is None:
         server_port = get_free_port(strategy="random") if get_random_port else 5000
@@ -251,7 +270,7 @@ def start_server(
     ),
     exclusive: bool | None = typer.Option(None, help="If set will add exclusive flag to the slurm job."),
     check_mounted_paths: bool = typer.Option(False, help="Check if mounted paths are available on the remote machine"),
-    get_random_port: bool = typer.Option(False, help="If True, will get a random port for the server"),
+    get_random_port: bool | None = typer.Option(None, help="If unset, partial-node servers use a random port"),
     sbatch_kwargs: str = typer.Option(
         "",
         help="Additional sbatch kwargs to pass to the job scheduler. Values should be provided as a JSON string or as a `dict` if invoking from code.",
@@ -263,6 +282,23 @@ def start_server(
     sandbox_tunnel_port: int = typer.Option(6000, help="Local tunnel port for the sandbox server."),
 ):
     """Self-host a model server."""
+    cluster_config = get_cluster_config(cluster, config_dir)
+    gpus_per_node = get_cluster_gpus_per_node(cluster_config)
+    if get_random_port is None:
+        get_random_port = should_get_random_port(
+            server_gpus=server_gpus,
+            exclusive=exclusive,
+            gpus_per_node=gpus_per_node,
+        )
+    warn_hosted_server_allocation(
+        server_gpus=server_gpus,
+        exclusive=exclusive,
+        gpus_per_node=gpus_per_node,
+        get_random_port=get_random_port,
+        server_port=None,
+        context="ns start_server",
+    )
+
     server_port = get_free_port(strategy="random") if get_random_port else 5000
     sandbox_port = get_free_port(strategy="random") if get_random_port else 6000
 

--- a/nemo_skills/pipeline/utils/__init__.py
+++ b/nemo_skills/pipeline/utils/__init__.py
@@ -83,11 +83,13 @@ from nemo_skills.pipeline.utils.scripts import (
 from nemo_skills.pipeline.utils.server import (
     SupportedServers,
     SupportedServersSelfHosted,
+    get_cluster_gpus_per_node,
     get_free_port,
     get_ray_server_cmd,
     get_server_command,
     get_server_wait_cmd,
     set_python_path_and_wait_for_server,
     should_get_random_port,
+    warn_hosted_server_allocation,
     wrap_python_path,
 )

--- a/nemo_skills/pipeline/utils/server.py
+++ b/nemo_skills/pipeline/utils/server.py
@@ -70,6 +70,10 @@ def get_cluster_gpus_per_node(cluster_config: dict | None, default: int = 8) -> 
     Slurm GPU allocations isolate CUDA visibility, but jobs on the same
     physical node still share the localhost network namespace. Fixed ports are
     only safe by default when the hosted server consumes the whole GPU node.
+
+    Reads ``gpus_per_node`` / ``num_gpus_per_node`` from the cluster config when
+    present, otherwise falls back to ``default``. Set one of those keys in the
+    cluster config for nodes that do not have ``default`` GPUs.
     """
     if not cluster_config:
         return default
@@ -79,16 +83,31 @@ def get_cluster_gpus_per_node(cluster_config: dict | None, default: int = 8) -> 
         if value is not None:
             return int(value)
 
-    cluster_name = str(cluster_config.get("_cluster_yaml_name") or cluster_config.get("name") or "").lower()
-    if any(token in cluster_name for token in ("aws-cmh", "aws-dfw")):
-        return 4
     return default
 
 
-def should_get_random_port(server_gpus, exclusive, gpus_per_node: int | None = None):
+def should_get_random_port(server_gpus, exclusive, gpus_per_node: int | None = None, server_port: int | None = None):
+    """Whether a hosted server should bind a random port instead of a fixed one.
+
+    A server that uses fewer GPUs than the node has shares the node's localhost
+    namespace with other jobs, so it defaults to a random port to avoid
+    collisions. This is also the single choke point every server-hosting
+    pipeline passes through, so the allocation guardrail warnings are emitted
+    here (see ``warn_hosted_server_allocation``) instead of at each call site.
+    """
     if not server_gpus or exclusive:
-        return False
-    return int(server_gpus) != int(gpus_per_node or 8)
+        get_random_port = False
+    else:
+        get_random_port = int(server_gpus) != int(gpus_per_node or 8)
+
+    warn_hosted_server_allocation(
+        server_gpus=server_gpus,
+        exclusive=exclusive,
+        gpus_per_node=gpus_per_node,
+        get_random_port=get_random_port,
+        server_port=server_port,
+    )
+    return get_random_port
 
 
 def warn_hosted_server_allocation(
@@ -98,9 +117,8 @@ def warn_hosted_server_allocation(
     gpus_per_node: int | None = None,
     get_random_port: bool | None = None,
     server_port: int | None = None,
-    context: str = "hosted server",
 ) -> None:
-    """Warn about hosted-server configurations that can waste GPU allocations."""
+    """Warn about hosted-server configs that can waste GPUs or risk port collisions."""
     if not server_gpus:
         return
 
@@ -110,25 +128,24 @@ def warn_hosted_server_allocation(
 
     if is_partial_node and exclusive:
         LOG.warning(
-            "%s requests server_gpus=%d on a %d-GPU node with exclusive=True. "
-            "This can reserve idle GPUs. Prefer full-node serving with "
-            "server_gpus=%d and matching server_args='--tensor-parallel-size %d', "
-            "or remove exclusive=True for partial-node serving.",
-            context,
+            "Hosting server_gpus=%d on a %d-GPU node with exclusive=True reserves the whole "
+            "node and leaves %d GPU(s) idle. Prefer full-node serving (server_gpus=%d with a "
+            "matching '--tensor-parallel-size %d'), or drop exclusive=True for partial-node serving.",
             server_gpus,
             gpus_per_node,
+            gpus_per_node - server_gpus,
             gpus_per_node,
             gpus_per_node,
         )
 
-    fixed_port = get_random_port is False or (server_port is not None and get_random_port is not True)
-    if is_partial_node and fixed_port:
+    # A port is "fixed" only when the caller pinned one: an explicit server_port or
+    # get_random_port explicitly disabled. A resolved random port is not a fixed port.
+    fixed_port = (server_port is not None) or (get_random_port is False)
+    if is_partial_node and not exclusive and fixed_port:
         LOG.warning(
-            "%s uses a fixed server port on a partial-node allocation "
-            "(server_gpus=%d, gpus_per_node=%d). Jobs sharing the node can "
-            "collide on localhost ports. Prefer get_random_port=True or omit "
-            "the fixed server port and propagate the resolved port to clients.",
-            context,
+            "Hosting server_gpus=%d on a %d-GPU node with a fixed server port can collide with "
+            "other jobs sharing the node on localhost. Prefer get_random_port=True (or omit the "
+            "fixed server port) and propagate the resolved port to clients.",
             server_gpus,
             gpus_per_node,
         )

--- a/nemo_skills/pipeline/utils/server.py
+++ b/nemo_skills/pipeline/utils/server.py
@@ -64,8 +64,74 @@ def get_free_port(exclude: list[int] | None = None, strategy: int | str = 5000) 
         raise ValueError(f"Strategy {strategy} not supported.")
 
 
-def should_get_random_port(server_gpus, exclusive):
-    return server_gpus != 8 and not exclusive
+def get_cluster_gpus_per_node(cluster_config: dict | None, default: int = 8) -> int:
+    """Best-effort physical GPU count per node for hosted-server port policy.
+
+    Slurm GPU allocations isolate CUDA visibility, but jobs on the same
+    physical node still share the localhost network namespace. Fixed ports are
+    only safe by default when the hosted server consumes the whole GPU node.
+    """
+    if not cluster_config:
+        return default
+
+    for key in ("gpus_per_node", "num_gpus_per_node"):
+        value = cluster_config.get(key)
+        if value is not None:
+            return int(value)
+
+    cluster_name = str(cluster_config.get("_cluster_yaml_name") or cluster_config.get("name") or "").lower()
+    if any(token in cluster_name for token in ("aws-cmh", "aws-dfw")):
+        return 4
+    return default
+
+
+def should_get_random_port(server_gpus, exclusive, gpus_per_node: int | None = None):
+    if not server_gpus or exclusive:
+        return False
+    return int(server_gpus) != int(gpus_per_node or 8)
+
+
+def warn_hosted_server_allocation(
+    *,
+    server_gpus,
+    exclusive,
+    gpus_per_node: int | None = None,
+    get_random_port: bool | None = None,
+    server_port: int | None = None,
+    context: str = "hosted server",
+) -> None:
+    """Warn about hosted-server configurations that can waste GPU allocations."""
+    if not server_gpus:
+        return
+
+    server_gpus = int(server_gpus)
+    gpus_per_node = int(gpus_per_node or 8)
+    is_partial_node = server_gpus != gpus_per_node
+
+    if is_partial_node and exclusive:
+        LOG.warning(
+            "%s requests server_gpus=%d on a %d-GPU node with exclusive=True. "
+            "This can reserve idle GPUs. Prefer full-node serving with "
+            "server_gpus=%d and matching server_args='--tensor-parallel-size %d', "
+            "or remove exclusive=True for partial-node serving.",
+            context,
+            server_gpus,
+            gpus_per_node,
+            gpus_per_node,
+            gpus_per_node,
+        )
+
+    fixed_port = get_random_port is False or (server_port is not None and get_random_port is not True)
+    if is_partial_node and fixed_port:
+        LOG.warning(
+            "%s uses a fixed server port on a partial-node allocation "
+            "(server_gpus=%d, gpus_per_node=%d). Jobs sharing the node can "
+            "collide on localhost ports. Prefer get_random_port=True or omit "
+            "the fixed server port and propagate the resolved port to clients.",
+            context,
+            server_gpus,
+            gpus_per_node,
+        )
 
 
 def wrap_python_path(cmd):

--- a/nemo_skills/pipeline/verl/ppo.py
+++ b/nemo_skills/pipeline/verl/ppo.py
@@ -377,14 +377,6 @@ def ppo_verl(
     if server_type is not None:
         gpus_per_node = pipeline_utils.get_cluster_gpus_per_node(cluster_config)
         get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive, gpus_per_node)
-        pipeline_utils.warn_hosted_server_allocation(
-            server_gpus=server_gpus,
-            exclusive=exclusive,
-            gpus_per_node=gpus_per_node,
-            get_random_port=get_random_port,
-            server_port=None,
-            context="ns verl ppo",
-        )
         if server_address is None:  # we need to host the model
             assert server_gpus is not None, "Need to specify server_gpus if hosting the model"
             server_port = get_free_port(strategy="random") if get_random_port else 5000

--- a/nemo_skills/pipeline/verl/ppo.py
+++ b/nemo_skills/pipeline/verl/ppo.py
@@ -375,7 +375,16 @@ def ppo_verl(
 
     server_config = None
     if server_type is not None:
-        get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive)
+        gpus_per_node = pipeline_utils.get_cluster_gpus_per_node(cluster_config)
+        get_random_port = pipeline_utils.should_get_random_port(server_gpus, exclusive, gpus_per_node)
+        pipeline_utils.warn_hosted_server_allocation(
+            server_gpus=server_gpus,
+            exclusive=exclusive,
+            gpus_per_node=gpus_per_node,
+            get_random_port=get_random_port,
+            server_port=None,
+            context="ns verl ppo",
+        )
         if server_address is None:  # we need to host the model
             assert server_gpus is not None, "Need to specify server_gpus if hosting the model"
             server_port = get_free_port(strategy="random") if get_random_port else 5000

--- a/tests/test_pipeline_utils.py
+++ b/tests/test_pipeline_utils.py
@@ -25,6 +25,11 @@ from nemo_skills.pipeline.utils.generation import (
     get_remaining_jobs,
     separate_hydra_args,
 )
+from nemo_skills.pipeline.utils.server import (
+    get_cluster_gpus_per_node,
+    should_get_random_port,
+    warn_hosted_server_allocation,
+)
 
 
 def create_done_files(output_dir, seed_chunk_pairs):
@@ -35,6 +40,59 @@ def create_done_files(output_dir, seed_chunk_pairs):
         os.makedirs(os.path.dirname(done_file), exist_ok=True)
         with open(done_file, "w") as f:
             f.write("")
+
+
+def test_should_get_random_port_respects_cluster_gpu_count():
+    assert should_get_random_port(server_gpus=4, exclusive=None, gpus_per_node=8)
+    assert not should_get_random_port(server_gpus=8, exclusive=None, gpus_per_node=8)
+    assert not should_get_random_port(server_gpus=4, exclusive=None, gpus_per_node=4)
+    assert not should_get_random_port(server_gpus=4, exclusive=True, gpus_per_node=8)
+
+
+def test_get_cluster_gpus_per_node_known_clusters_and_override():
+    assert get_cluster_gpus_per_node({"_cluster_yaml_name": "aws-cmh-science"}) == 4
+    assert get_cluster_gpus_per_node({"_cluster_yaml_name": "aws-dfw-science"}) == 4
+    assert get_cluster_gpus_per_node({"_cluster_yaml_name": "aws-iad-science"}) == 8
+    assert get_cluster_gpus_per_node({"gpus_per_node": 4, "_cluster_yaml_name": "aws-iad-science"}) == 4
+
+
+def test_warn_hosted_server_allocation_partial_fixed_port(caplog):
+    warn_hosted_server_allocation(
+        server_gpus=4,
+        exclusive=False,
+        gpus_per_node=8,
+        get_random_port=False,
+        context="test",
+    )
+
+    assert "fixed server port" in caplog.text
+    assert "get_random_port=True" in caplog.text
+
+
+def test_warn_hosted_server_allocation_partial_exclusive(caplog):
+    warn_hosted_server_allocation(
+        server_gpus=4,
+        exclusive=True,
+        gpus_per_node=8,
+        get_random_port=False,
+        context="test",
+    )
+
+    assert "exclusive=True" in caplog.text
+    assert "server_gpus=8" in caplog.text
+
+
+def test_warn_hosted_server_allocation_random_partial_has_no_port_warning(caplog):
+    warn_hosted_server_allocation(
+        server_gpus=4,
+        exclusive=False,
+        gpus_per_node=8,
+        get_random_port=True,
+        server_port=23456,
+        context="test",
+    )
+
+    assert "fixed server port" not in caplog.text
 
 
 def test_get_chunked_rs_filename():

--- a/tests/test_pipeline_utils.py
+++ b/tests/test_pipeline_utils.py
@@ -49,11 +49,22 @@ def test_should_get_random_port_respects_cluster_gpu_count():
     assert not should_get_random_port(server_gpus=4, exclusive=True, gpus_per_node=8)
 
 
-def test_get_cluster_gpus_per_node_known_clusters_and_override():
-    assert get_cluster_gpus_per_node({"_cluster_yaml_name": "aws-cmh-science"}) == 4
-    assert get_cluster_gpus_per_node({"_cluster_yaml_name": "aws-dfw-science"}) == 4
-    assert get_cluster_gpus_per_node({"_cluster_yaml_name": "aws-iad-science"}) == 8
-    assert get_cluster_gpus_per_node({"gpus_per_node": 4, "_cluster_yaml_name": "aws-iad-science"}) == 4
+def test_should_get_random_port_warns_on_exclusive_partial_node(caplog):
+    # The guardrail warning is centralized here so every server-hosting pipeline gets it.
+    should_get_random_port(server_gpus=4, exclusive=True, gpus_per_node=8)
+    assert "exclusive=True" in caplog.text
+
+
+def test_get_cluster_gpus_per_node_reads_config_and_defaults():
+    # Reads explicit cluster-config values; falls back to the default otherwise.
+    assert get_cluster_gpus_per_node({"gpus_per_node": 4}) == 4
+    assert get_cluster_gpus_per_node({"num_gpus_per_node": 16}) == 16
+    assert get_cluster_gpus_per_node(None) == 8
+    assert get_cluster_gpus_per_node({"_cluster_yaml_name": "some-cluster"}) == 8
+    # gpus_per_node takes precedence over num_gpus_per_node.
+    assert get_cluster_gpus_per_node({"gpus_per_node": 2, "num_gpus_per_node": 8}) == 2
+    # Explicit default override.
+    assert get_cluster_gpus_per_node(None, default=4) == 4
 
 
 def test_warn_hosted_server_allocation_partial_fixed_port(caplog):
@@ -62,7 +73,6 @@ def test_warn_hosted_server_allocation_partial_fixed_port(caplog):
         exclusive=False,
         gpus_per_node=8,
         get_random_port=False,
-        context="test",
     )
 
     assert "fixed server port" in caplog.text
@@ -75,7 +85,6 @@ def test_warn_hosted_server_allocation_partial_exclusive(caplog):
         exclusive=True,
         gpus_per_node=8,
         get_random_port=False,
-        context="test",
     )
 
     assert "exclusive=True" in caplog.text
@@ -83,16 +92,28 @@ def test_warn_hosted_server_allocation_partial_exclusive(caplog):
 
 
 def test_warn_hosted_server_allocation_random_partial_has_no_port_warning(caplog):
+    # A resolved random port (no caller-pinned port) must not trigger the collision warning.
     warn_hosted_server_allocation(
         server_gpus=4,
         exclusive=False,
         gpus_per_node=8,
         get_random_port=True,
-        server_port=23456,
-        context="test",
     )
 
     assert "fixed server port" not in caplog.text
+
+
+def test_warn_hosted_server_allocation_explicit_port_is_fixed(caplog):
+    # An explicitly pinned server_port is a fixed port even when get_random_port is True.
+    warn_hosted_server_allocation(
+        server_gpus=4,
+        exclusive=False,
+        gpus_per_node=8,
+        get_random_port=True,
+        server_port=5000,
+    )
+
+    assert "fixed server port" in caplog.text
 
 
 def test_get_chunked_rs_filename():


### PR DESCRIPTION
## Summary
Adds hosted-server guardrails for common wasted-compute configurations:
- warn when a partial-node hosted server uses a fixed port
- warn when `exclusive=True` may reserve more GPUs than the server can use
- make random-port behavior aware of cluster `gpus_per_node`
- keep submission allowed; this is warning-only

## Why
Partial-node serving jobs can collide on fixed localhost ports, and exclusive allocations can reserve idle GPUs when `server_gpus` is smaller than the node size. Both patterns can produce idle-GPU waste while the job appears submitted successfully.

## Tests
- `python -m pytest tests/test_pipeline_utils.py::test_should_get_random_port_respects_cluster_gpu_count tests/test_pipeline_utils.py::test_get_cluster_gpus_per_node_known_clusters_and_override tests/test_pipeline_utils.py::test_warn_hosted_server_allocation_partial_fixed_port tests/test_pipeline_utils.py::test_warn_hosted_server_allocation_partial_exclusive tests/test_pipeline_utils.py::test_warn_hosted_server_allocation_random_partial_has_no_port_warning -q`
- `python -m ruff check nemo_skills/pipeline/generate.py nemo_skills/pipeline/start_server.py nemo_skills/pipeline/utils/server.py nemo_skills/pipeline/nemo_rl/grpo.py nemo_skills/pipeline/verl/ppo.py tests/test_pipeline_utils.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New warnings for hosted-server GPU allocation that may waste resources or risk localhost port conflicts
  * Start-server CLI option now supports an “unset” mode that auto-resolves port behavior from cluster GPU layout

* **Improvements**
  * Port-allocation logic now considers cluster GPU counts and exclusive-allocation settings for smarter defaults and fewer port collisions

* **Tests**
  * Added tests covering cluster-aware port selection and allocation-warning behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->