### PR TITLE
Add direct Tavily browser tool

### DIFF
--- a/nemo_skills/inference/model/tool_call.py
+++ b/nemo_skills/inference/model/tool_call.py
@@ -301,6 +301,9 @@ class ToolCallingWrapper:
             result_steps["num_tool_calls"] = sum(result_steps["num_tool_calls"])
             result_steps["conversation"] = conversation
             result_steps["tools"] = tools  # Schema sent to model (with overrides applied)
+            tool_metrics = await self.tool_manager.get_request_metrics(request_id)
+            if tool_metrics:
+                result_steps["tool_metrics"] = tool_metrics
 
             return result_steps
         finally:
@@ -437,6 +440,9 @@ class ToolCallingWrapper:
             }
             if all_reasoning:
                 final_result["reasoning_content"] = "".join(all_reasoning)
+            tool_metrics = await self.tool_manager.get_request_metrics(request_id)
+            if tool_metrics:
+                final_result["tool_metrics"] = tool_metrics
             yield final_result
         finally:
             await self.tool_manager.cleanup_request(request_id)

--- a/nemo_skills/mcp/servers/tavily_search_tool.py
+++ b/nemo_skills/mcp/servers/tavily_search_tool.py
@@ -98,6 +98,7 @@ DEFAULT_API_BASE_URL = "https://api.tavily.com"
 DEFAULT_HTTP_TIMEOUT_S = 30.0
 DEFAULT_MAX_RETRIES = 2
 DEFAULT_RETRY_BACKOFF_S = 0.5
+DEFAULT_MAX_RETRY_DELAY_S = 30.0
 DEFAULT_GYM_MAX_RESULTS = 10
 DEFAULT_GYM_MAX_RESULT_CHARS = 2000
 DEFAULT_GYM_MAX_QUERY_CHARS = 400
@@ -120,6 +121,8 @@ STATUS_CODE_ERRORS = {
 }
 
 RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
+GYM_TOOL_ERROR_PREFIXES = ("URL ", "Query ", "Search ")
+GYM_NO_CONTENT_RESULT = "No content found."
 
 # These errors should stop the process - no point continuing with bad credentials
 FATAL_STATUS_CODES = {401, 403}
@@ -164,59 +167,62 @@ def _retry_after_seconds(response: httpx.Response) -> float | None:
 
 async def _post_tavily_json(
     *,
-    api_base_url: str,
     api_key: str,
     endpoint: str,
     payload: dict[str, Any],
-    timeout_s: float,
-    max_retries: int,
-    retry_backoff_s: float,
+    api_base_url: str = DEFAULT_API_BASE_URL,
+    timeout_s: float = DEFAULT_HTTP_TIMEOUT_S,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    retry_backoff_s: float = DEFAULT_RETRY_BACKOFF_S,
+    max_retry_delay_s: float = DEFAULT_MAX_RETRY_DELAY_S,
 ) -> dict[str, Any]:
     url = f"{api_base_url.rstrip('/')}/{endpoint.lstrip('/')}"
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
-    delay = retry_backoff_s
+    max_retry_delay_s = max(0.0, max_retry_delay_s)
+    delay = min(max(0.0, retry_backoff_s), max_retry_delay_s)
     last_error = "Search request failed"
 
-    for attempt in range(max_retries + 1):
-        try:
-            async with httpx.AsyncClient(timeout=timeout_s) as client:
-                response = await client.post(url, headers=headers, json=payload)
-        except httpx.TimeoutException:
-            last_error = "Search request timed out"
-            if attempt < max_retries:
-                await asyncio.sleep(delay)
-                delay *= 2
-                continue
-            return {"error": last_error}
-        except httpx.RequestError:
-            last_error = "Search request failed due to network error"
-            if attempt < max_retries:
-                await asyncio.sleep(delay)
-                delay *= 2
-                continue
-            return {"error": last_error}
-
-        if response.status_code in FATAL_STATUS_CODES:
-            raise FatalToolError("Search authentication failed")
-
-        if response.status_code == 200:
+    async with httpx.AsyncClient(timeout=timeout_s) as client:
+        for attempt in range(max_retries + 1):
             try:
-                return response.json()
-            except json.JSONDecodeError:
-                return {"error": "Search returned invalid response"}
+                response = await client.post(url, headers=headers, json=payload)
+            except httpx.TimeoutException:
+                last_error = "Search request timed out"
+                if attempt < max_retries:
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, max_retry_delay_s)
+                    continue
+                return {"error": last_error}
+            except httpx.RequestError:
+                last_error = "Search request failed due to network error"
+                if attempt < max_retries:
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, max_retry_delay_s)
+                    continue
+                return {"error": last_error}
 
-        last_error = STATUS_CODE_ERRORS.get(
-            response.status_code,
-            f"Search request failed with status {response.status_code}",
-        )
-        if response.status_code in RETRY_STATUS_CODES and attempt < max_retries:
-            await asyncio.sleep(_retry_after_seconds(response) or delay)
-            delay *= 2
-            continue
-        return {"error": last_error}
+            if response.status_code in FATAL_STATUS_CODES:
+                raise FatalToolError("Search authentication failed")
+
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except json.JSONDecodeError:
+                    return {"error": "Search returned invalid response"}
+
+            last_error = STATUS_CODE_ERRORS.get(
+                response.status_code,
+                f"Search request failed with status {response.status_code}",
+            )
+            if response.status_code in RETRY_STATUS_CODES and attempt < max_retries:
+                response_delay = _retry_after_seconds(response)
+                await asyncio.sleep(min(response_delay if response_delay is not None else delay, max_retry_delay_s))
+                delay = min(delay * 2, max_retry_delay_s)
+                continue
+            return {"error": last_error}
 
     return {"error": last_error}
 
@@ -268,6 +274,18 @@ def _coerce_int_arg(value: Any, default: int | None, arg_name: str) -> tuple[int
         return None, f"{arg_name} must be an integer"
 
 
+def _unsupported_args_error(arguments: dict[str, Any], allowed_args: set[str]) -> str | None:
+    unsupported = sorted(set(arguments) - allowed_args)
+    if not unsupported:
+        return None
+    arg_word = "argument" if len(unsupported) == 1 else "arguments"
+    return f"Unsupported {arg_word}: {', '.join(unsupported)}"
+
+
+def _is_gym_tool_error_result(result: Any) -> bool:
+    return isinstance(result, str) and (result.startswith(GYM_TOOL_ERROR_PREFIXES) or result == GYM_NO_CONTENT_RESULT)
+
+
 def _remember_lru(cache: OrderedDict[str, Any], key: str, value: Any, max_items: int) -> None:
     if key in cache:
         cache.move_to_end(key)
@@ -310,6 +328,7 @@ class _DirectTavilyBase(Tool):
             "timeout_s": DEFAULT_HTTP_TIMEOUT_S,
             "max_retries": DEFAULT_MAX_RETRIES,
             "retry_backoff_s": DEFAULT_RETRY_BACKOFF_S,
+            "max_retry_delay_s": DEFAULT_MAX_RETRY_DELAY_S,
             "hide_args": {},
         }
         self._api_keys: list[str] = []
@@ -363,11 +382,18 @@ class _DirectTavilyBase(Tool):
             timeout_s=float(self._config["timeout_s"]),
             max_retries=int(self._config["max_retries"]),
             retry_backoff_s=float(self._config["retry_backoff_s"]),
+            max_retry_delay_s=float(self._config["max_retry_delay_s"]),
         )
 
     def _sanitize_arguments(self, tool_name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
         hidden = self._sanitize_keys.get(tool_name, set())
         return {k: v for k, v in dict(arguments or {}).items() if k not in hidden}
+
+    def _sanitize_and_validate_arguments(
+        self, tool_name: str, arguments: dict[str, Any] | None, allowed_args: set[str]
+    ) -> tuple[dict[str, Any], str | None]:
+        sanitized = self._sanitize_arguments(tool_name, arguments)
+        return sanitized, _unsupported_args_error(sanitized, allowed_args)
 
     async def _tracked_post_json(
         self,
@@ -435,13 +461,9 @@ async def answer(
 
     try:
         result = await _post_tavily_json(
-            api_base_url=DEFAULT_API_BASE_URL,
             api_key=TAVILY_API_KEY or "",
             endpoint="/search",
             payload=payload,
-            timeout_s=DEFAULT_HTTP_TIMEOUT_S,
-            max_retries=DEFAULT_MAX_RETRIES,
-            retry_backoff_s=DEFAULT_RETRY_BACKOFF_S,
         )
     except FatalToolError:
         return {"error": "Search authentication failed", "fatal": True}
@@ -525,6 +547,7 @@ class DirectTavilySearchTool(_DirectTavilyBase):
                     "type": "object",
                     "properties": {"query": {"type": "string", "description": "Search query."}},
                     "required": ["query"],
+                    "additionalProperties": False,
                 },
             }
         ]
@@ -535,7 +558,9 @@ class DirectTavilySearchTool(_DirectTavilyBase):
         if tool_name not in {"web-search", "web_search"}:
             return {"error": f"unknown tool '{tool_name}'"}
 
-        arguments = self._sanitize_arguments(tool_name, arguments)
+        arguments, error = self._sanitize_and_validate_arguments(tool_name, arguments, {"query"})
+        if error:
+            return {"error": error}
         query = arguments.get("query")
         if not isinstance(query, str):
             return {"error": "Missing required argument 'query'"}
@@ -592,13 +617,14 @@ class DirectTavilyGymTool(_DirectTavilyBase):
                 "extract_depth": "basic",
                 "extract_format": "markdown",
                 "scroll_words": DEFAULT_SCROLL_WORDS,
+                "max_cached_pages": DEFAULT_BROWSER_MAX_CACHED_PAGES,
             }
         )
-        self._page_cache: dict[str, str] = {}
+        self._page_cache: OrderedDict[str, str] = OrderedDict()
 
     def configure(self, overrides: dict[str, Any] | None = None, context: dict[str, Any] | None = None) -> None:
         super().configure(overrides, context)
-        self._page_cache = {}
+        self._page_cache = OrderedDict()
 
     async def list_tools(self) -> list[dict[str, Any]]:
         return [
@@ -609,6 +635,7 @@ class DirectTavilyGymTool(_DirectTavilyBase):
                     "type": "object",
                     "properties": {"query": {"type": "string", "description": "Search query."}},
                     "required": ["query"],
+                    "additionalProperties": False,
                 },
             },
             {
@@ -621,6 +648,7 @@ class DirectTavilyGymTool(_DirectTavilyBase):
                         "query": {"type": "string", "description": "Term or question to locate within the page."},
                     },
                     "required": ["url", "query"],
+                    "additionalProperties": False,
                 },
             },
             {
@@ -637,6 +665,7 @@ class DirectTavilyGymTool(_DirectTavilyBase):
                         "n": {"type": "integer", "description": "Number of words to return."},
                     },
                     "required": ["url"],
+                    "additionalProperties": False,
                 },
             },
         ]
@@ -644,13 +673,24 @@ class DirectTavilyGymTool(_DirectTavilyBase):
     async def execute(
         self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None
     ) -> str | dict[str, Any]:
-        arguments = self._sanitize_arguments(tool_name, arguments)
+        allowed_args_by_tool = {
+            "web_search": {"query"},
+            "find_in_page": {"url", "query"},
+            "scroll_page": {"url", "start_index", "n"},
+        }
+        if tool_name not in allowed_args_by_tool:
+            return f"Error: unknown tool '{tool_name}'"
+
+        arguments, error = self._sanitize_and_validate_arguments(tool_name, arguments, allowed_args_by_tool[tool_name])
+        if error:
+            return error
+
         request_id = (extra_args or {}).get("request_id")
         if tool_name == "web_search":
             return await self._web_search(arguments, request_id=request_id)
-        if tool_name == "find_in_page":
+        elif tool_name == "find_in_page":
             return await self._find_in_page(arguments, request_id=request_id)
-        if tool_name == "scroll_page":
+        elif tool_name == "scroll_page":
             return await self._scroll_page(arguments, request_id=request_id)
         return f"Error: unknown tool '{tool_name}'"
 
@@ -719,12 +759,17 @@ class DirectTavilyGymTool(_DirectTavilyBase):
         if _is_url_excluded(url, self._exclude_domains):
             return "URL is in excluded domains"
 
-        start_index = int(arguments.get("start_index", 0) or 0)
-        n = int(arguments.get("n", self._config["scroll_words"]) or self._config["scroll_words"])
+        start_index, error = _coerce_int_arg(arguments.get("start_index"), 0, "start_index")
+        if error or start_index is None:
+            return "Invalid start_index: start_index must be an integer"
+        n, error = _coerce_int_arg(arguments.get("n"), int(self._config["scroll_words"]), "n")
+        if error or n is None:
+            return "Invalid n: n must be an integer"
         start_index = max(0, start_index)
         n = max(1, n)
 
         if url in self._page_cache:
