### PR TITLE
fix(pipeline): harden eval runtime plumbing

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -912,10 +912,28 @@ class GenerationTask:
         with open(self.cfg.output_file + "-async", "rt", encoding="utf-8") as fin:
             generations = [json.loads(line) for line in fin]
 
-        ordered_generations = [None] * len(generations)
+        if not generations:
+            ordered_generations = []
+        else:
+            max_position = max(gen_dict[self.cfg.async_position_key] for gen_dict in generations)
+            ordered_generations = [None] * (max_position + 1)
         for gen_dict in generations:
             async_pos = gen_dict.pop(self.cfg.async_position_key)
+            if async_pos < 0:
+                raise ValueError(f"Invalid async output position {async_pos}")
+            if ordered_generations[async_pos] is not None:
+                raise RuntimeError(f"Duplicate async output position {async_pos}")
             ordered_generations[async_pos] = gen_dict
+
+        missing_positions = [idx for idx, gen_dict in enumerate(ordered_generations) if gen_dict is None]
+        if missing_positions:
+            preview = ", ".join(map(str, missing_positions[:20]))
+            if len(missing_positions) > 20:
+                preview += ", ..."
+            raise RuntimeError(
+                f"Missing async outputs for {len(missing_positions)} positions: {preview}. "
+                "Refusing to write null rows to the merged output."
+            )
 
         with open(self.cfg.output_file, "wt", encoding="utf-8") as fout:
             for gen_dict in ordered_generations:

--- a/nemo_skills/inference/model/vllm_multimodal.py
+++ b/nemo_skills/inference/model/vllm_multimodal.py
@@ -321,6 +321,12 @@ class VLLMMultimodalModel(VLLMModel):
         content = result["content"]
         if isinstance(content, str):
             result["content"] = [{"type": "text", "text": content}]
+        elif isinstance(content, dict):
+            if set(content) == {"type", "text"} and content["type"] == "text":
+                text = content["text"]
+                result["content"] = [] if text is None else [{"type": "text", "text": str(text)}]
+            else:
+                raise TypeError(f"Unexpected content dict: {content}")
         elif not isinstance(content, list):
             raise TypeError(f"Unexpected content type: {type(content)}")
 
@@ -433,8 +439,16 @@ class VLLMMultimodalModel(VLLMModel):
                     content = msg_copy["content"]
                     if isinstance(content, str):
                         text_content = [{"type": "text", "text": content}]
-                    else:
+                    elif isinstance(content, dict):
+                        if set(content) == {"type", "text"} and content["type"] == "text":
+                            text = content["text"]
+                            text_content = [] if text is None else [{"type": "text", "text": str(text)}]
+                        else:
+                            raise TypeError(f"Unexpected content dict: {content}")
+                    elif isinstance(content, list):
                         text_content = content
+                    else:
+                        raise TypeError(f"Unexpected content type: {type(content)}")
 
                     # Add audio chunk at the beginning (before text)
                     msg_copy["content"] = [make_audio_content_block(chunk_base64, self.audio_format)] + text_content

--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -479,9 +479,20 @@ def eval(
         extra_benchmark_map=extra_benchmark_map,
     )
 
+    summarize_sbatch_kwargs_raw = summarize_sbatch_kwargs
     sbatch_kwargs = parse_kwargs(sbatch_kwargs, exclusive=exclusive, qos=qos, time_min=time_min)
     judge_sbatch_kwargs = _resolve_child_sbatch_kwargs(sbatch_kwargs, judge_sbatch_kwargs)
     summarize_sbatch_kwargs = _resolve_child_sbatch_kwargs(sbatch_kwargs, summarize_sbatch_kwargs)
+    summarize_sbatch_kwargs = dict(summarize_sbatch_kwargs or {})
+    summarize_sbatch_kwargs.setdefault("exclusive", False)
+    summarize_sbatch_kwargs.setdefault("mem", "16G")
+    if summarize_sbatch_kwargs_raw is None:
+        # Summaries only parse already-written jsonl files; do not inherit long GPU eval limits.
+        summarize_sbatch_kwargs["time"] = "0-01:00:00"
+        summarize_sbatch_kwargs["time_min"] = "00:15:00"
+    else:
+        summarize_sbatch_kwargs.setdefault("time", "0-01:00:00")
+        summarize_sbatch_kwargs.setdefault("time_min", "00:15:00")
 
     has_tasks = False
     job_id_to_tasks = {}

--- a/nemo_skills/pipeline/utils/cluster.py
+++ b/nemo_skills/pipeline/utils/cluster.py
@@ -259,6 +259,8 @@ def get_env_variables(cluster_config):
     # the job is being launched, not where its being run.
     for key, value in env_vars.items():
         if isinstance(value, str) and "$" in value:
