### PR TITLE
Add timeout for tool calls

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -202,6 +202,7 @@ class GenerationTaskConfig:
     schema_overrides: dict | None = field(default_factory=dict)
 
     max_tool_calls: int = -1  # If >= 0, will limit the number of tool calls executed during generation to this number
+    tool_call_timeout_s: float | None = 300.0  # Wall-clock timeout for each individual tool call
 
     # if True, will move full generation to _full_generation key and keep cfg.generation_key without thinking tokens
     # IMPORTANT: do not set this for non-reasoning models as it will make the generations empty!
@@ -482,6 +483,7 @@ class GenerationTask:
                 tool_overrides=self.cfg.tool_overrides,
                 schema_overrides=self.cfg.schema_overrides,
                 max_tool_calls=self.cfg.max_tool_calls,
+                tool_call_timeout_s=self.cfg.tool_call_timeout_s,
                 tokenizer=self.tokenizer,
                 require_tokenizer=self.cfg.inference.tokens_to_generate is not None,
                 additional_config={"sandbox": self.cfg.sandbox},

--- a/nemo_skills/inference/model/__init__.py
+++ b/nemo_skills/inference/model/__init__.py
@@ -136,6 +136,7 @@ def get_tool_calling_model(
     tool_overrides: dict | None = None,
     schema_overrides: dict | None = None,
     max_tool_calls: int = -1,
+    tool_call_timeout_s: float | None = 300.0,
     **kwargs,
 ):
     if isinstance(model, str):
@@ -147,6 +148,7 @@ def get_tool_calling_model(
         additional_config=additional_config,
         schema_overrides=schema_overrides,
         max_tool_calls=max_tool_calls,
+        tool_call_timeout_s=tool_call_timeout_s,
     )
 
 

--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import copy
 import json
 import logging
@@ -49,6 +50,7 @@ class ToolCallingWrapper:
         additional_config: dict | None = None,
         schema_overrides: dict | None = None,
         max_tool_calls: int = -1,
+        tool_call_timeout_s: float | None = 300.0,
     ):
         self.model = model
         additional_config = additional_config or {}
@@ -63,6 +65,7 @@ class ToolCallingWrapper:
         self.schema_overrides = load_schema_overrides(schema_overrides)
         self.schema_mappings = {}  # Built when tools are listed
         self.max_tool_calls = max_tool_calls
+        self.tool_call_timeout_s = tool_call_timeout_s
 
     async def _execute_tool_call(self, tool_call, request_id: str, endpoint_type: EndpointType):
         ## TODO(sanyamk): The correct key format needs to be cohesive with other formatters.
@@ -85,9 +88,16 @@ class ToolCallingWrapper:
 
         try:
             # Allow providers to specify extra_args behavior internally if needed in the future