+            self._page_cache.move_to_end(url)
             page_content = self._page_cache[url]
         else:
             payload = {
@@ -736,7 +781,7 @@ class DirectTavilyGymTool(_DirectTavilyBase):
             if results.get("error"):
                 return results["error"]
             page_content = _first_raw_content(results)
-            self._page_cache[url] = page_content
+            _remember_lru(self._page_cache, url, page_content, max(1, int(self._config["max_cached_pages"])))
 
         words = page_content.split()
         total_words = len(words)
@@ -758,9 +803,8 @@ class DirectTavilyGymTool(_DirectTavilyBase):
 class DirectTavilyBrowserTool(DirectTavilyGymTool):
     """Tavily browser tool with request-local memory, bounded cache, and metrics.
 
-    This intentionally leaves DirectTavilySearchTool and DirectTavilyGymTool
-    unchanged. The browser tool keeps the Gym surface and adds
-    ``open_result(index)`` for opening a result from the most recent search.
+    The browser tool keeps the Gym surface and adds ``open_result(index)`` for
+    opening a result from the most recent search.
     """
 
     def __init__(self) -> None:
@@ -852,15 +896,29 @@ class DirectTavilyBrowserTool(DirectTavilyGymTool):
     async def execute(
         self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None
     ) -> str | dict[str, Any]:
-        arguments = self._sanitize_arguments(tool_name, arguments)
+        allowed_args_by_tool = {
+            "web_search": {"query"},
+            "open_result": {"index"},
+            "find_in_page": {"url", "query"},
+            "scroll_page": {"url", "start_index", "n"},
+        }
+        if tool_name not in allowed_args_by_tool:
+            self._increment_stat((extra_args or {}).get("request_id"), "tool_errors")
+            return f"Error: unknown tool '{tool_name}'"
+
+        arguments, error = self._sanitize_and_validate_arguments(tool_name, arguments, allowed_args_by_tool[tool_name])
         request_id = (extra_args or {}).get("request_id")
+        if error:
+            self._increment_stat(request_id, "tool_errors")
+            return error
+
         if tool_name == "web_search":
             return await self._web_search(arguments, request_id=request_id)
-        if tool_name == "open_result":
+        elif tool_name == "open_result":
             return await self._open_result(arguments, request_id=request_id)
-        if tool_name == "find_in_page":
+        elif tool_name == "find_in_page":
             return await self._find_in_page(arguments, request_id=request_id)
-        if tool_name == "scroll_page":
+        elif tool_name == "scroll_page":
             return await self._scroll_page(arguments, request_id=request_id)
         self._increment_stat(request_id, "tool_errors")
         return f"Error: unknown tool '{tool_name}'"
@@ -963,12 +1021,7 @@ class DirectTavilyBrowserTool(DirectTavilyGymTool):
     async def _find_in_page(self, arguments: dict[str, Any], *, request_id: str | None) -> str:
         self._increment_stat(request_id, "find_in_page_calls")
         result = await super()._find_in_page(arguments, request_id=request_id)
-        if isinstance(result, str) and (
-            result.startswith("URL ")
-            or result.startswith("Query ")
-            or result.startswith("Search ")
-            or result == "No content found."
-        ):
+        if _is_gym_tool_error_result(result):
             self._increment_stat(request_id, "tool_errors")
         return result
 

--- a/nemo_skills/mcp/servers/tavily_search_tool.py
+++ b/nemo_skills/mcp/servers/tavily_search_tool.py
@@ -121,8 +121,22 @@ STATUS_CODE_ERRORS = {
 }
 
 RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
-GYM_TOOL_ERROR_PREFIXES = ("URL ", "Query ", "Search ")
-GYM_NO_CONTENT_RESULT = "No content found."
+DIRECT_TAVILY_ERROR_PREFIXES = (
+    "Error:",
+    "Invalid ",
+    "No search result",
+    "Query ",
+    "Search authentication",
+    "Search request",
+    "Search response",
+    "Search rate",
+    "Unsupported ",
+    "URL ",
+)
+DIRECT_TAVILY_ERROR_MESSAGES = {
+    "No content found.",
+    "Start index is beyond page length.",
+}
 
 # These errors should stop the process - no point continuing with bad credentials
 FATAL_STATUS_CODES = {401, 403}
@@ -282,8 +296,20 @@ def _unsupported_args_error(arguments: dict[str, Any], allowed_args: set[str]) -
     return f"Unsupported {arg_word}: {', '.join(unsupported)}"
 
 
-def _is_gym_tool_error_result(result: Any) -> bool:
-    return isinstance(result, str) and (result.startswith(GYM_TOOL_ERROR_PREFIXES) or result == GYM_NO_CONTENT_RESULT)
+def _tool_error(message: str) -> dict[str, str]:
+    return {"error": message}
+
+
+def _is_direct_tavily_error_result(result: Any) -> bool:
+    return isinstance(result, str) and (
+        result.startswith(DIRECT_TAVILY_ERROR_PREFIXES) or result in DIRECT_TAVILY_ERROR_MESSAGES
+    )
+
+
+def _standardize_tool_result(result: Any) -> Any:
+    if _is_direct_tavily_error_result(result):
+        return _tool_error(result)
+    return result
 
 
 def _remember_lru(cache: OrderedDict[str, Any], key: str, value: Any, max_items: int) -> None:
@@ -556,22 +582,22 @@ class DirectTavilySearchTool(_DirectTavilyBase):
         self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None
     ) -> Any:
         if tool_name not in {"web-search", "web_search"}:
-            return {"error": f"unknown tool '{tool_name}'"}
+            return _tool_error(f"unknown tool '{tool_name}'")
 
         arguments, error = self._sanitize_and_validate_arguments(tool_name, arguments, {"query"})
         if error:
-            return {"error": error}
+            return _tool_error(error)
         query = arguments.get("query")
         if not isinstance(query, str):
-            return {"error": "Missing required argument 'query'"}
+            return _tool_error("Missing required argument 'query'")
 
         num_results = int(self._config["num_results"])
         if num_results > int(self._config["max_num_results"]):
-            return {"error": f"Number of results must be less than or equal to {self._config['max_num_results']}."}
+            return _tool_error(f"Number of results must be less than or equal to {self._config['max_num_results']}.")
 
         answer_type = self._config["answer_type"]
         if answer_type not in ["answer", "results"]:
-            return {"error": "Invalid answer type. Choose 'answer' or 'results'."}
+            return _tool_error("Invalid answer type. Choose 'answer' or 'results'.")
 
         extra_args = dict(extra_args or {})
         request_id = extra_args.get("request_id")
@@ -588,7 +614,7 @@ class DirectTavilySearchTool(_DirectTavilyBase):
 
         extracted = result.get(answer_type)
         if extracted is None:
-            return {"error": "Search response is missing required field"}
+            return _tool_error("Search response is missing required field")
         return extracted
 
 
@@ -679,20 +705,20 @@ class DirectTavilyGymTool(_DirectTavilyBase):
             "scroll_page": {"url", "start_index", "n"},
         }
         if tool_name not in allowed_args_by_tool:
-            return f"Error: unknown tool '{tool_name}'"
+            return _tool_error(f"Error: unknown tool '{tool_name}'")
 
         arguments, error = self._sanitize_and_validate_arguments(tool_name, arguments, allowed_args_by_tool[tool_name])
         if error:
-            return error
+            return _tool_error(error)
 
         request_id = (extra_args or {}).get("request_id")
         if tool_name == "web_search":
-            return await self._web_search(arguments, request_id=request_id)
+            return _standardize_tool_result(await self._web_search(arguments, request_id=request_id))
         elif tool_name == "find_in_page":
-            return await self._find_in_page(arguments, request_id=request_id)
+            return _standardize_tool_result(await self._find_in_page(arguments, request_id=request_id))
         elif tool_name == "scroll_page":
-            return await self._scroll_page(arguments, request_id=request_id)
-        return f"Error: unknown tool '{tool_name}'"
+            return _standardize_tool_result(await self._scroll_page(arguments, request_id=request_id))
+        return _tool_error(f"Error: unknown tool '{tool_name}'")
 
     async def _web_search(self, arguments: dict[str, Any], *, request_id: str | None) -> str:
         query = arguments.get("query")
@@ -904,24 +930,24 @@ class DirectTavilyBrowserTool(DirectTavilyGymTool):
         }
         if tool_name not in allowed_args_by_tool:
             self._increment_stat((extra_args or {}).get("request_id"), "tool_errors")
-            return f"Error: unknown tool '{tool_name}'"
+            return _tool_error(f"Error: unknown tool '{tool_name}'")
 
         arguments, error = self._sanitize_and_validate_arguments(tool_name, arguments, allowed_args_by_tool[tool_name])
         request_id = (extra_args or {}).get("request_id")
         if error:
             self._increment_stat(request_id, "tool_errors")
-            return error
+            return _tool_error(error)
 
         if tool_name == "web_search":
-            return await self._web_search(arguments, request_id=request_id)
+            return _standardize_tool_result(await self._web_search(arguments, request_id=request_id))
         elif tool_name == "open_result":
-            return await self._open_result(arguments, request_id=request_id)
+            return _standardize_tool_result(await self._open_result(arguments, request_id=request_id))
         elif tool_name == "find_in_page":
-            return await self._find_in_page(arguments, request_id=request_id)
+            return _standardize_tool_result(await self._find_in_page(arguments, request_id=request_id))
         elif tool_name == "scroll_page":
-            return await self._scroll_page(arguments, request_id=request_id)
+            return _standardize_tool_result(await self._scroll_page(arguments, request_id=request_id))
         self._increment_stat(request_id, "tool_errors")
-        return f"Error: unknown tool '{tool_name}'"
+        return _tool_error(f"Error: unknown tool '{tool_name}'")
 
     def _stats_for_request(self, request_id: str | None) -> defaultdict[str, int]:
         if request_id is None:
@@ -1021,7 +1047,7 @@ class DirectTavilyBrowserTool(DirectTavilyGymTool):
     async def _find_in_page(self, arguments: dict[str, Any], *, request_id: str | None) -> str:
         self._increment_stat(request_id, "find_in_page_calls")
         result = await super()._find_in_page(arguments, request_id=request_id)
-        if _is_gym_tool_error_result(result):
+        if _is_direct_tavily_error_result(result):
             self._increment_stat(request_id, "tool_errors")
         return result
 

--- a/nemo_skills/mcp/servers/tavily_search_tool.py
+++ b/nemo_skills/mcp/servers/tavily_search_tool.py
@@ -36,7 +36,7 @@ from collections import OrderedDict, defaultdict
 from dataclasses import dataclass, field
 from time import time
 from typing import Annotated, Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import httpx
 from mcp.server.fastmcp import FastMCP
@@ -137,6 +137,15 @@ DIRECT_TAVILY_ERROR_MESSAGES = {
     "No content found.",
     "Start index is beyond page length.",
 }
+TRACKING_QUERY_PARAM_NAMES = {
+    "fbclid",
+    "gclid",
+    "igshid",
+    "mc_cid",
+    "mc_eid",
+    "msclkid",
+}
+TRACKING_QUERY_PARAM_PREFIXES = ("utm_",)
 
 # These errors should stop the process - no point continuing with bad credentials
 FATAL_STATUS_CODES = {401, 403}
@@ -248,6 +257,17 @@ def _extract_domain(url: str) -> str:
 def _is_url_excluded(url: str, exclude_domains: list[str]) -> bool:
     hostname = urlparse(url).hostname or ""
     return any(hostname == domain or hostname.endswith("." + domain) for domain in exclude_domains)
+
+
+def _cache_key_for_url(url: str) -> str:
+    parsed = urlparse(url)
+    filtered_query = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key.lower() not in TRACKING_QUERY_PARAM_NAMES and not key.lower().startswith(TRACKING_QUERY_PARAM_PREFIXES)
+    ]
+    query = urlencode(sorted(filtered_query), doseq=True)
+    return urlunparse(parsed._replace(query=query, fragment=""))
 
 
 def _clean_text(text: str) -> str:
@@ -794,9 +814,10 @@ class DirectTavilyGymTool(_DirectTavilyBase):
         start_index = max(0, start_index)
         n = max(1, n)
 