+            if key == "NEMO_SKILLS_SANDBOX_PORT" and "SLURM_JOB_ID" in value:
+                continue
             if key in os.environ:
                 env_vars[key] = os.path.expandvars(value)
                 LOG.info(

--- a/nemo_skills/pipeline/utils/exp.py
+++ b/nemo_skills/pipeline/utils/exp.py
@@ -325,9 +325,13 @@ def get_executor(
             # by default we use exclusive if no gpus are needed and use non-exclusive if gpus are required
             # as cpu jobs almost always need more resources than automatically allocated by slurm
             sbatch_kwargs = dict(sbatch_kwargs) if sbatch_kwargs else {}
-            sbatch_kwargs["exclusive"] = True
+            sbatch_kwargs.setdefault("exclusive", True)
 
     timeout = get_slurm_timeout_str(cluster_config, partition, with_save_delay=False)
+
+    if sbatch_kwargs and sbatch_kwargs.get("exclusive") is False:
+        sbatch_kwargs = dict(sbatch_kwargs)
+        sbatch_kwargs.pop("exclusive")
 
     additional_parameters = {}
     if cluster_config.get("mail_type") is not None:

--- a/nemo_skills/pipeline/utils/scripts/eval.py
+++ b/nemo_skills/pipeline/utils/scripts/eval.py
@@ -48,7 +48,7 @@ def _inject_single_server_overrides(
     server_type: str,
     model_name: str,
     host: str | None = None,
-    port: int | None = None,
+    port: int | str | None = None,
     base_url: str | None = None,
 ) -> str:
     """Inject single-model server config overrides (like configure_client does).

--- a/nemo_skills/pipeline/utils/scripts/server.py
+++ b/nemo_skills/pipeline/utils/scripts/server.py
@@ -66,7 +66,7 @@ class ServerScript(BaseJobScript):
     num_nodes: int = 1
     server_args: str = ""
     server_entrypoint: Optional[str] = None
-    port: Optional[int] = None
+    port: Optional[int | str] = None
     allocate_port: bool = True
 
     # Server spans all group nodes (e.g., for distributed inference)
@@ -115,7 +115,7 @@ class SandboxScript(BaseJobScript):
     """
 
     cluster_config: Dict
-    port: Optional[int] = None
+    port: Optional[int | str] = None
     keep_mounts: bool = False
     allocate_port: bool = True
     env_overrides: Optional[List[str]] = None

--- a/nemo_skills/pipeline/utils/server.py
+++ b/nemo_skills/pipeline/utils/server.py
@@ -13,13 +13,20 @@
 # limitations under the License.
 
 import logging
+import os
 import shlex
+import tempfile
+import time
 from enum import Enum
 
 from nemo_skills.pipeline.utils.mounts import check_if_mounted
 from nemo_skills.utils import get_logger_name, get_server_wait_cmd
 
 LOG = logging.getLogger(get_logger_name(__file__))
+
+_ALLOCATED_RANDOM_PORTS: set[int] = set()
+DEFAULT_PORT_RESERVATION_TTL = 3600
+_SLURM_JOB_PORT_OFFSET = 0
 
 
 class SupportedServersSelfHosted(str, Enum):
@@ -45,7 +52,7 @@ class SupportedServers(str, Enum):
     generic = "generic"
 
 
-def get_free_port(exclude: list[int] | None = None, strategy: int | str = 5000) -> int:
+def get_free_port(exclude: list[int] | None = None, strategy: int | str = 5000) -> int | str:
     """Will return a free port on the host."""
     exclude = exclude or []
     if isinstance(strategy, int):
@@ -54,12 +61,70 @@ def get_free_port(exclude: list[int] | None = None, strategy: int | str = 5000) 
             port += 1
         return port
     elif strategy == "random":
+        import fcntl
         import random
 
-        port = random.randint(1024, 65535)
-        while port in exclude:
-            port = random.randint(1024, 65535)
-        return port
+        if os.getenv("NEMO_SKILLS_USE_SLURM_JOB_ID_PORTS") == "1":
+            global _SLURM_JOB_PORT_OFFSET
+
+            offset = _SLURM_JOB_PORT_OFFSET
+            _SLURM_JOB_PORT_OFFSET += 1
+            # Expanded inside the SLURM job, not at submit time. This keeps
+            # ports stable between the co-scheduled server and client, while
+            # making concurrent jobs on the same node overwhelmingly unlikely
+            # to collide.
+            return f"$((20000+(${{SLURM_JOB_ID:-0}}+{offset})%45000))"
+
+        # These ports are embedded into SLURM scripts before the jobs land on
+        # worker nodes. A plain random draw can assign the same port to many
+        # concurrent single-GPU jobs, and then vLLM fails with EADDRINUSE when
+        # two such jobs share a node. Keep a small per-user reservation file so
+        # independent submitter processes don't reuse ports in the same burst.
+        uid = os.getuid() if hasattr(os, "getuid") else "nouid"
+        lock_path = os.path.join(tempfile.gettempdir(), f"nemo_skills_ports_{uid}.lock")
+        state_path = os.path.join(tempfile.gettempdir(), f"nemo_skills_ports_{uid}.txt")
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+
+        with open(lock_path, "w") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            now = time.time()
+            cutoff = now - DEFAULT_PORT_RESERVATION_TTL
+            reserved_entries: dict[int, float] = {}
+            try:
+                with open(state_path) as state:
+                    for line in state:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        port_value, _, timestamp_value = line.partition(",")
+                        try:
+                            port = int(port_value)
+                        except ValueError:
+                            continue
+                        try:
+                            timestamp = float(timestamp_value) if timestamp_value else 0.0
+                        except ValueError:
+                            timestamp = 0.0
+                        if timestamp >= cutoff:
+                            reserved_entries[port] = timestamp
+            except FileNotFoundError:
+                pass
+
+            for port in _ALLOCATED_RANDOM_PORTS:
+                reserved_entries.setdefault(port, now)
+
+            reserved: set[int] = set(reserved_entries)
+            for _ in range(10000):
+                port = random.randint(20000, 65000)
+                if port not in exclude and port not in reserved:
+                    reserved_entries[port] = now
+                    _ALLOCATED_RANDOM_PORTS.add(port)
+                    with open(state_path, "w") as state:
+                        for reserved_port, timestamp in sorted(reserved_entries.items()):
+                            state.write(f"{reserved_port},{timestamp}\n")
+                    return port
+
+        raise RuntimeError("Unable to allocate a unique random port")
     else:
         raise ValueError(f"Strategy {strategy} not supported.")
 
@@ -232,7 +297,7 @@ def get_server_command(
     num_nodes: int,
     model_path: str,
     cluster_config: dict,
-    server_port: int,
+    server_port: int | str,
     server_args: str = "",
     server_entrypoint: str | None = None,
 ):

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -619,11 +619,21 @@ def maybe_get_env(value: Union[Any, List[Any]], env_name, default=None, cast: Ca
 
 
 def get_server_wait_cmd(server_address):
+    server_url = server_address.rstrip("/")
+    if not server_url.startswith(("http://", "https://")):
+        server_url = f"http://{server_url}"
+    if server_url.endswith("/v1"):
+        models_url = f"{server_url}/models"
+        health_url = f"{server_url[:-3]}/health"
+    else:
+        models_url = f"{server_url}/v1/models"
+        health_url = f"{server_url}/health"
     # might be required if we are not hosting server ourselves
-    # this will try to handshake in a loop and unblock when the server responds
+    # this will try to handshake in a loop and unblock when the server is ready
     return (
         f"echo 'Waiting for the server to start at {server_address}' && "
-        f"while [ $(curl -X PUT {server_address} >/dev/null 2>&1; echo $?) -ne 0 ]; do sleep 3; done "
+        f"while ! (curl -sS {models_url} >/dev/null 2>&1 || "
+        f"curl -sS {health_url} >/dev/null 2>&1); do sleep 3; done "
     )
 
 


### PR DESCRIPTION
## Summary

Split out from #1443.

This PR contains general runtime and pipeline hardening that is useful independently of the AppTek benchmark.

## What Changed

- Hardened async generation merge behavior:
  - preserves async output order
  - rejects negative or duplicate positions
  - reports missing indices instead of writing null rows
  - handles empty async output cleanly
- Improved multimodal message content normalization:
  - accepts typed text dictionaries
  - normalizes `None` text to empty content
  - rejects malformed dicts and unsupported content types with clear errors
- Improved self-hosted server readiness checks:
  - normalizes server addresses
  - probes `/v1/models` and `/health`
  - avoids relying on unsupported raw-address checks
- Reduced random port collisions for concurrent SLURM submissions:
  - supports deferred `SLURM_JOB_ID`-derived ports
  - stores timestamped random-port reservations
  - prunes stale reservations with a TTL
- Plumbed integer or string-valued ports through server and sandbox scripts.
- Refined judge/summarize sbatch override handling and exclusivity defaults.

## Relationship To #1443

This PR is a prerequisite/adjacent cleanup split out of the original AppTek PR. It does not add the AppTek benchmark itself.

## Validation

- `python -m py_compile` on changed Python files.
- Isolated smoke test for timestamped port reservation pruning.
- CI lint/DCO/copyright checks are passing.