-            result = await self.tool_manager.execute_tool(
+            tool_future = self.tool_manager.execute_tool(
                 original_tool_name, tool_args, extra_args={"request_id": request_id}
             )
+            if self.tool_call_timeout_s is None:
+                result = await tool_future
+            else:
+                result = await asyncio.wait_for(tool_future, timeout=self.tool_call_timeout_s)
+        except asyncio.TimeoutError:
+            LOG.error("Tool execution timed out after %s seconds: %s", self.tool_call_timeout_s, original_tool_name)
+            return {"error": f"Tool execution timed out after {self.tool_call_timeout_s} seconds."}
         except FatalToolError:
             # Fatal errors should propagate up and stop the process
             raise

--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -65,6 +65,8 @@ class ToolCallingWrapper:
         self.schema_overrides = load_schema_overrides(schema_overrides)
         self.schema_mappings = {}  # Built when tools are listed
         self.max_tool_calls = max_tool_calls
+        if tool_call_timeout_s is not None and tool_call_timeout_s <= 0:
+            raise ValueError("tool_call_timeout_s must be a positive number of seconds, or None to disable.")
         self.tool_call_timeout_s = tool_call_timeout_s
 
     async def _execute_tool_call(self, tool_call, request_id: str, endpoint_type: EndpointType):

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import types
 
 import pytest
 
 # Dummy client to exercise MCPClientMeta behavior without real I/O
+from nemo_skills.inference.model.base import EndpointType
+from nemo_skills.inference.model.tool_call import ToolCallingWrapper
 from nemo_skills.mcp.clients import MCPClient, MCPStdioClient, MCPStreamableHttpClient
 from nemo_skills.mcp.tool_manager import Tool, ToolManager
 
@@ -219,6 +222,27 @@ class DummyTool(Tool):
         return {"unknown": tool_name, "args": arguments}
 
 
+class SlowTool(Tool):
+    def default_config(self):
+        return {}
+
+    def configure(self, overrides=None, context=None):
+        return None
+
+    async def list_tools(self):
+        return [
+            {
+                "name": "sleep",
+                "description": "Sleep long enough to exercise timeout handling",
+                "input_schema": {"type": "object", "properties": {}},
+            }
+        ]
+
+    async def execute(self, tool_name: str, arguments: dict, extra_args: dict | None = None):
+        await asyncio.sleep(10)
+        return "too late"
+
+
 # Helper class for test_tool_manager_cache_and_duplicate_detection
 # Defined at module level so it can be imported via locate()
 class CountingTool(DummyTool):
@@ -253,6 +277,24 @@ async def test_tool_manager_list_and_execute_with_class_locator():
 
     result = await tm.execute_tool("execute", {"code": "x=1"})
     assert result == {"ran": True, "code": "x=1"}
+
+
+@pytest.mark.asyncio
+async def test_tool_calling_wrapper_times_out_slow_tool_call():
+    wrapper = ToolCallingWrapper(
+        model=object(),
+        tool_modules=[f"{__name__}::SlowTool"],
+        tool_call_timeout_s=0.01,
+    )
+    await wrapper.tool_manager.list_all_tools(use_cache=False)
+
+    result = await wrapper._execute_tool_call(
+        {"id": "call-1", "function": {"name": "sleep", "arguments": "{}"}},
+        request_id="req-1",
+        endpoint_type=EndpointType.chat,
+    )
+
+    assert result["error"].startswith("Tool execution timed out")
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -239,6 +239,10 @@ class SlowTool(Tool):
         ]
 
     async def execute(self, tool_name: str, arguments: dict, extra_args: dict | None = None):
+        if tool_name != "sleep":
+            raise ValueError(f"Unsupported tool: {tool_name}")
+        if arguments:
+            raise ValueError(f"Unexpected arguments: {arguments}")
         await asyncio.sleep(10)
         return "too late"
 
@@ -295,6 +299,16 @@ async def test_tool_calling_wrapper_times_out_slow_tool_call():
     )
 
     assert result["error"].startswith("Tool execution timed out")
+
+
+@pytest.mark.parametrize("bad_timeout", [0, -1, -0.5])
+def test_tool_calling_wrapper_rejects_nonpositive_timeout(bad_timeout):
+    with pytest.raises(ValueError):
+        ToolCallingWrapper(
+            model=object(),
+            tool_modules=[f"{__name__}::SlowTool"],
+            tool_call_timeout_s=bad_timeout,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Adds `GenerationTaskConfig.tool_call_timeout_s` with a default of `300.0` seconds and wraps tool execution in a wall-clock timeout. When a tool times out, generation receives a model-visible tool error instead of waiting indefinitely.

## Why
If retrieval/tool/environment calls hang while an inference server is allocated, GPUs can sit idle until the Slurm job is cancelled by idle-GPU monitoring. A bounded timeout lets the sample fail or continue cleanly.

## Tests
- `python -m pytest tests/test_mcp_clients.py::test_tool_calling_wrapper_times_out_slow_tool_call -q`
- `python -m ruff check nemo_skills/inference/generate.py nemo_skills/inference/model/__init__.py nemo_skills/inference/model/tool_call.py tests/test_mcp_clients.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-tool-call execution timeout (default 300s). Tool calls that exceed the timeout are aborted and return a structured error indicating the call timed out, improving robustness of tool integrations. Initialization validates timeout values and rejects non-positive values.

* **Tests**
  * Added tests verifying timeout enforcement for slow tools and validation that non-positive timeout values are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->