-        if url in self._page_cache:
-            self._page_cache.move_to_end(url)
-            page_content = self._page_cache[url]
+        cache_key = _cache_key_for_url(url)
+        if cache_key in self._page_cache:
+            self._page_cache.move_to_end(cache_key)
+            page_content = self._page_cache[cache_key]
         else:
             payload = {
                 "urls": url,
@@ -807,7 +828,7 @@ class DirectTavilyGymTool(_DirectTavilyBase):
             if results.get("error"):
                 return results["error"]
             page_content = _first_raw_content(results)
-            _remember_lru(self._page_cache, url, page_content, max(1, int(self._config["max_cached_pages"])))
+            _remember_lru(self._page_cache, cache_key, page_content, max(1, int(self._config["max_cached_pages"])))
 
         words = page_content.split()
         total_words = len(words)
@@ -1059,11 +1080,12 @@ class DirectTavilyBrowserTool(DirectTavilyGymTool):
             self._increment_stat(request_id, "excluded_url_attempts")
             return None, "URL is in excluded domains"
 
+        cache_key = _cache_key_for_url(url)
         cache = self._page_cache_for_request(request_id)
-        if url in cache:
-            cache.move_to_end(url)
+        if cache_key in cache:
+            cache.move_to_end(cache_key)
             self._increment_stat(request_id, "cache_hits")
-            return cache[url], None
+            return cache[cache_key], None
 
         self._increment_stat(request_id, "cache_misses")
         payload = {
@@ -1084,7 +1106,7 @@ class DirectTavilyBrowserTool(DirectTavilyGymTool):
         raw_content, was_truncated = _truncate_text(raw_content, max_cached_page_chars)
         cleaned = _clean_text(raw_content)
         page = TavilyBrowserCachedPage(content=cleaned, words=cleaned.split(), truncated=was_truncated)
-        _remember_lru(cache, url, page, max(1, int(self._config["max_cached_pages"])))
+        _remember_lru(cache, cache_key, page, max(1, int(self._config["max_cached_pages"])))
         return page, None
 
     async def _open_result(self, arguments: dict[str, Any], *, request_id: str | None) -> str:

--- a/nemo_skills/mcp/servers/tavily_search_tool.py
+++ b/nemo_skills/mcp/servers/tavily_search_tool.py
@@ -22,6 +22,31 @@ Usage:
     ++tool_modules=[nemo_skills.mcp.servers.tavily_search_tool::DirectTavilySearchTool]
     ++tool_modules=[nemo_skills.mcp.servers.tavily_search_tool::DirectTavilyGymTool]
     ++tool_modules=[nemo_skills.mcp.servers.tavily_search_tool::DirectTavilyBrowserTool]
+
+Configuration:
+    All Tavily tools require ``exclude_domains_config`` and intentionally do not
+    provide a default. Example override:
+
+        ++tool_overrides.DirectTavilyBrowserTool.exclude_domains_config=/path/to/exclude_domains.json
+
+    The config file is expected to contain domain-valued notice properties:
+
+        {
+          "notices": [
+            {
+              "properties": [
+                {"type": "domain", "value": "example.com"},
+                {"type": "domain", "value": "restricted.example.org"}
+              ]
+            }
+          ]
+        }
+
+    If these tools are used for training data curation, use an
+    organization-approved exclusion registry. This reduces the risk of collecting
+    content from domains that must be excluded for legal, license, policy, or
+    contractual reasons. Do not use an intentionally empty allow-all config for
+    training data curation without review.
 """
 
 from __future__ import annotations
@@ -364,13 +389,13 @@ def _postprocess_gym_search_results(results: dict[str, Any], max_result_chars: i
 
 
 class _DirectTavilyBase(Tool):
+    _required_config_keys = {"exclude_domains_config"}
+
     def __init__(self) -> None:
         self._config: dict[str, Any] = {
             "tavily_api_key": None,
             "api_base_url": DEFAULT_API_BASE_URL,
             "exclude_domains": [],
-            "exclude_domains_config": None,
-            "require_exclude_domains_config": False,
             "timeout_s": DEFAULT_HTTP_TIMEOUT_S,
             "max_retries": DEFAULT_MAX_RETRIES,
             "retry_backoff_s": DEFAULT_RETRY_BACKOFF_S,
@@ -389,18 +414,19 @@ class _DirectTavilyBase(Tool):
     def configure(self, overrides: dict[str, Any] | None = None, context: dict[str, Any] | None = None) -> None:
         cfg = dict(self._config)
         if overrides:
-            unknown = set(overrides) - set(cfg)
+            allowed_keys = set(cfg) | self._required_config_keys
+            unknown = set(overrides) - allowed_keys
             if unknown:
                 raise ValueError(f"Unknown {self.__class__.__name__} override(s): {sorted(unknown)}")
             cfg.update(overrides)
 
+        if not cfg.get("exclude_domains_config"):
+            raise ValueError("exclude_domains_config is required. Provide a path to an exclude-domain config file.")
+
         self._config = cfg
         self._api_keys = _normalize_api_keys(cfg.get("tavily_api_key"))
         self._exclude_domains = list(cfg.get("exclude_domains") or [])
-        if cfg.get("exclude_domains_config"):
-            self._exclude_domains.extend(_load_exclude_domains_from_file(cfg["exclude_domains_config"]))
-        if cfg.get("require_exclude_domains_config") and not self._exclude_domains:
-            raise ValueError("exclude_domains_config is not set")
+        self._exclude_domains.extend(_load_exclude_domains_from_file(cfg["exclude_domains_config"]))
         self._exclude_domains = sorted(set(self._exclude_domains))
         self._sanitize_keys = {tool: set(keys) for tool, keys in cfg.get("hide_args", {}).items()}
 
@@ -536,22 +562,20 @@ class TavilySearchTool(MCPClientTool):
                 "hide_args": {
                     "web-search": ["exclude_domains", "num_results", "answer_type"],
                 },
-                "exclude_domains_config": None,
             }
         )
 
     def post_configure(self) -> None:
-        # Require excluded domains for the legacy MCP path to preserve existing behavior.
-        if (conf := self._config.get("exclude_domains_config")) is not None:
-            self.exclude_domains = _load_exclude_domains_from_file(conf)
-        else:
-            raise ValueError("exclude_domains_config is not set")
+        conf = self._config.get("exclude_domains_config")
+        if not conf:
+            raise ValueError("exclude_domains_config is required. Provide a path to an exclude-domain config file.")
+        self.exclude_domains = _load_exclude_domains_from_file(conf)
 
     async def execute(self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None):
         arguments = dict(arguments)
         merged_extra = dict(extra_args or {})
         if not hasattr(self, "exclude_domains"):
-            raise ValueError("exclude_domains_config is not set")
+            raise ValueError("exclude_domains_config is required. Provide a path to an exclude-domain config file.")
         merged_extra["exclude_domains"] = self.exclude_domains
         for key in ["num_results", "answer_type"]:
             if key in self._config:

--- a/nemo_skills/mcp/servers/tavily_search_tool.py
+++ b/nemo_skills/mcp/servers/tavily_search_tool.py
@@ -12,18 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Tavily MCP and direct tools.
+
+The direct tools mirror the ``PythonTool`` -> ``DirectPythonTool`` split:
+they implement the Tool abstraction directly and call Tavily over HTTP without
+spawning an MCP server/client pair.
+
+Usage:
+    ++tool_modules=[nemo_skills.mcp.servers.tavily_search_tool::DirectTavilySearchTool]
+    ++tool_modules=[nemo_skills.mcp.servers.tavily_search_tool::DirectTavilyGymTool]
+    ++tool_modules=[nemo_skills.mcp.servers.tavily_search_tool::DirectTavilyBrowserTool]
+"""
+
+from __future__ import annotations
+
 import argparse
+import asyncio
 import json
 import logging
 import os
-from dataclasses import dataclass
+import re
+from collections import OrderedDict, defaultdict
+from dataclasses import dataclass, field
+from time import time
 from typing import Annotated, Any
+from urllib.parse import urlparse
 
 import httpx
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from nemo_skills.mcp.tool_manager import FatalToolError
+from nemo_skills.mcp.tool_manager import FatalToolError, Tool
 from nemo_skills.mcp.tool_providers import MCPClientTool
 
 logger = logging.getLogger(__name__)
@@ -35,6 +54,39 @@ class ExecutionResult:
     result: str | None = None
 
 
+@dataclass
+class TavilySearchSingleCallMetric:
+    function: str
+    status: str
+    start_time: float
+    end_time: float
+    time_taken: float = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.time_taken = self.end_time - self.start_time
+
+
+@dataclass
+class TavilySearchMetrics:
+    async_tavily_calls: list[TavilySearchSingleCallMetric] = field(default_factory=list)
+
+
+@dataclass
+class TavilyBrowserCachedPage:
+    content: str
+    words: list[str]
+    truncated: bool = False
+
+
+@dataclass
+class TavilyBrowserSearchMemoryItem:
+    index: int
+    title: str
+    url: str
+    domain: str
+    snippet: str
+
+
 mcp = FastMCP(name="tavily")
 
 # Populated from CLI args in main()
@@ -42,25 +94,321 @@ TAVILY_API_KEY: str | None = None
 
 EXCLUDE_DOMAINS: list[str] | None = None
 MAX_NUM_RESULTS: int = 20
+DEFAULT_API_BASE_URL = "https://api.tavily.com"
+DEFAULT_HTTP_TIMEOUT_S = 30.0
+DEFAULT_MAX_RETRIES = 2
+DEFAULT_RETRY_BACKOFF_S = 0.5
+DEFAULT_GYM_MAX_RESULTS = 10
+DEFAULT_GYM_MAX_RESULT_CHARS = 2000
+DEFAULT_GYM_MAX_QUERY_CHARS = 400
+DEFAULT_SCROLL_WORDS = 2000
+DEFAULT_BROWSER_MAX_SCROLL_WORDS = 2000
+DEFAULT_BROWSER_MAX_SCROLL_CHARS = 8000
+DEFAULT_BROWSER_MAX_CACHED_PAGES = 64
+DEFAULT_BROWSER_MAX_CACHED_PAGE_CHARS = 500_000
+DEFAULT_BROWSER_MAX_SEARCH_RESULTS = 50
 
 STATUS_CODE_ERRORS = {
+    400: "Search request is invalid",
     429: "Search rate limit exceeded",
+    432: "Search request failed due to Tavily account quota or billing status",
+    433: "Search request failed due to Tavily access restrictions",
     500: "Search request failed due to server error",
     502: "Search request failed due to bad gateway",
     503: "Search request failed due to service unavailable",
     504: "Search request failed due to gateway timeout",
 }
 
+RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
+
 # These errors should stop the process - no point continuing with bad credentials
 FATAL_STATUS_CODES = {401, 403}
 
 
+def _parse_exclude_domains(exclude_config: dict[str, Any]) -> list[str]:
+    exclude_domains = []
+    # This is deliberately aligned with the Nemotron/TDM registry structure.
+    notices = exclude_config["notices"]
+    for notice in notices:
+        for prop in notice["properties"]:
+            if prop.get("type") == "domain":
+                exclude_domains.append(prop["value"])
+    return exclude_domains
+
+
+def _load_exclude_domains_from_file(path: str) -> list[str]:
+    with open(path, "r", encoding="utf-8") as f:
+        exclude_config = json.load(f)
+    return _parse_exclude_domains(exclude_config)
+
+
+def _normalize_api_keys(value: str | list[str] | tuple[str, ...] | None) -> list[str]:
+    if value is None:
+        value = os.getenv("TAVILY_API_KEY")
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [key.strip() for key in value.split(",") if key.strip()]
+    return [str(key).strip() for key in value if str(key).strip()]
+
+
+def _retry_after_seconds(response: httpx.Response) -> float | None:
+    raw = response.headers.get("retry-after")
+    if not raw:
+        return None
+    try:
+        return max(0.0, min(float(raw), 30.0))
+    except ValueError:
+        return None
+
+
+async def _post_tavily_json(
+    *,
+    api_base_url: str,
+    api_key: str,
+    endpoint: str,
+    payload: dict[str, Any],
+    timeout_s: float,
+    max_retries: int,
+    retry_backoff_s: float,
+) -> dict[str, Any]:
+    url = f"{api_base_url.rstrip('/')}/{endpoint.lstrip('/')}"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    delay = retry_backoff_s
+    last_error = "Search request failed"
+
+    for attempt in range(max_retries + 1):
+        try:
+            async with httpx.AsyncClient(timeout=timeout_s) as client:
+                response = await client.post(url, headers=headers, json=payload)
+        except httpx.TimeoutException:
+            last_error = "Search request timed out"
+            if attempt < max_retries:
+                await asyncio.sleep(delay)
+                delay *= 2
+                continue
+            return {"error": last_error}
+        except httpx.RequestError:
+            last_error = "Search request failed due to network error"
+            if attempt < max_retries:
+                await asyncio.sleep(delay)
+                delay *= 2
+                continue
+            return {"error": last_error}
+
+        if response.status_code in FATAL_STATUS_CODES:
+            raise FatalToolError("Search authentication failed")
+
+        if response.status_code == 200:
+            try:
+                return response.json()
+            except json.JSONDecodeError:
+                return {"error": "Search returned invalid response"}
+
+        last_error = STATUS_CODE_ERRORS.get(
+            response.status_code,
+            f"Search request failed with status {response.status_code}",
+        )
+        if response.status_code in RETRY_STATUS_CODES and attempt < max_retries:
+            await asyncio.sleep(_retry_after_seconds(response) or delay)
+            delay *= 2
+            continue
+        return {"error": last_error}
+
+    return {"error": last_error}
+
+
+def _extract_domain(url: str) -> str:
+    return urlparse(url).hostname or url
+
+
+def _is_url_excluded(url: str, exclude_domains: list[str]) -> bool:
+    hostname = urlparse(url).hostname or ""
+    return any(hostname == domain or hostname.endswith("." + domain) for domain in exclude_domains)
+
+
+def _clean_text(text: str) -> str:
+    """Remove common wiki/web navigation artifacts and normalize whitespace."""
+    text = re.sub(r"\[edit\]", "", text)
+    text = re.sub(r"^\[(?:Jump to content|Search|Read|Edit|View history)[^\]]*\].*$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\[[^\]]+\]\(https?://[a-z]{2,3}\.wikipedia\.org/[^\)]*\)", "", text)
+    text = re.sub(r"^\s*\*\s*\[[^\]]*\]\(#[^\)]*\)\s*$", "", text, flags=re.MULTILINE)
+    text = text.replace("\u200b", "").replace("\u200c", "").replace("\u200d", "").replace("\ufeff", "")
+    text = text.replace("\u3010", "[").replace("\u3011", "]")
+    text = re.sub(r"[ \t]+$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _add_line_numbers(text: str) -> str:
+    lines = text.split("\n")
+    return "\n".join(f"L{i}: {line}" for i, line in enumerate(lines))
+
+
+def _truncate_text(text: str, max_chars: int = DEFAULT_GYM_MAX_RESULT_CHARS) -> tuple[str, bool]:
+    if len(text) <= max_chars:
+        return text, False
+    cut = text.rfind("\n", 0, max_chars)
+    if cut == -1:
+        cut = max_chars
+    return text[:cut], True
+
+
+def _coerce_int_arg(value: Any, default: int | None, arg_name: str) -> tuple[int | None, str | None]:
+    if value is None or value == "":
+        return default, None
+    if isinstance(value, bool):
+        return None, f"{arg_name} must be an integer"
+    try:
+        return int(value), None
+    except (TypeError, ValueError):
+        return None, f"{arg_name} must be an integer"
+
+
+def _remember_lru(cache: OrderedDict[str, Any], key: str, value: Any, max_items: int) -> None:
+    if key in cache:
+        cache.move_to_end(key)
+    cache[key] = value
+    while len(cache) > max_items:
+        cache.popitem(last=False)
+
+
+def _first_raw_content(results: dict[str, Any]) -> str:
+    result_list = results.get("results") or []
+    if not result_list:
+        return ""
+    return result_list[0].get("raw_content", "") or ""
+
+
+def _postprocess_gym_search_results(results: dict[str, Any], max_result_chars: int) -> list[str]:
+    answer = results.get("answer")
+    if answer is not None:
+        return [f"Search Answer\n==============\n{answer}\n"]
+
+    formatted_results = ["Search Results\n==============\n"]
+    for i, result in enumerate(results.get("results") or [], 1):
+        domain = _extract_domain(result.get("url", ""))
+        snippet = _clean_text(result.get("content", ""))
+        snippet, _ = _truncate_text(snippet, max_result_chars)
+        formatted_results.append(
+            f"[{i}] {result.get('title', '')} ({domain})\n URL: {result.get('url', '')}\n Summary: {snippet}\n\n"
+        )
+    return formatted_results
+
+
+class _DirectTavilyBase(Tool):
+    def __init__(self) -> None:
+        self._config: dict[str, Any] = {
+            "tavily_api_key": None,
+            "api_base_url": DEFAULT_API_BASE_URL,
+            "exclude_domains": [],
+            "exclude_domains_config": None,
+            "require_exclude_domains_config": False,
+            "timeout_s": DEFAULT_HTTP_TIMEOUT_S,
+            "max_retries": DEFAULT_MAX_RETRIES,
+            "retry_backoff_s": DEFAULT_RETRY_BACKOFF_S,
+            "hide_args": {},
+        }
+        self._api_keys: list[str] = []
+        self._num_requests = 0
+        self._exclude_domains: list[str] = []
+        self._sanitize_keys: dict[str, set[str]] = {}
+        self.requests_to_metrics: dict[str, TavilySearchMetrics] = defaultdict(TavilySearchMetrics)
+
+    def default_config(self) -> dict[str, Any]:
+        return dict(self._config)
+
+    def configure(self, overrides: dict[str, Any] | None = None, context: dict[str, Any] | None = None) -> None:
+        cfg = dict(self._config)
+        if overrides:
+            unknown = set(overrides) - set(cfg)
+            if unknown:
+                raise ValueError(f"Unknown {self.__class__.__name__} override(s): {sorted(unknown)}")
+            cfg.update(overrides)
+
+        self._config = cfg
+        self._api_keys = _normalize_api_keys(cfg.get("tavily_api_key"))
+        self._exclude_domains = list(cfg.get("exclude_domains") or [])
+        if cfg.get("exclude_domains_config"):
+            self._exclude_domains.extend(_load_exclude_domains_from_file(cfg["exclude_domains_config"]))
+        if cfg.get("require_exclude_domains_config") and not self._exclude_domains:
+            raise ValueError("exclude_domains_config is not set")
+        self._exclude_domains = sorted(set(self._exclude_domains))
+        self._sanitize_keys = {tool: set(keys) for tool, keys in cfg.get("hide_args", {}).items()}
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    async def execute(
+        self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None
+    ) -> Any:
+        raise NotImplementedError
+
+    def _select_api_key(self) -> str:
+        if not self._api_keys:
+            raise FatalToolError("Missing Tavily API key. Set TAVILY_API_KEY or tool override tavily_api_key.")
+        api_key = self._api_keys[self._num_requests % len(self._api_keys)]
+        self._num_requests += 1
+        return api_key
+
+    async def _post_json(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return await _post_tavily_json(
+            api_base_url=self._config["api_base_url"],
+            api_key=self._select_api_key(),
+            endpoint=endpoint,
+            payload=payload,
+            timeout_s=float(self._config["timeout_s"]),
+            max_retries=int(self._config["max_retries"]),
+            retry_backoff_s=float(self._config["retry_backoff_s"]),
+        )
+
+    def _sanitize_arguments(self, tool_name: str, arguments: dict[str, Any] | None) -> dict[str, Any]:
+        hidden = self._sanitize_keys.get(tool_name, set())
+        return {k: v for k, v in dict(arguments or {}).items() if k not in hidden}
+
+    async def _tracked_post_json(
+        self,
+        endpoint: str,
+        payload: dict[str, Any],
+        *,
+        request_id: str | None,
+        function: str,
+    ) -> dict[str, Any]:
+        start_time = time()
+        status = "success"
+        try:
+            response = await self._post_json(endpoint, payload)
+            if isinstance(response, dict) and response.get("error"):
+                status = "error"
+            return response
+        except Exception:
+            status = "error"
+            raise
+        finally:
+            if request_id is not None:
+                self.requests_to_metrics[request_id].async_tavily_calls.append(
+                    TavilySearchSingleCallMetric(
+                        function=function,
+                        status=status,
+                        start_time=start_time,
+                        end_time=time(),
+                    )
+                )
+
+    async def cleanup_request(self, request_id: str) -> None:
+        self.requests_to_metrics.pop(request_id, None)
+
+
 ## See docs https://docs.tavily.com/documentation/api-reference/endpoint/search
-## There is also a hosted MCP that can be used instead of this tool: https://github.com/tavily-ai/tavily-mcp?tab=readme-ov-file#remote-mcp-server
+## There is also a hosted MCP that can be used instead of this tool:
+## https://github.com/tavily-ai/tavily-mcp?tab=readme-ov-file#remote-mcp-server
 @mcp.tool(name="web-search")
 async def answer(
     query: Annotated[str, Field(description="Search query.")],
-    exclude_domains: Annotated[list[str], Field(description="Domains to exclude from the search.")] = [],
+    exclude_domains: Annotated[list[str] | None, Field(description="Domains to exclude from the search.")] = None,
     num_results: Annotated[int, Field(description="Number of results to return.")] = 10,
     answer_type: Annotated[
         str,
@@ -69,9 +417,7 @@ async def answer(
         ),
     ] = "answer",
 ):
-    """Search the web for a query"""
-
-    api_url = "https://api.tavily.com/search"
+    """Search the web for a query."""
 
     # Validate inputs
     if answer_type not in ["answer", "results"]:
@@ -79,61 +425,34 @@ async def answer(
     if num_results > MAX_NUM_RESULTS:
         return {"error": f"Number of results must be less than or equal to {MAX_NUM_RESULTS}."}
 
-    headers = {
-        "Authorization": f"Bearer {TAVILY_API_KEY}",
-        "Content-Type": "application/json",
-    }
-
     payload = {
         "query": query,
-        # "auto_parameters": False,
         "search_depth": "basic",
-        "include_answer": "basic",  ## or advanced.
-        "num_results": num_results,
-        # this should be statically set to the domains we want to exclude
-        "exclude_domains": exclude_domains,
+        "include_answer": "basic",
+        "max_results": num_results,
+        "exclude_domains": exclude_domains or [],
     }
 
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.post(api_url, headers=headers, json=payload)
-    except httpx.TimeoutException:
-        return {"error": "Search request timed out"}
-    except httpx.RequestError:
-        return {"error": "Search request failed due to network error"}
-
-    # Handle non-200 responses
-    if response.status_code in FATAL_STATUS_CODES:
-        return {"error": "Search authentication failed", "fatal": True}
-    if response.status_code != 200:
-        error_msg = STATUS_CODE_ERRORS.get(
-            response.status_code, f"Search request failed with status {response.status_code}"
+        result = await _post_tavily_json(
+            api_base_url=DEFAULT_API_BASE_URL,
+            api_key=TAVILY_API_KEY or "",
+            endpoint="/search",
+            payload=payload,
+            timeout_s=DEFAULT_HTTP_TIMEOUT_S,
+            max_retries=DEFAULT_MAX_RETRIES,
+            retry_backoff_s=DEFAULT_RETRY_BACKOFF_S,
         )
-        return {"error": error_msg}
+    except FatalToolError:
+        return {"error": "Search authentication failed", "fatal": True}
+    if isinstance(result, dict) and result.get("error"):
+        return result
 
-    # Parse response
-    try:
-        data = response.json()
-    except json.JSONDecodeError:
-        return {"error": "Search returned invalid response"}
-
-    # Extract result
-    result = data.get(answer_type)
-    if result is None:
+    extracted = result.get(answer_type)
+    if extracted is None:
         return {"error": "Search response is missing required field"}
 
-    return result
-
-
-def _parse_exclude_domains(exclude_config: dict) -> list[str]:
-    exclude_domains = []
-    # this is pretty hard-coded so we ensure the file structure is correct
-    notices = exclude_config["notices"]
-    for notice in notices:
-        for prop in notice["properties"]:
-            if prop.get("type") == "domain":
-                exclude_domains.append(prop["value"])
-    return exclude_domains
+    return extracted
 
 
 class TavilySearchTool(MCPClientTool):
@@ -154,11 +473,9 @@ class TavilySearchTool(MCPClientTool):
         )
 
     def post_configure(self) -> None:
-        # Required the exclude domains to be set--we do not want to accidentally include all domains
+        # Require excluded domains for the legacy MCP path to preserve existing behavior.
         if (conf := self._config.get("exclude_domains_config")) is not None:
-            with open(conf, "r") as f:
-                exlude_config = json.load(f)
-                self.exclude_domains = _parse_exclude_domains(exlude_config)
+            self.exclude_domains = _load_exclude_domains_from_file(conf)
         else:
             raise ValueError("exclude_domains_config is not set")
 
@@ -178,6 +495,659 @@ class TavilySearchTool(MCPClientTool):
             raise FatalToolError(result.get("error", "Fatal tool error"))
 
         return result
+
+
+class DirectTavilySearchTool(_DirectTavilyBase):
+    """Direct version of TavilySearchTool that bypasses MCP transport."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._config.update(
+            {
+                "hide_args": {
+                    "web-search": ["exclude_domains", "num_results", "answer_type"],
+                    "web_search": ["exclude_domains", "num_results", "answer_type"],
+                },
+                "num_results": 10,
+                "answer_type": "answer",
+                "search_depth": "basic",
+                "include_answer": "basic",
+                "max_num_results": MAX_NUM_RESULTS,
+            }
+        )
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "web_search",
+                "description": "Search the web for a query using Tavily.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string", "description": "Search query."}},
+                    "required": ["query"],
+                },
+            }
+        ]
+
+    async def execute(
+        self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None
+    ) -> Any:
+        if tool_name not in {"web-search", "web_search"}:
+            return {"error": f"unknown tool '{tool_name}'"}
+
+        arguments = self._sanitize_arguments(tool_name, arguments)
+        query = arguments.get("query")
+        if not isinstance(query, str):
+            return {"error": "Missing required argument 'query'"}
+
+        num_results = int(self._config["num_results"])
+        if num_results > int(self._config["max_num_results"]):
+            return {"error": f"Number of results must be less than or equal to {self._config['max_num_results']}."}
+
+        answer_type = self._config["answer_type"]
+        if answer_type not in ["answer", "results"]:
+            return {"error": "Invalid answer type. Choose 'answer' or 'results'."}
+
+        extra_args = dict(extra_args or {})
+        request_id = extra_args.get("request_id")
+        payload = {
+            "query": query,
+            "search_depth": self._config["search_depth"],
+            "include_answer": self._config["include_answer"],
+            "max_results": num_results,
+            "exclude_domains": self._exclude_domains,
+        }
+        result = await self._tracked_post_json("/search", payload, request_id=request_id, function="search")
+        if isinstance(result, dict) and result.get("error"):
+            return result
+
+        extracted = result.get(answer_type)
+        if extracted is None:
+            return {"error": "Search response is missing required field"}
+        return extracted
+
+
+class DirectTavilyGymTool(_DirectTavilyBase):
+    """Direct implementation of the NeMo-Gym Tavily search resource tools.
+
+    This ports the core tool surface from NVIDIA-NeMo/Gym's Tavily resource
+    server: web search, query-focused page extraction, and paginated page
+    scrolling. Judge/verify logic is intentionally excluded.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._config.update(
+            {
+                "hide_args": {
+                    "web_search": ["exclude_domains", "max_results", "search_depth"],
+                    "find_in_page": ["extract_depth"],
+                    "scroll_page": ["extract_depth"],
+                },
+                "max_results": DEFAULT_GYM_MAX_RESULTS,
+                "max_result_chars": DEFAULT_GYM_MAX_RESULT_CHARS,
+                "max_query_chars": DEFAULT_GYM_MAX_QUERY_CHARS,
+                "search_depth": "advanced",
+                "include_answer": None,
+                "extract_depth": "basic",
+                "extract_format": "markdown",
+                "scroll_words": DEFAULT_SCROLL_WORDS,
+            }
+        )
+        self._page_cache: dict[str, str] = {}
+
+    def configure(self, overrides: dict[str, Any] | None = None, context: dict[str, Any] | None = None) -> None:
+        super().configure(overrides, context)
+        self._page_cache = {}
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "web_search",
+                "description": "Search the web using Tavily and return a concise answer or ranked search results.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string", "description": "Search query."}},
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "find_in_page",
+                "description": "Find query-relevant content inside a specific URL using Tavily Extract.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "URL to inspect."},
+                        "query": {"type": "string", "description": "Term or question to locate within the page."},
+                    },
+                    "required": ["url", "query"],
+                },
+            },
+            {
+                "name": "scroll_page",
+                "description": "Read a word window from a URL, starting at a specific word index.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "URL to read."},
+                        "start_index": {
+                            "type": "integer",
+                            "description": "Zero-based word index to start reading from.",
+                        },
+                        "n": {"type": "integer", "description": "Number of words to return."},
+                    },
+                    "required": ["url"],
+                },
+            },
+        ]
+
+    async def execute(
+        self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None
+    ) -> str | dict[str, Any]:
+        arguments = self._sanitize_arguments(tool_name, arguments)
+        request_id = (extra_args or {}).get("request_id")
+        if tool_name == "web_search":
+            return await self._web_search(arguments, request_id=request_id)
+        if tool_name == "find_in_page":
+            return await self._find_in_page(arguments, request_id=request_id)
+        if tool_name == "scroll_page":
+            return await self._scroll_page(arguments, request_id=request_id)
+        return f"Error: unknown tool '{tool_name}'"
+
+    async def _web_search(self, arguments: dict[str, Any], *, request_id: str | None) -> str:
+        query = arguments.get("query")
+        if query is None:
+            return "Query is none"
+        if not isinstance(query, str):
+            return "Query must be a string"
+        if len(query) > int(self._config["max_query_chars"]):
+            return "Query is too long"
+
+        payload = {
+            "query": query,
+            "max_results": int(self._config["max_results"]),
+            "exclude_domains": self._exclude_domains,
+            "search_depth": self._config["search_depth"],
+        }
+        if self._config["include_answer"] is not None:
+            payload["include_answer"] = self._config["include_answer"]
+        results = await self._tracked_post_json("/search", payload, request_id=request_id, function="search")
+        if results.get("error"):
+            return results["error"]
+        return "".join(_postprocess_gym_search_results(results, int(self._config["max_result_chars"])))
+
+    async def _find_in_page(self, arguments: dict[str, Any], *, request_id: str | None) -> str:
+        url = arguments.get("url")
+        query = arguments.get("query")
+        if url is None:
+            return "URL is none"
+        if query is None:
+            return "Query is none"
+        if not isinstance(url, str) or not isinstance(query, str):
+            return "URL and query must be strings"
+        if _is_url_excluded(url, self._exclude_domains):
+            return "URL is in excluded domains"
+
+        payload = {
+            "urls": url,
+            "query": query,
+            "extract_depth": self._config["extract_depth"],
+            "format": self._config["extract_format"],
+        }
+        results = await self._tracked_post_json("/extract", payload, request_id=request_id, function="extract")
+        if results.get("error"):
+            return results["error"]
+
+        raw_content = _first_raw_content(results)
+        if not raw_content:
+            return "No content found."
+
+        domain = _extract_domain(url)
+        cleaned = _clean_text(raw_content)
+        truncated, was_truncated = _truncate_text(cleaned, int(self._config["max_result_chars"]))
+        numbered = _add_line_numbers(truncated)
+        header = f'Content from: {domain}\nURL: {url}\nQuery: "{query}"\n========================================\n'
+        footer = "\n[...truncated, use scroll_page for full content]" if was_truncated else ""
+        return header + numbered + footer
+
+    async def _scroll_page(self, arguments: dict[str, Any], *, request_id: str | None) -> str:
+        url = arguments.get("url")
+        if url is None:
+            return "URL is none"
+        if not isinstance(url, str):
+            return "URL must be a string"
+        if _is_url_excluded(url, self._exclude_domains):
+            return "URL is in excluded domains"
+
+        start_index = int(arguments.get("start_index", 0) or 0)
+        n = int(arguments.get("n", self._config["scroll_words"]) or self._config["scroll_words"])
+        start_index = max(0, start_index)
+        n = max(1, n)
+
+        if url in self._page_cache:
+            page_content = self._page_cache[url]
+        else:
+            payload = {
+                "urls": url,
+                "extract_depth": self._config["extract_depth"],
+                "format": self._config["extract_format"],
+            }
+            results = await self._tracked_post_json("/extract", payload, request_id=request_id, function="extract")
+            if results.get("error"):
+                return results["error"]
+            page_content = _first_raw_content(results)
+            self._page_cache[url] = page_content
+
+        words = page_content.split()
+        total_words = len(words)
+        sliced_words = words[start_index : start_index + n]
+        chunk_text = " ".join(sliced_words)
+        domain = _extract_domain(url)
+        cleaned = _clean_text(chunk_text)
+        numbered = _add_line_numbers(cleaned)
+        end_index = min(start_index + n, total_words)
+        header = (
+            f"Page content from: {domain}\n"
+            f"URL: {url}\n"
+            f"Showing words [{start_index}-{end_index}] of {total_words}\n"
+            f"========================================\n"
+        )
+        return header + numbered
+
+
+class DirectTavilyBrowserTool(DirectTavilyGymTool):
+    """Tavily browser tool with request-local memory, bounded cache, and metrics.
+
+    This intentionally leaves DirectTavilySearchTool and DirectTavilyGymTool
+    unchanged. The browser tool keeps the Gym surface and adds
+    ``open_result(index)`` for opening a result from the most recent search.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._config.update(
+            {
+                "hide_args": {
+                    "web_search": ["exclude_domains", "max_results", "search_depth"],
+                    "find_in_page": ["extract_depth"],
+                    "scroll_page": ["extract_depth", "max_scroll_words", "max_scroll_chars"],
+                    "open_result": ["extract_depth", "max_open_result_chars"],
+                },
+                "max_scroll_words": DEFAULT_BROWSER_MAX_SCROLL_WORDS,
+                "max_scroll_chars": DEFAULT_BROWSER_MAX_SCROLL_CHARS,
+                "max_cached_pages": DEFAULT_BROWSER_MAX_CACHED_PAGES,
+                "max_cached_page_chars": DEFAULT_BROWSER_MAX_CACHED_PAGE_CHARS,
+                "max_search_memory_results": DEFAULT_BROWSER_MAX_SEARCH_RESULTS,
+                "max_open_result_chars": DEFAULT_GYM_MAX_RESULT_CHARS,
+            }
+        )
+        self._reset_browser_state()
+
+    def _reset_browser_state(self) -> None:
+        self._request_page_cache: dict[str, OrderedDict[str, TavilyBrowserCachedPage]] = defaultdict(OrderedDict)
+        self._global_page_cache: OrderedDict[str, TavilyBrowserCachedPage] = OrderedDict()
+        self._request_search_memory: dict[str, list[TavilyBrowserSearchMemoryItem]] = {}
+        self._global_search_memory: list[TavilyBrowserSearchMemoryItem] = []
+        self._request_tool_stats: dict[str, defaultdict[str, int]] = defaultdict(lambda: defaultdict(int))
+        self._global_tool_stats: defaultdict[str, int] = defaultdict(int)
+
+    def configure(self, overrides: dict[str, Any] | None = None, context: dict[str, Any] | None = None) -> None:
+        super().configure(overrides, context)
+        self._reset_browser_state()
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "web_search",
+                "description": "Search the web using Tavily and return numbered results.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string", "description": "Search query."}},
+                    "required": ["query"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "open_result",
+                "description": "Open a numbered result from the most recent web_search call.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"index": {"type": "integer", "description": "One-based result index to open."}},
+                    "required": ["index"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "find_in_page",
+                "description": "Find query-relevant content inside a specific URL using Tavily Extract.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "URL to inspect."},
+                        "query": {"type": "string", "description": "Term or question to locate within the page."},
+                    },
+                    "required": ["url", "query"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "scroll_page",
+                "description": "Read a bounded word window from a URL, starting at a specific word index.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string", "description": "URL to read."},
+                        "start_index": {
+                            "type": "integer",
+                            "description": "Zero-based word index to start reading from.",
+                        },
+                        "n": {"type": "integer", "description": "Number of words to return."},
+                    },
+                    "required": ["url"],
+                    "additionalProperties": False,
+                },
+            },
+        ]
+
+    async def execute(
+        self, tool_name: str, arguments: dict[str, Any], extra_args: dict[str, Any] | None = None
+    ) -> str | dict[str, Any]:
+        arguments = self._sanitize_arguments(tool_name, arguments)
+        request_id = (extra_args or {}).get("request_id")
+        if tool_name == "web_search":
+            return await self._web_search(arguments, request_id=request_id)
+        if tool_name == "open_result":
+            return await self._open_result(arguments, request_id=request_id)
+        if tool_name == "find_in_page":
+            return await self._find_in_page(arguments, request_id=request_id)
+        if tool_name == "scroll_page":
+            return await self._scroll_page(arguments, request_id=request_id)
+        self._increment_stat(request_id, "tool_errors")
+        return f"Error: unknown tool '{tool_name}'"
+
+    def _stats_for_request(self, request_id: str | None) -> defaultdict[str, int]:
+        if request_id is None:
+            return self._global_tool_stats
+        return self._request_tool_stats[request_id]
+
+    def _increment_stat(self, request_id: str | None, key: str, amount: int = 1) -> None:
+        self._stats_for_request(request_id)[key] += amount
+
+    def _page_cache_for_request(self, request_id: str | None) -> OrderedDict[str, TavilyBrowserCachedPage]:
+        if request_id is None:
+            return self._global_page_cache
+        return self._request_page_cache[request_id]
+
+    def _search_memory_for_request(self, request_id: str | None) -> list[TavilyBrowserSearchMemoryItem]:
+        if request_id is None:
+            return self._global_search_memory
+        return self._request_search_memory.get(request_id, [])
+
+    def _store_search_memory(
+        self, request_id: str | None, results: dict[str, Any]
+    ) -> list[TavilyBrowserSearchMemoryItem]:
+        max_results = max(1, int(self._config["max_search_memory_results"]))
+        max_result_chars = max(1, int(self._config["max_result_chars"]))
+        entries: list[TavilyBrowserSearchMemoryItem] = []
+        for result in results.get("results") or []:
+            url = result.get("url")
+            if not isinstance(url, str) or not url or _is_url_excluded(url, self._exclude_domains):
+                continue
+            snippet = _clean_text(str(result.get("content") or ""))
+            snippet, _ = _truncate_text(snippet, max_result_chars)
+            entries.append(
+                TavilyBrowserSearchMemoryItem(
+                    index=len(entries) + 1,
+                    title=str(result.get("title") or ""),
+                    url=url,
+                    domain=_extract_domain(url),
+                    snippet=snippet,
+                )
+            )
+            if len(entries) >= max_results:
+                break
+
+        if request_id is None:
+            self._global_search_memory = entries
+        else:
+            self._request_search_memory[request_id] = entries
+        self._increment_stat(request_id, "search_results_seen", len(entries))
+        return entries
+
+    def _format_browser_search_results(
+        self, results: dict[str, Any], entries: list[TavilyBrowserSearchMemoryItem]
+    ) -> str:
+        formatted_results = []
+        answer = results.get("answer")
+        if answer is not None:
+            formatted_results.append(f"Search Answer\n==============\n{answer}\n\n")
+        if entries:
+            formatted_results.append("Search Results\n==============\n")
+            for entry in entries:
+                formatted_results.append(
+                    f"[{entry.index}] {entry.title} ({entry.domain})\n URL: {entry.url}\n Summary: {entry.snippet}\n\n"
+                )
+        if not formatted_results:
+            return "No search results found."
+        return "".join(formatted_results).rstrip()
+
+    async def _web_search(self, arguments: dict[str, Any], *, request_id: str | None) -> str:
+        self._increment_stat(request_id, "web_search_calls")
+        query = arguments.get("query")
+        if query is None:
+            self._increment_stat(request_id, "tool_errors")
+            return "Query is none"
+        if not isinstance(query, str):
+            self._increment_stat(request_id, "tool_errors")
+            return "Query must be a string"
+        if len(query) > int(self._config["max_query_chars"]):
+            self._increment_stat(request_id, "tool_errors")
+            return "Query is too long"
+
+        payload = {
+            "query": query,
+            "max_results": int(self._config["max_results"]),
+            "exclude_domains": self._exclude_domains,
+            "search_depth": self._config["search_depth"],
+        }
+        if self._config["include_answer"] is not None:
+            payload["include_answer"] = self._config["include_answer"]
+        results = await self._tracked_post_json("/search", payload, request_id=request_id, function="search")
+        if results.get("error"):
+            self._increment_stat(request_id, "tool_errors")
+            return results["error"]
+
+        entries = self._store_search_memory(request_id, results)
+        return self._format_browser_search_results(results, entries)
+
+    async def _find_in_page(self, arguments: dict[str, Any], *, request_id: str | None) -> str:
+        self._increment_stat(request_id, "find_in_page_calls")
+        result = await super()._find_in_page(arguments, request_id=request_id)
+        if isinstance(result, str) and (
+            result.startswith("URL ")
+            or result.startswith("Query ")
+            or result.startswith("Search ")
+            or result == "No content found."
+        ):
+            self._increment_stat(request_id, "tool_errors")
+        return result
+
+    async def _extract_page(
+        self, url: str, *, request_id: str | None
+    ) -> tuple[TavilyBrowserCachedPage | None, str | None]:
+        if _is_url_excluded(url, self._exclude_domains):
+            self._increment_stat(request_id, "tool_errors")
+            self._increment_stat(request_id, "excluded_url_attempts")
+            return None, "URL is in excluded domains"
+
+        cache = self._page_cache_for_request(request_id)
+        if url in cache:
+            cache.move_to_end(url)
+            self._increment_stat(request_id, "cache_hits")
+            return cache[url], None
+
+        self._increment_stat(request_id, "cache_misses")
+        payload = {
+            "urls": url,
+            "extract_depth": self._config["extract_depth"],
+            "format": self._config["extract_format"],
+        }
+        results = await self._tracked_post_json("/extract", payload, request_id=request_id, function="extract")
+        if results.get("error"):
+            self._increment_stat(request_id, "tool_errors")
+            return None, results["error"]
+
+        raw_content = _first_raw_content(results)
+        if not raw_content:
+            return None, "No content found."
+
+        max_cached_page_chars = max(1, int(self._config["max_cached_page_chars"]))
+        raw_content, was_truncated = _truncate_text(raw_content, max_cached_page_chars)
+        cleaned = _clean_text(raw_content)
+        page = TavilyBrowserCachedPage(content=cleaned, words=cleaned.split(), truncated=was_truncated)
+        _remember_lru(cache, url, page, max(1, int(self._config["max_cached_pages"])))
+        return page, None
+
+    async def _open_result(self, arguments: dict[str, Any], *, request_id: str | None) -> str:
+        self._increment_stat(request_id, "open_result_calls")
+        index, error = _coerce_int_arg(arguments.get("index"), None, "index")
+        if error or index is None:
+            self._increment_stat(request_id, "tool_errors")
+            return "Invalid index: index must be an integer"
+        if index < 1:
+            self._increment_stat(request_id, "tool_errors")
+            return "Invalid index: index must be at least 1"
+
+        memory = self._search_memory_for_request(request_id)
+        if not memory:
+            self._increment_stat(request_id, "tool_errors")
+            return "No search results in memory. Run web_search before open_result."
+        if index > len(memory):
+            self._increment_stat(request_id, "tool_errors")
+            return f"No search result at index {index}. Last web_search has {len(memory)} result(s)."
+
+        entry = memory[index - 1]
+        page, error = await self._extract_page(entry.url, request_id=request_id)
+        if error:
+            return error
+        assert page is not None
+
+        max_open_result_chars = max(1, int(self._config["max_open_result_chars"]))
+        content, output_truncated = _truncate_text(page.content, max_open_result_chars)
+        numbered = _add_line_numbers(content)
+        footer_parts = []
+        if output_truncated:
+            footer_parts.append("[...truncated, use scroll_page for more content]")
+        if page.truncated:
+            footer_parts.append("[cached page truncated by max_cached_page_chars]")
+        footer = "\n" + "\n".join(footer_parts) if footer_parts else ""
+        header = (
+            f"Opened search result [{entry.index}]: {entry.title}\n"
+            f"Content from: {entry.domain}\n"
+            f"URL: {entry.url}\n"
+            f"========================================\n"
+        )
+        return header + numbered + footer
+
+    async def _scroll_page(self, arguments: dict[str, Any], *, request_id: str | None) -> str:
+        self._increment_stat(request_id, "scroll_page_calls")
+        url = arguments.get("url")
+        if url is None:
+            self._increment_stat(request_id, "tool_errors")
+            return "URL is none"
+        if not isinstance(url, str):
+            self._increment_stat(request_id, "tool_errors")
+            return "URL must be a string"
+
+        start_index, error = _coerce_int_arg(arguments.get("start_index"), 0, "start_index")
+        if error or start_index is None:
+            self._increment_stat(request_id, "tool_errors")
+            return "Invalid start_index: start_index must be an integer"
+        n, error = _coerce_int_arg(arguments.get("n"), int(self._config["scroll_words"]), "n")
+        if error or n is None:
+            self._increment_stat(request_id, "tool_errors")
+            return "Invalid n: n must be an integer"
+
+        requested_n = n
+        start_index = max(0, start_index)
+        max_scroll_words = max(1, int(self._config["max_scroll_words"]))
+        n = min(max(1, n), max_scroll_words)
+
+        page, error = await self._extract_page(url, request_id=request_id)
+        if error:
+            return error
+        assert page is not None
+
+        total_words = len(page.words)
+        end_index = min(start_index + n, total_words)
+        domain = _extract_domain(url)
+        header_parts = [
+            f"Page content from: {domain}",
+            f"URL: {url}",
+            f"Showing words [{start_index}-{end_index}] of {total_words}",
+        ]
+        if requested_n > n:
+            header_parts.append(f"Requested window capped at {n} words")
+        header = "\n".join(header_parts) + "\n========================================\n"
+
+        if total_words == 0:
+            return header + "No content found."
+        if start_index >= total_words:
+            return header + "Start index is beyond page length."
+
+        chunk_text = " ".join(page.words[start_index:end_index])
+        chunk_text, output_truncated = _truncate_text(chunk_text, max(1, int(self._config["max_scroll_chars"])))
+        numbered = _add_line_numbers(chunk_text)
+        footer_parts = []
+        if output_truncated:
+            footer_parts.append("[scroll output truncated; request a smaller window]")
+        if page.truncated:
+            footer_parts.append("[cached page truncated by max_cached_page_chars]")
+        footer = "\n" + "\n".join(footer_parts) if footer_parts else ""
+        return header + numbered + footer
+
+    async def get_request_metrics(self, request_id: str) -> dict[str, Any]:
+        stats = dict(self._request_tool_stats.get(request_id, {}))
+        calls = self.requests_to_metrics.get(request_id)
+        http_calls = calls.async_tavily_calls if calls is not None else []
+        if not stats and not http_calls and request_id not in self._request_search_memory:
+            return {}
+
+        http_calls_by_function: dict[str, int] = {}
+        for call in http_calls:
+            http_calls_by_function[call.function] = http_calls_by_function.get(call.function, 0) + 1
+
+        memory = self._request_search_memory.get(request_id, [])
+        cache = self._request_page_cache.get(request_id, {})
+        metrics = {
+            "web_search_calls": stats.get("web_search_calls", 0),
+            "open_result_calls": stats.get("open_result_calls", 0),
+            "find_in_page_calls": stats.get("find_in_page_calls", 0),
+            "scroll_page_calls": stats.get("scroll_page_calls", 0),
+            "tool_errors": stats.get("tool_errors", 0),
+            "cache_hits": stats.get("cache_hits", 0),
+            "cache_misses": stats.get("cache_misses", 0),
+            "cached_pages": len(cache),
+            "search_results_seen": stats.get("search_results_seen", 0),
+            "search_results_in_memory": len(memory),
+            "unique_domains_in_memory": len({entry.domain for entry in memory}),
+            "excluded_url_attempts": stats.get("excluded_url_attempts", 0),
+            "tavily_http_calls": len(http_calls),
+            "tavily_http_errors": sum(1 for call in http_calls if call.status == "error"),
+            "tavily_http_time_s": round(sum(call.time_taken for call in http_calls), 6),
+            "tavily_http_calls_by_function": http_calls_by_function,
+        }
+        return metrics
+
+    async def cleanup_request(self, request_id: str) -> None:
+        await super().cleanup_request(request_id)
+        self._request_page_cache.pop(request_id, None)
+        self._request_search_memory.pop(request_id, None)
+        self._request_tool_stats.pop(request_id, None)
+
+
+class DirectTavilyV3Tool(DirectTavilyBrowserTool):
+    """Deprecated compatibility name for DirectTavilyBrowserTool."""
 
 
 def main():

--- a/nemo_skills/mcp/tool_manager.py
+++ b/nemo_skills/mcp/tool_manager.py
@@ -25,10 +25,13 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterable, List
 
 from nemo_skills.mcp.utils import locate
+
+LOG = logging.getLogger(__name__)
 
 
 class FatalToolError(Exception):
@@ -69,6 +72,9 @@ class Tool(ABC):
 
     async def cleanup_request(self, request_id: str) -> None:  # Optional hook
         return None
+
+    async def get_request_metrics(self, request_id: str) -> Dict[str, Any]:  # Optional hook
+        return {}
 
     async def shutdown(self) -> None:  # Optional hook
         return None
@@ -128,6 +134,18 @@ class ToolManager:
     async def cleanup_request(self, request_id: str) -> None:
         for tool in self._tools.values():
             await tool.cleanup_request(request_id)
+
+    async def get_request_metrics(self, request_id: str) -> Dict[str, Any]:
+        metrics: Dict[str, Any] = {}
+        for provider_id, tool in self._tools.items():
+            try:
+                provider_metrics = await tool.get_request_metrics(request_id)
+            except Exception:
+                LOG.exception("Failed to collect request metrics from tool %s", provider_id)
+                continue
+            if provider_metrics:
+                metrics[provider_id] = provider_metrics
+        return metrics
 
     async def list_all_tools(self, use_cache: bool = True) -> List[Dict[str, Any]]:
         async with self._list_lock:

--- a/tests/test_streaming_tool_calling.py
+++ b/tests/test_streaming_tool_calling.py
@@ -120,6 +120,32 @@ def test_generate_async_duplicates_reasoning_key_in_conversation():
     assert assistant_message["reasoning"] == "internal trace"
 
 
+def test_generate_async_includes_tool_metrics_when_available():
+    """Tool providers can expose structured per-request metrics before cleanup."""
+    wrapper = _make_wrapper()
+    wrapper.tool_manager.get_request_metrics = AsyncMock(
+        return_value={"DirectTavilyBrowserTool": {"web_search_calls": 1, "tavily_http_calls": 1}}
+    )
+    wrapper.model.generate_async = AsyncMock(
+        return_value={
+            "generation": "Hello world",
+            "num_generated_tokens": 2,
+            "finish_reason": "stop",
+            "serialized_output": [{"role": "assistant", "content": "Hello world"}],
+        }
+    )
+
+    with _PATCH_TOOLS:
+        result = asyncio.run(
+            wrapper.generate_async(
+                prompt=[{"role": "user", "content": "hi"}],
+                endpoint_type=EndpointType.chat,
+            )
+        )
+
+    assert result["tool_metrics"] == {"DirectTavilyBrowserTool": {"web_search_calls": 1, "tavily_http_calls": 1}}
+
+
 def test_stream_final_conversation_duplicates_reasoning_key():
     """Streaming conversation entries mirror reasoning_content to reasoning."""
     wrapper = _make_wrapper()

--- a/tests/test_tavily_search_tool.py
+++ b/tests/test_tavily_search_tool.py
@@ -102,7 +102,7 @@ def test_direct_tavily_gym_tool_web_search_formats_results_and_hides_internal_ar
         assert all(t["input_schema"]["additionalProperties"] is False for t in tools)
 
         invalid = await tool.execute("web_search", {"query": "NVIDIA GPU programming", "typo": True})
-        assert invalid == "Unsupported argument: typo"
+        assert invalid == {"error": "Unsupported argument: typo"}
 
         result = await tool.execute(
             "web_search",
@@ -144,17 +144,14 @@ def test_direct_tavily_gym_tool_find_in_page_and_scroll_page():
             }
         )
 
-        assert await tool.execute("find_in_page", {"url": None, "query": "x"}) == "URL is none"
+        assert await tool.execute("find_in_page", {"url": None, "query": "x"}) == {"error": "URL is none"}
         assert await tool.execute("find_in_page", {"url": "https://sub.blocked.example/a", "query": "x"}) == (
-            "URL is in excluded domains"
+            {"error": "URL is in excluded domains"}
         )
-        assert (
-            await tool.execute(
-                "scroll_page",
-                {"url": "https://example.com/page", "start_index": 0, "n": "many"},
-            )
-            == "Invalid n: n must be an integer"
-        )
+        assert await tool.execute(
+            "scroll_page",
+            {"url": "https://example.com/page", "start_index": 0, "n": "many"},
+        ) == {"error": "Invalid n: n must be an integer"}
 
         calls = []
 
@@ -356,7 +353,7 @@ def test_direct_tavily_browser_scroll_page_is_bounded_and_request_cached():
             {"url": "https://example.com/page", "start_index": 0, "n": "many"},
             extra_args={"request_id": "req-scroll"},
         )
-        assert invalid == "Invalid n: n must be an integer"
+        assert invalid == {"error": "Invalid n: n must be an integer"}
 
         first = await tool.execute(
             "scroll_page",

--- a/tests/test_tavily_search_tool.py
+++ b/tests/test_tavily_search_tool.py
@@ -42,6 +42,10 @@ def test_direct_tavily_search_tool_uses_configured_hidden_args():
         tools = await tool.list_tools()
         assert tools[0]["name"] == "web_search"
         assert set(tools[0]["input_schema"]["properties"]) == {"query"}
+        assert tools[0]["input_schema"]["additionalProperties"] is False
+
+        invalid = await tool.execute("web_search", {"query": "capital of France", "typo": True})
+        assert invalid == {"error": "Unsupported argument: typo"}
 
         result = await tool.execute(
             "web_search",
@@ -95,6 +99,10 @@ def test_direct_tavily_gym_tool_web_search_formats_results_and_hides_internal_ar
 
         tools = await tool.list_tools()
         assert {t["name"] for t in tools} == {"web_search", "find_in_page", "scroll_page"}
+        assert all(t["input_schema"]["additionalProperties"] is False for t in tools)
+
+        invalid = await tool.execute("web_search", {"query": "NVIDIA GPU programming", "typo": True})
+        assert invalid == "Unsupported argument: typo"
 
         result = await tool.execute(
             "web_search",
@@ -140,6 +148,13 @@ def test_direct_tavily_gym_tool_find_in_page_and_scroll_page():
         assert await tool.execute("find_in_page", {"url": "https://sub.blocked.example/a", "query": "x"}) == (
             "URL is in excluded domains"
         )
+        assert (
+            await tool.execute(
+                "scroll_page",
+                {"url": "https://example.com/page", "start_index": 0, "n": "many"},
+            )
+            == "Invalid n: n must be an integer"
+        )
 
         calls = []
 
@@ -182,6 +197,35 @@ def test_direct_tavily_gym_tool_find_in_page_and_scroll_page():
 
         extract_calls = [call for call in calls if call[0] == "/extract"]
         assert len(extract_calls) == 2
+
+    asyncio.run(run_test())
+
+
+def test_direct_tavily_gym_tool_scroll_cache_is_bounded():
+    async def run_test():
+        from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyGymTool
+
+        tool = DirectTavilyGymTool()
+        tool.configure({"tavily_api_key": "test-key", "max_cached_pages": 1})
+
+        calls = []
+
+        async def fake_post_json(endpoint, payload):
+            calls.append((endpoint, payload["urls"]))
+            return {"results": [{"url": payload["urls"], "raw_content": f"{payload['urls']} content"}]}
+
+        tool._post_json = fake_post_json
+
+        await tool.execute("scroll_page", {"url": "https://example.com/a"})
+        await tool.execute("scroll_page", {"url": "https://example.com/b"})
+        await tool.execute("scroll_page", {"url": "https://example.com/a"})
+
+        assert calls == [
+            ("/extract", "https://example.com/a"),
+            ("/extract", "https://example.com/b"),
+            ("/extract", "https://example.com/a"),
+        ]
+        assert list(tool._page_cache) == ["https://example.com/a"]
 
     asyncio.run(run_test())
 

--- a/tests/test_tavily_search_tool.py
+++ b/tests/test_tavily_search_tool.py
@@ -227,6 +227,34 @@ def test_direct_tavily_gym_tool_scroll_cache_is_bounded():
     asyncio.run(run_test())
 
 
+def test_direct_tavily_gym_tool_scroll_cache_ignores_tracking_params():
+    async def run_test():
+        from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyGymTool
+
+        tool = DirectTavilyGymTool()
+        tool.configure({"tavily_api_key": "test-key"})
+
+        calls = []
+
+        async def fake_post_json(endpoint, payload):
+            calls.append((endpoint, payload["urls"]))
+            return {"results": [{"url": payload["urls"], "raw_content": "same page content"}]}
+
+        tool._post_json = fake_post_json
+
+        await tool.execute("scroll_page", {"url": "https://example.com/page?id=1&utm_source=a#section"})
+        await tool.execute("scroll_page", {"url": "https://example.com/page?utm_campaign=b&id=1"})
+        await tool.execute("scroll_page", {"url": "https://example.com/page?id=2&utm_source=a"})
+
+        assert calls == [
+            ("/extract", "https://example.com/page?id=1&utm_source=a#section"),
+            ("/extract", "https://example.com/page?id=2&utm_source=a"),
+        ]
+        assert list(tool._page_cache) == ["https://example.com/page?id=1", "https://example.com/page?id=2"]
+
+    asyncio.run(run_test())
+
+
 def test_direct_tavily_tool_loads_exclude_domains_config(tmp_path):
     from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilySearchTool
 
@@ -387,6 +415,44 @@ def test_direct_tavily_browser_scroll_page_is_bounded_and_request_cached():
         assert metrics["tool_errors"] == 1
         assert metrics["cache_misses"] == 1
         assert metrics["cache_hits"] == 2
+
+    asyncio.run(run_test())
+
+
+def test_direct_tavily_browser_scroll_cache_ignores_tracking_params():
+    async def run_test():
+        from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyBrowserTool
+
+        tool = DirectTavilyBrowserTool()
+        tool.configure({"tavily_api_key": "test-key"})
+
+        calls = []
+
+        async def fake_post_json(endpoint, payload):
+            calls.append((endpoint, payload["urls"]))
+            return {"results": [{"url": payload["urls"], "raw_content": "zero one two"}]}
+
+        tool._post_json = fake_post_json
+
+        first = await tool.execute(
+            "scroll_page",
+            {"url": "https://example.com/page?id=1&utm_source=newsletter#intro"},
+            extra_args={"request_id": "req-tracking"},
+        )
+        second = await tool.execute(
+            "scroll_page",
+            {"url": "https://example.com/page?utm_medium=email&id=1"},
+            extra_args={"request_id": "req-tracking"},
+        )
+
+        assert "L0: zero one two" in first
+        assert "L0: zero one two" in second
+        assert calls == [("/extract", "https://example.com/page?id=1&utm_source=newsletter#intro")]
+
+        metrics = await tool.get_request_metrics("req-tracking")
+        assert metrics["cache_misses"] == 1
+        assert metrics["cache_hits"] == 1
+        assert metrics["cached_pages"] == 1
 
     asyncio.run(run_test())
 

--- a/tests/test_tavily_search_tool.py
+++ b/tests/test_tavily_search_tool.py
@@ -1,0 +1,357 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+
+def test_direct_tavily_search_tool_uses_configured_hidden_args():
+    async def run_test():
+        from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilySearchTool
+
+        tool = DirectTavilySearchTool()
+        tool.configure(
+            {
+                "tavily_api_key": "test-key",
+                "exclude_domains": ["blocked.example"],
+                "num_results": 3,
+            }
+        )
+
+        calls = []
+
+        async def fake_post_json(endpoint, payload):
+            calls.append((endpoint, payload))
+            return {"answer": "Paris", "results": []}
+
+        tool._post_json = fake_post_json
+
+        tools = await tool.list_tools()
+        assert tools[0]["name"] == "web_search"
+        assert set(tools[0]["input_schema"]["properties"]) == {"query"}
+
+        result = await tool.execute(
+            "web_search",
+            {"query": "capital of France", "num_results": 99, "answer_type": "results"},
+            extra_args={"request_id": "req-search"},
+        )
+
+        assert result == "Paris"
+        assert calls == [
+            (
+                "/search",
+                {
+                    "query": "capital of France",
+                    "search_depth": "basic",
+                    "include_answer": "basic",
+                    "max_results": 3,
+                    "exclude_domains": ["blocked.example"],
+                },
+            )
+        ]
+        assert len(tool.requests_to_metrics["req-search"].async_tavily_calls) == 1
+        assert tool.requests_to_metrics["req-search"].async_tavily_calls[0].function == "search"
+
+    asyncio.run(run_test())
+
+
+def test_direct_tavily_gym_tool_web_search_formats_results_and_hides_internal_args():
+    async def run_test():
+        from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyGymTool
+
+        tool = DirectTavilyGymTool()
+        tool.configure({"tavily_api_key": "test-key", "exclude_domains": ["blocked.example"]})
+
+        calls = []
+
+        async def fake_post_json(endpoint, payload):
+            calls.append((endpoint, payload))
+            return {
+                "results": [
+                    {
+                        "url": "https://example.com/page1",
+                        "title": "Example Page 1",
+                        "content": "This is the content of page 1",
+                        "score": 0.95,
+                        "raw_content": "raw content",
+                    }
+                ]
+            }
+
+        tool._post_json = fake_post_json
+
+        tools = await tool.list_tools()
+        assert {t["name"] for t in tools} == {"web_search", "find_in_page", "scroll_page"}
+
+        result = await tool.execute(
+            "web_search",
+            {"query": "NVIDIA GPU programming", "max_results": 1, "exclude_domains": ["model.example"]},
+            extra_args={"request_id": "req-gym-search"},
+        )
+
+        assert "Search Results" in result
+        assert "[1] Example Page 1 (example.com)" in result
+        assert "URL: https://example.com/page1" in result
+        assert "This is the content of page 1" in result
+        assert "0.95" not in result
+        assert "raw content" not in result
+        assert calls == [
+            (
+                "/search",
+                {
+                    "query": "NVIDIA GPU programming",
+                    "max_results": 10,
+                    "exclude_domains": ["blocked.example"],
+                    "search_depth": "advanced",
+                },
+            )
+        ]
+
+    asyncio.run(run_test())
+
+
+def test_direct_tavily_gym_tool_find_in_page_and_scroll_page():
+    async def run_test():
+        from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyGymTool
+
+        tool = DirectTavilyGymTool()
+        tool.configure(
+            {
+                "tavily_api_key": "test-key",
+                "exclude_domains": ["blocked.example"],
+                "max_result_chars": 35,
+            }
+        )
+
+        assert await tool.execute("find_in_page", {"url": None, "query": "x"}) == "URL is none"
+        assert await tool.execute("find_in_page", {"url": "https://sub.blocked.example/a", "query": "x"}) == (
+            "URL is in excluded domains"
+        )
+
+        calls = []
+
+        async def fake_post_json(endpoint, payload):
+            calls.append((endpoint, payload))
+            if payload.get("query"):
+                return {
+                    "results": [
+                        {
+                            "url": payload["urls"],
+                            "raw_content": "Hello [edit] world\n[Jump to content]\nContent here\nMore content after limit",
+                        }
+                    ]
+                }
+            return {"results": [{"url": payload["urls"], "raw_content": "zero one two three four five"}]}
+
+        tool._post_json = fake_post_json
+
+        find_result = await tool.execute(
+            "find_in_page",
+            {"url": "https://example.com/page", "query": "content"},
+            extra_args={"request_id": "req-find"},
+        )
+        assert "Content from: example.com" in find_result
+        assert 'Query: "content"' in find_result
+        assert "[edit]" not in find_result
+        assert "[Jump to content]" not in find_result
+        assert "[...truncated, use scroll_page for full content]" in find_result
+
+        scroll_result = await tool.execute(
+            "scroll_page", {"url": "https://example.com/page", "start_index": 2, "n": 3}
+        )
+        assert "Showing words [2-5] of 6" in scroll_result
+        assert "L0: two three four" in scroll_result
+
+        cached_scroll_result = await tool.execute(
+            "scroll_page", {"url": "https://example.com/page", "start_index": 0, "n": 1}
+        )
+        assert "Showing words [0-1] of 6" in cached_scroll_result
+
+        extract_calls = [call for call in calls if call[0] == "/extract"]
+        assert len(extract_calls) == 2
+
+    asyncio.run(run_test())
+
+
+def test_direct_tavily_tool_loads_exclude_domains_config(tmp_path):
+    from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilySearchTool
+
+    exclude_file = tmp_path / "exclude.json"
+    exclude_file.write_text(
+        json.dumps({"notices": [{"properties": [{"type": "domain", "value": "blocked.example"}]}]}),
+        encoding="utf-8",
+    )
+
+    tool = DirectTavilySearchTool()
+    tool.configure({"tavily_api_key": "test-key", "exclude_domains_config": str(exclude_file)})
+
+    assert tool._exclude_domains == ["blocked.example"]
+
+
+def test_direct_tavily_tool_rotates_api_keys():
+    from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyGymTool
+
+    tool = DirectTavilyGymTool()
+    tool.configure({"tavily_api_key": ["key-a", "key-b"]})
+
+    assert [tool._select_api_key(), tool._select_api_key(), tool._select_api_key()] == ["key-a", "key-b", "key-a"]
+
+
+def test_direct_tavily_browser_search_memory_open_result_and_metrics():
+    async def run_test():
+        from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyBrowserTool
+
+        tool = DirectTavilyBrowserTool()
+        tool.configure(
+            {
+                "tavily_api_key": "test-key",
+                "exclude_domains": ["blocked.example"],
+                "max_open_result_chars": 80,
+            }
+        )
+
+        calls = []
+
+        async def fake_post_json(endpoint, payload):
+            calls.append((endpoint, payload))
+            if endpoint == "/search":
+                return {
+                    "results": [
+                        {
+                            "url": "https://example.com/page1",
+                            "title": "Example Page 1",
+                            "content": "Snippet one",
+                        },
+                        {
+                            "url": "https://example.org/page2",
+                            "title": "Example Page 2",
+                            "content": "Snippet two",
+                        },
+                    ]
+                }
+            return {
+                "results": [
+                    {
+                        "url": payload["urls"],
+                        "raw_content": "Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu.",
+                    }
+                ]
+            }
+
+        tool._post_json = fake_post_json
+
+        search_result = await tool.execute(
+            "web_search", {"query": "example query"}, extra_args={"request_id": "req-browser"}
+        )
+        assert "[1] Example Page 1 (example.com)" in search_result
+        assert "[2] Example Page 2 (example.org)" in search_result
+
+        opened = await tool.execute("open_result", {"index": 2}, extra_args={"request_id": "req-browser"})
+        assert "Opened search result [2]: Example Page 2" in opened
+        assert "URL: https://example.org/page2" in opened
+        assert "L0: Alpha beta gamma" in opened
+
+        metrics = await tool.get_request_metrics("req-browser")
+        assert metrics["web_search_calls"] == 1
+        assert metrics["open_result_calls"] == 1
+        assert metrics["search_results_in_memory"] == 2
+        assert metrics["cached_pages"] == 1
+        assert metrics["cache_misses"] == 1
+        assert metrics["tavily_http_calls"] == 2
+        assert metrics["tavily_http_calls_by_function"] == {"search": 1, "extract": 1}
+
+        await tool.cleanup_request("req-browser")
+        assert await tool.get_request_metrics("req-browser") == {}
+
+    asyncio.run(run_test())
+
+
+def test_direct_tavily_browser_scroll_page_is_bounded_and_request_cached():
+    async def run_test():
+        from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyBrowserTool
+
+        tool = DirectTavilyBrowserTool()
+        tool.configure(
+            {
+                "tavily_api_key": "test-key",
+                "max_scroll_words": 3,
+                "max_scroll_chars": 100,
+            }
+        )
+
+        calls = []
+
+        async def fake_post_json(endpoint, payload):
+            calls.append((endpoint, payload))
+            return {
+                "results": [
+                    {
+                        "url": payload["urls"],
+                        "raw_content": "zero one two three four five six seven eight nine",
+                    }
+                ]
+            }
+
+        tool._post_json = fake_post_json
+
+        invalid = await tool.execute(
+            "scroll_page",
+            {"url": "https://example.com/page", "start_index": 0, "n": "many"},
+            extra_args={"request_id": "req-scroll"},
+        )
+        assert invalid == "Invalid n: n must be an integer"
+
+        first = await tool.execute(
+            "scroll_page",
+            {"url": "https://example.com/page", "start_index": -5, "n": 10},
+            extra_args={"request_id": "req-scroll"},
+        )
+        assert "Showing words [0-3] of 10" in first
+        assert "Requested window capped at 3 words" in first
+        assert "L0: zero one two" in first
+
+        second = await tool.execute(
+            "scroll_page",
+            {"url": "https://example.com/page", "start_index": 2, "n": 2},
+            extra_args={"request_id": "req-scroll"},
+        )
+        assert "Showing words [2-4] of 10" in second
+        assert "L0: two three" in second
+
+        beyond = await tool.execute(
+            "scroll_page",
+            {"url": "https://example.com/page", "start_index": 99, "n": 2},
+            extra_args={"request_id": "req-scroll"},
+        )
+        assert "Start index is beyond page length." in beyond
+
+        extract_calls = [call for call in calls if call[0] == "/extract"]
+        assert len(extract_calls) == 1
+
+        metrics = await tool.get_request_metrics("req-scroll")
+        assert metrics["scroll_page_calls"] == 4
+        assert metrics["tool_errors"] == 1
+        assert metrics["cache_misses"] == 1
+        assert metrics["cache_hits"] == 2
+
+    asyncio.run(run_test())
+
+
+def test_direct_tavily_v3_name_remains_compatible():
+    from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyBrowserTool, DirectTavilyV3Tool
+
+    assert issubclass(DirectTavilyV3Tool, DirectTavilyBrowserTool)
+    assert DirectTavilyV3Tool().__class__.__name__ == "DirectTavilyV3Tool"

--- a/tests/test_tavily_search_tool.py
+++ b/tests/test_tavily_search_tool.py
@@ -17,8 +17,20 @@ from __future__ import annotations
 import asyncio
 import json
 
+import pytest
 
-def test_direct_tavily_search_tool_uses_configured_hidden_args():
+
+@pytest.fixture
+def exclude_domains_config(tmp_path):
+    exclude_file = tmp_path / "exclude.json"
+    exclude_file.write_text(
+        json.dumps({"notices": [{"properties": [{"type": "domain", "value": "blocked.example"}]}]}),
+        encoding="utf-8",
+    )
+    return str(exclude_file)
+
+
+def test_direct_tavily_search_tool_uses_configured_hidden_args(exclude_domains_config):
     async def run_test():
         from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilySearchTool
 
@@ -26,7 +38,7 @@ def test_direct_tavily_search_tool_uses_configured_hidden_args():
         tool.configure(
             {
                 "tavily_api_key": "test-key",
-                "exclude_domains": ["blocked.example"],
+                "exclude_domains_config": exclude_domains_config,
                 "num_results": 3,
             }
         )
@@ -72,12 +84,12 @@ def test_direct_tavily_search_tool_uses_configured_hidden_args():
     asyncio.run(run_test())
 
 
-def test_direct_tavily_gym_tool_web_search_formats_results_and_hides_internal_args():
+def test_direct_tavily_gym_tool_web_search_formats_results_and_hides_internal_args(exclude_domains_config):
     async def run_test():
         from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyGymTool
 
         tool = DirectTavilyGymTool()
-        tool.configure({"tavily_api_key": "test-key", "exclude_domains": ["blocked.example"]})
+        tool.configure({"tavily_api_key": "test-key", "exclude_domains_config": exclude_domains_config})
 
         calls = []
 
@@ -131,7 +143,7 @@ def test_direct_tavily_gym_tool_web_search_formats_results_and_hides_internal_ar
     asyncio.run(run_test())
 
 
-def test_direct_tavily_gym_tool_find_in_page_and_scroll_page():
+def test_direct_tavily_gym_tool_find_in_page_and_scroll_page(exclude_domains_config):
     async def run_test():
         from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyGymTool
 
@@ -139,7 +151,7 @@ def test_direct_tavily_gym_tool_find_in_page_and_scroll_page():
         tool.configure(
             {
                 "tavily_api_key": "test-key",
-                "exclude_domains": ["blocked.example"],
+                "exclude_domains_config": exclude_domains_config,
                 "max_result_chars": 35,
             }
         )
@@ -198,12 +210,14 @@ def test_direct_tavily_gym_tool_find_in_page_and_scroll_page():
     asyncio.run(run_test())
 
 
-def test_direct_tavily_gym_tool_scroll_cache_is_bounded():
+def test_direct_tavily_gym_tool_scroll_cache_is_bounded(exclude_domains_config):
     async def run_test():
         from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyGymTool
 
         tool = DirectTavilyGymTool()
-        tool.configure({"tavily_api_key": "test-key", "max_cached_pages": 1})
+        tool.configure(
+            {"tavily_api_key": "test-key", "exclude_domains_config": exclude_domains_config, "max_cached_pages": 1}
+        )
 
         calls = []
 
@@ -227,12 +241,12 @@ def test_direct_tavily_gym_tool_scroll_cache_is_bounded():
     asyncio.run(run_test())
 
 
-def test_direct_tavily_gym_tool_scroll_cache_ignores_tracking_params():
+def test_direct_tavily_gym_tool_scroll_cache_ignores_tracking_params(exclude_domains_config):
     async def run_test():
         from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyGymTool
 
         tool = DirectTavilyGymTool()
-        tool.configure({"tavily_api_key": "test-key"})
+        tool.configure({"tavily_api_key": "test-key", "exclude_domains_config": exclude_domains_config})
 
         calls = []
 
@@ -270,16 +284,30 @@ def test_direct_tavily_tool_loads_exclude_domains_config(tmp_path):
     assert tool._exclude_domains == ["blocked.example"]
 
 
-def test_direct_tavily_tool_rotates_api_keys():
+def test_direct_tavily_tool_requires_exclude_domains_config():
+    from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilySearchTool, TavilySearchTool
+
+    tool = DirectTavilySearchTool()
+    assert "exclude_domains_config" not in tool.default_config()
+    assert "exclude_domains_config" not in TavilySearchTool().default_config()
+
+    with pytest.raises(ValueError, match="exclude_domains_config is required"):
+        tool.configure({"tavily_api_key": "test-key", "exclude_domains": ["blocked.example"]})
+
+    with pytest.raises(ValueError, match="Unknown DirectTavilySearchTool override"):
+        tool.configure({"tavily_api_key": "test-key", "require_exclude_domains_config": False})
+
+
+def test_direct_tavily_tool_rotates_api_keys(exclude_domains_config):
     from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyGymTool
 
     tool = DirectTavilyGymTool()
-    tool.configure({"tavily_api_key": ["key-a", "key-b"]})
+    tool.configure({"tavily_api_key": ["key-a", "key-b"], "exclude_domains_config": exclude_domains_config})
 
     assert [tool._select_api_key(), tool._select_api_key(), tool._select_api_key()] == ["key-a", "key-b", "key-a"]
 
 
-def test_direct_tavily_browser_search_memory_open_result_and_metrics():
+def test_direct_tavily_browser_search_memory_open_result_and_metrics(exclude_domains_config):
     async def run_test():
         from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyBrowserTool
 
@@ -287,7 +315,7 @@ def test_direct_tavily_browser_search_memory_open_result_and_metrics():
         tool.configure(
             {
                 "tavily_api_key": "test-key",
-                "exclude_domains": ["blocked.example"],
+                "exclude_domains_config": exclude_domains_config,
                 "max_open_result_chars": 80,
             }
         )
@@ -348,7 +376,7 @@ def test_direct_tavily_browser_search_memory_open_result_and_metrics():
     asyncio.run(run_test())
 
 
-def test_direct_tavily_browser_scroll_page_is_bounded_and_request_cached():
+def test_direct_tavily_browser_scroll_page_is_bounded_and_request_cached(exclude_domains_config):
     async def run_test():
         from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyBrowserTool
 
@@ -356,6 +384,7 @@ def test_direct_tavily_browser_scroll_page_is_bounded_and_request_cached():
         tool.configure(
             {
                 "tavily_api_key": "test-key",
+                "exclude_domains_config": exclude_domains_config,
                 "max_scroll_words": 3,
                 "max_scroll_chars": 100,
             }
@@ -419,12 +448,12 @@ def test_direct_tavily_browser_scroll_page_is_bounded_and_request_cached():
     asyncio.run(run_test())
 
 
-def test_direct_tavily_browser_scroll_cache_ignores_tracking_params():
+def test_direct_tavily_browser_scroll_cache_ignores_tracking_params(exclude_domains_config):
     async def run_test():
         from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyBrowserTool
 
         tool = DirectTavilyBrowserTool()
-        tool.configure({"tavily_api_key": "test-key"})
+        tool.configure({"tavily_api_key": "test-key", "exclude_domains_config": exclude_domains_config})
 
         calls = []
 


### PR DESCRIPTION
latest search tool for ultra 
ultra reached 37+ with this tavily tool + python tool. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request tool execution metrics are now aggregated and attached to generated results, including streamed outputs; request-scoped cleanup and metrics retrieval are supported.
  * Tavily: added direct HTTP-based tools with browser-style features (caching, search memory, open-result), Gym endpoints (search/extract/scroll), exclude-domain config, input validation, formatted/truncated outputs, and API-key rotation.

* **Tests**
  * New tests covering metrics inclusion and extensive Tavily behaviors: formatting, caching, validation, rotation, scrolling, and metrics reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->