### PR TITLE
Call tool shutdown hooks after generation

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import inspect
 import json
 import logging
 import random
@@ -954,36 +955,50 @@ class GenerationTask:
             litellm.cache.cache.force_save()
             shutil.rmtree(self.litellm_cache_dir)
 
+    def shutdown(self):
+        shutdown = getattr(self.llm, "shutdown", None)
+        if shutdown is None:
+            return
+        try:
+            result = shutdown()
+            if inspect.isawaitable(result):
+                asyncio.run(result)
+        except Exception:
+            LOG.exception("Failed to shut down generation resources cleanly")
+
     def generate(self):
-        Path(self.cfg.output_file).absolute().parent.mkdir(parents=True, exist_ok=True)
+        try:
+            Path(self.cfg.output_file).absolute().parent.mkdir(parents=True, exist_ok=True)
 
-        data = self.load_data()
+            data = self.load_data()
 
-        data = self.skip_completed_samples(data)
+            data = self.skip_completed_samples(data)
 
-        if len(data) == 0:
-            LOG.info("No data to process, skipping generation")
-        else:
-            data = self.preprocess_data(data)
+            if len(data) == 0:
+                LOG.info("No data to process, skipping generation")
+            else:
+                data = self.preprocess_data(data)
 
-            self.log_example_prompt(data)
+                self.log_example_prompt(data)
 
-            if self.cfg.dry_run:
-                LOG.info("Exiting without running generation as dry_run flag is set.")
-                return
+                if self.cfg.dry_run:
+                    LOG.info("Exiting without running generation as dry_run flag is set.")
+                    return
 
-            if not self.cfg.skip_filled:
-                for output_path in [Path(self.cfg.output_file), Path(self.cfg.output_file + "-async")]:
-                    if output_path.exists():
-                        output_path.unlink()
+                if not self.cfg.skip_filled:
+                    for output_path in [Path(self.cfg.output_file), Path(self.cfg.output_file + "-async")]:
+                        if output_path.exists():
+                            output_path.unlink()
 
-            self.wait_for_server()
-            self.wait_for_sandbox()
-            asyncio.run(self.async_loop(data))
+                self.wait_for_server()
+                self.wait_for_sandbox()
+                asyncio.run(self.async_loop(data))
 
-        if self.should_run_evaluation and self.evaluator is None:
-            self.run_batch_evaluation()
-        self.postprocess()
+            if self.should_run_evaluation and self.evaluator is None:
+                self.run_batch_evaluation()
+            self.postprocess()
+        finally:
+            self.shutdown()
 
 
 GENERATION_TASK_CLASS = GenerationTask

--- a/nemo_skills/inference/model/code_execution.py
+++ b/nemo_skills/inference/model/code_execution.py
@@ -14,6 +14,7 @@
 
 
 import copy
+import inspect
 import logging
 import time
 from dataclasses import field
@@ -43,6 +44,17 @@ class CodeExecutionWrapper:
         self.model = model
         self.sandbox = sandbox
         self.config = config
+
+    async def shutdown(self) -> None:
+        try:
+            shutdown = getattr(self.model, "shutdown", None)
+            if shutdown is not None:
+                result = shutdown()
+                if inspect.isawaitable(result):
+                    await result
+        finally:
+            if self.sandbox is not None:
+                await self.sandbox.close()
 
     async def _generate_single(
         self,

--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import inspect
 import json
 import logging
 import uuid
@@ -63,6 +64,16 @@ class ToolCallingWrapper:
         self.schema_overrides = load_schema_overrides(schema_overrides)
         self.schema_mappings = {}  # Built when tools are listed
         self.max_tool_calls = max_tool_calls
+
+    async def shutdown(self) -> None:
+        try:
+            await self.tool_manager.shutdown()
+        finally:
+            shutdown = getattr(self.model, "shutdown", None)
+            if shutdown is not None:
+                result = shutdown()
+                if inspect.isawaitable(result):
+                    await result
 
     async def _execute_tool_call(self, tool_call, request_id: str, endpoint_type: EndpointType):
         ## TODO(sanyamk): The correct key format needs to be cohesive with other formatters.

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -28,6 +28,22 @@ from nemo_skills.pipeline.utils.generation import configure_client
 from nemo_skills.pipeline.utils.scripts import ServerScript
 
 
+def test_generation_task_shutdown_awaits_async_llm_shutdown():
+    class LLM:
+        def __init__(self):
+            self.shutdown_called = False
+
+        async def shutdown(self):
+            self.shutdown_called = True
+
+    task = GenerationTask.__new__(GenerationTask)
+    task.llm = LLM()
+
+    task.shutdown()
+
+    assert task.llm.shutdown_called
+
+
 @pytest.mark.timeout(300)
 def test_eval_gsm8k_api(tmp_path):
     cmd = (

--- a/tests/test_mcp_clients.py
+++ b/tests/test_mcp_clients.py
@@ -17,6 +17,7 @@ import types
 import pytest
 
 # Dummy client to exercise MCPClientMeta behavior without real I/O
+from nemo_skills.inference.model.tool_call import ToolCallingWrapper
 from nemo_skills.mcp.clients import MCPClient, MCPStdioClient, MCPStreamableHttpClient
 from nemo_skills.mcp.tool_manager import Tool, ToolManager
 
@@ -219,6 +220,13 @@ class DummyTool(Tool):
         return {"unknown": tool_name, "args": arguments}
 
 
+class ShutdownTool(DummyTool):
+    shutdown_calls = 0
+
+    async def shutdown(self) -> None:
+        type(self).shutdown_calls += 1
+
+
 # Helper class for test_tool_manager_cache_and_duplicate_detection
 # Defined at module level so it can be imported via locate()
 class CountingTool(DummyTool):
@@ -253,6 +261,16 @@ async def test_tool_manager_list_and_execute_with_class_locator():
 
     result = await tm.execute_tool("execute", {"code": "x=1"})
     assert result == {"ran": True, "code": "x=1"}
+
+
+@pytest.mark.asyncio
+async def test_tool_calling_wrapper_shutdown_calls_registered_tools():
+    ShutdownTool.shutdown_calls = 0
+    wrapper = ToolCallingWrapper(model=object(), tool_modules=[f"{__name__}::ShutdownTool"])
+
+    await wrapper.shutdown()
+
+    assert ShutdownTool.shutdown_calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Adds shutdown hooks for tool/code execution wrappers and ensures `GenerationTask.generate()` calls them from a `finally` block. This covers normal completion, errors, and early exits.

## Why
Tool sessions, sandbox clients, or subprocess-backed providers should be closed before process exit. Without a guaranteed shutdown path, cleanup can hang or leak resources after outputs are already produced.

## Tests
- `python -m pytest tests/test_mcp_clients.py::test_tool_calling_wrapper_shutdown_calls_registered_tools tests/test_generation.py::test_generation_task_shutdown_awaits_async_llm_shutdown -q`
- `python -m ruff check nemo_skills/inference/generate.py nemo_skills/inference/model/code_execution.py nemo_skills/inference/model/tool_call.py tests/test_generation.py tests/test_mcp_clients.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup and lifecycle management for generation tasks to ensure models and sandboxes are properly shut down even when errors occur or tasks exit early.

* **Tests**
  * Added test coverage for shutdown procedures to verify proper cleanup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Skills/pull/1468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->