### PR TITLE
upgrade mArenaHard version (v2.0 -> v2.1)

### DIFF
--- a/nemo_skills/dataset/m-arena-hard-v2/prepare.py
+++ b/nemo_skills/dataset/m-arena-hard-v2/prepare.py
@@ -18,8 +18,11 @@ from pathlib import Path
 
 import datasets
 
-HF_DATASET = "CohereLabs/m-ArenaHard-v2.0"
-SUPPORTED_LANGUAGES = datasets.get_dataset_config_names(HF_DATASET)
+HF_DATASET_VERSIONS = {
+    "v2.0": "CohereLabs/m-ArenaHard-v2.0",
+    "v2.1": "CohereLabs/m-ArenaHard-v2.1",
+}
+DEFAULT_VERSION = "v2.1"
 
 
 def format_entry(row: dict, language: str) -> dict:
@@ -36,17 +39,21 @@ def format_entry(row: dict, language: str) -> dict:
 
 
 def main(args):
-    invalid_langs = set(args.languages) - set(SUPPORTED_LANGUAGES)
+    hf_dataset = HF_DATASET_VERSIONS[args.version]
+    supported_languages = datasets.get_dataset_config_names(hf_dataset)
+
+    languages = args.languages if args.languages is not None else supported_languages
+    invalid_langs = set(languages) - set(supported_languages)
     if invalid_langs:
-        raise ValueError(f"Unsupported languages: {invalid_langs}. Supported: {SUPPORTED_LANGUAGES}")
+        raise ValueError(f"Unsupported languages: {invalid_langs}. Supported: {supported_languages}")
 
     data_dir = Path(__file__).absolute().parent
     output_file = data_dir / "test.jsonl"
 
     all_entries = []
-    for language in args.languages:
+    for language in languages:
         print(f"Processing {language}...")
-        ds = datasets.load_dataset(HF_DATASET, name=language, split="test")
+        ds = datasets.load_dataset(hf_dataset, name=language, split="test")
         for row in ds:
             all_entries.append(format_entry(row, language))
 
@@ -72,12 +79,18 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Prepare m-ArenaHard-v2.0 multilingual benchmark.")
+    parser = argparse.ArgumentParser(description="Prepare m-ArenaHard multilingual benchmark.")
+    parser.add_argument(
+        "--version",
+        default=DEFAULT_VERSION,
+        choices=list(HF_DATASET_VERSIONS),
+        help=f"Dataset version to prepare. Default: {DEFAULT_VERSION}",
+    )
     parser.add_argument(
         "--languages",
-        default=SUPPORTED_LANGUAGES,
+        default=None,
         nargs="+",
-        help=f"Languages to include. Supported: {SUPPORTED_LANGUAGES}",
+        help="Languages to include. Defaults to all languages supported by the selected --version.",
     )
     parser.add_argument(
         "--baseline-file",

--- a/nemo_skills/dataset/m-arena-hard-v2/prepare.py
+++ b/nemo_skills/dataset/m-arena-hard-v2/prepare.py
@@ -45,7 +45,9 @@ def main(args):
     languages = args.languages if args.languages is not None else supported_languages
     invalid_langs = set(languages) - set(supported_languages)
     if invalid_langs:
-        raise ValueError(f"Unsupported languages: {invalid_langs}. Supported: {supported_languages}")
+        raise ValueError(
+            f"Unsupported languages: {sorted(invalid_langs)}. Supported: {sorted(supported_languages)}"
+        )
 
     data_dir = Path(__file__).absolute().parent
     output_file = data_dir / "test.jsonl"

--- a/nemo_skills/dataset/m-arena-hard-v2/prepare.py
+++ b/nemo_skills/dataset/m-arena-hard-v2/prepare.py
@@ -45,9 +45,7 @@ def main(args):
     languages = args.languages if args.languages is not None else supported_languages
     invalid_langs = set(languages) - set(supported_languages)
     if invalid_langs:
-        raise ValueError(
-            f"Unsupported languages: {sorted(invalid_langs)}. Supported: {sorted(supported_languages)}"
-        )
+        raise ValueError(f"Unsupported languages: {sorted(invalid_langs)}. Supported: {sorted(supported_languages)}")
 
     data_dir = Path(__file__).absolute().parent
     output_file = data_dir / "test.jsonl"


### PR DESCRIPTION
Adds support for the new CohereLabs/m-ArenaHard-v2.1 dataset (67 languages, 498 prompts each) in the m-arena-hard-v2 benchmark, defaulting to v2.1 while keeping v2.0 selectable.

## Usage
ns prepare_data m-arena-hard-v2 --version=v2.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for selecting multiple m-ArenaHard dataset versions via a new --version CLI option.
  * Language selection now defaults to all languages supported by the chosen version; you can also specify languages explicitly.
  * Requested languages are validated against the selected version before processing; output generation behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->