### PR TITLE
Add vLLM 0.22.1 DeepSeek-V4 fixes

### DIFF
--- a/dockerfiles/Dockerfile.vllm
+++ b/dockerfiles/Dockerfile.vllm
@@ -1,5 +1,24 @@
-FROM vllm/vllm-openai:v0.22.0
-RUN pip install ray
-RUN pip install "vllm[audio]"
-# Required by vLLM for Qwen-VL model family (runtime dependency, not directly imported)
-RUN pip install qwen-vl-utils
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM vllm/vllm-openai:v0.22.1
+
+# NeMo-Skills multi-node vLLM serving uses Ray as the distributed executor.
+ARG RAY_VERSION=2.55.1
+RUN pip install --no-cache-dir "ray==${RAY_VERSION}"
+
+# DeepSeek-V4-Pro on CUDA 13 needs compatibility guards for the official v0.22.1
+# image. Keep the patch in a standalone script so this Dockerfile stays readable.
+COPY dockerfiles/patch_vllm_v0221_deepseekv4.py /tmp/patch_vllm_v0221_deepseekv4.py
+RUN python3 /tmp/patch_vllm_v0221_deepseekv4.py && rm /tmp/patch_vllm_v0221_deepseekv4.py

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -34,6 +34,17 @@ We directly use official `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc8` image.
 
 We directly use official `lmsysorg/sglang:v0.5.10.post1` image.
 
+## Building vLLM image
+
+`dockerfiles/Dockerfile.vllm` builds from the official `vllm/vllm-openai:v0.22.1`
+image, installs pinned Ray for multi-node serving, and applies narrow CUDA 13
+compatibility guards needed for DeepSeek-V4-Pro. Build it from the repository
+root with:
+
+```shell
+docker build -t nemo-skills-vllm:v0.22.1 -f dockerfiles/Dockerfile.vllm .
+```
+
 ## NeMo-RL image default
 
 The sample local cluster config currently defaults `containers.nemo-rl` to the upstream NeMo-RL release image

--- a/dockerfiles/patch_vllm_v0221_deepseekv4.py
+++ b/dockerfiles/patch_vllm_v0221_deepseekv4.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Patch vLLM v0.22.1 CUDA-13 compatibility issues for DeepSeek-V4-Pro.
+
+This is intentionally narrow and fails closed if the expected upstream code is
+not present. It keeps the fast CUTE/DeepGEMM path enabled while working around
+two known image-level compatibility issues seen with DeepSeek-V4-Pro:
+
+1. vLLM FlashAttention CUTE calls ``nvvm.fmax`` without the explicit result
+   type expected by the installed CUTLASS DSL binding.
+2. CUTLASS DSL's MLIR verifier can reject generated modules with a CUDA-13
+   ``llvm.mlir.global_dtors`` schema mismatch even though the JIT can consume
+   the generated module.
+"""
+
+from __future__ import annotations
+
+import py_compile
+from pathlib import Path
+
+VLLM_CUTE_UTILS = Path("/usr/local/lib/python3.12/dist-packages/vllm/vllm_flash_attn/cute/utils.py")
+
+CUTLASS_VERIFY_PATHS = [
+    Path("/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/cutlass_dsl/cutlass.py"),
+    Path("/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/dsl.py"),
+]
+
+
+def patch_fmax() -> None:
+    """Patch vLLM's CUTE helper to match the installed nvvm.fmax binding."""
+    text = VLLM_CUTE_UTILS.read_text()
+    old = """    # * NVVM call based on nvvm version
+    if CUDA_VERSION.major == 12 and CUDA_VERSION.minor == 9:
+        # Old API: requires explicit result type as first positional argument
+        return Float32(
+            nvvm.fmax(
+                T.f32(),
+                Float32(a).ir_value(loc=loc, ip=ip),
+                Float32(b).ir_value(loc=loc, ip=ip),
+                c=Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None,
+                loc=loc,
+                ip=ip,
+            )
+        )
+    else:
+        # New API: infers result type automatically
+        return Float32(
+            nvvm.fmax(
+                Float32(a).ir_value(loc=loc, ip=ip),
+                Float32(b).ir_value(loc=loc, ip=ip),
+                c=Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None,
+                loc=loc,
+                ip=ip,
+            )
+        )
+"""
+    new = """    # CUTLASS DSL shipped in this vLLM image still expects the explicit result
+    # type argument for nvvm.fmax, including on CUDA 13. Keep the fast CUTE path
+    # enabled while matching the installed nvvm binding signature.
+    return Float32(
+        nvvm.fmax(
+            T.f32(),
+            Float32(a).ir_value(loc=loc, ip=ip),
+            Float32(b).ir_value(loc=loc, ip=ip),
+            c=Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None,
+            loc=loc,
+            ip=ip,
+        )
+    )
+"""
+    if old not in text:
+        if "type argument for nvvm.fmax" in text:
+            print(f"fmax patch already present: {VLLM_CUTE_UTILS}")
+            return
+        raise SystemExit(f"Expected fmax block was not found in {VLLM_CUTE_UTILS}; refusing to patch blindly")
+    VLLM_CUTE_UTILS.write_text(text.replace(old, new))
+    print(f"patched {VLLM_CUTE_UTILS}")
+
+
+def verifier_guard(indent: str) -> list[str]:
+    """Return a guarded MLIR verifier call preserving all unexpected errors."""
+    return [
+        f"{indent}try:\n",
+        f"{indent}    module.operation.verify()\n",
+        f"{indent}except Exception as exc:\n",
+        f"{indent}    msg = str(exc)\n",
+        f"{indent}    if (\n",
+        f'{indent}        "llvm.mlir.global_dtors" in msg\n',
+        f"{indent}        and \"requires attribute 'data'\" in msg\n",
+        f"{indent}    ):\n",
+        f'{indent}        __import__("warnings").warn(\n',
+        f'{indent}            "Skipping CUTLASS MLIR verifier for known CUDA 13 "\n',
+        f'{indent}            "global_dtors schema mismatch; compiled fast CUTE "\n',
+        f'{indent}            "kernel is still passed to the JIT engine.",\n',
+        f"{indent}            RuntimeWarning,\n",
+        f"{indent}        )\n",
+        f"{indent}    else:\n",
+        f"{indent}        raise\n",
+    ]
+
+
+def patch_global_dtors_verifier(path: Path) -> int:
+    """Guard known CUDA 13 global_dtors verifier failures in one CUTLASS file."""
+    lines = path.read_text().splitlines(keepends=True)
+    out: list[str] = []
+    count = 0
+    for line in lines:
+        if line.strip() == "module.operation.verify()":
+            indent = line[: len(line) - len(line.lstrip())]
+            out.extend(verifier_guard(indent))
+            count += 1
+        else:
+            out.append(line)
+
+    if count:
+        path.write_text("".join(out))
+        print(f"patched {path} verify calls {count}")
+    else:
+        print(f"no module.operation.verify() call found in {path}")
+    return count
+
+
+def main() -> None:
+    """Apply all image patches and compile-check modified Python files."""
+    patch_fmax()
+    existing_cutlass_paths = [path for path in CUTLASS_VERIFY_PATHS if path.exists()]
+    patched = sum(patch_global_dtors_verifier(path) for path in existing_cutlass_paths)
+    if patched == 0:
+        raise SystemExit("No CUTLASS verifier calls were patched; refusing to continue")
+    for path in [VLLM_CUTE_UTILS, *existing_cutlass_paths]:
+        py_compile.compile(str(path), doraise=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_skills/pipeline/utils/server.py
+++ b/nemo_skills/pipeline/utils/server.py
@@ -180,6 +180,24 @@ def get_ray_server_cmd(start_cmd, serving_nodes: int | None = None, num_gpus: in
     if serving_nodes is not None:
         if num_gpus is None:
             raise ValueError("get_ray_server_cmd: num_gpus must be set when serving_nodes is set")
+        expected_gpus = serving_nodes * num_gpus
+        wait_for_ray_resources = (
+            "    echo 'Waiting for Ray serving resources' && "
+            "    ray_ready=0 && "
+            "    for i in $(seq 1 150); do "
+            "        python3 -c 'import ray, sys; "
+            'ray.init(address="auto", log_to_driver=False); '
+            "resources = ray.cluster_resources(); "
+            'gpu = float(resources.get("GPU", 0)); '
+            'nodes = sum(1 for n in ray.nodes() if n.get("Alive") and float(n.get("Resources", {}).get("GPU", 0)) > 0); '
+            f'print("Ray ready check: GPU={{}}/{expected_gpus}, GPU nodes={{}}/{serving_nodes}".format(gpu, nodes)); '
+            "ray.shutdown(); "
+            f"sys.exit(0 if gpu >= {expected_gpus} and nodes >= {serving_nodes} else 1)' "
+            "        && ray_ready=1 && break; "
+            "        sleep 2; "
+            "    done && "
+            '    [ "$ray_ready" = 1 ] && '
+        )
         # Worker branch: split on whether this rank participates in vLLM serving.
         worker_branch = (
             'if [ "${SLURM_PROCID:-0}" -lt ' + str(serving_nodes) + " ]; then "
@@ -200,6 +218,7 @@ def get_ray_server_cmd(start_cmd, serving_nodes: int | None = None, num_gpus: in
             "fi"
         )
     else:
+        wait_for_ray_resources = ""
         worker_branch = (
             "    echo 'Starting worker node' && "
             '    echo "Connecting to head node at $SLURM_MASTER_NODE" && '
@@ -217,6 +236,7 @@ def get_ray_server_cmd(start_cmd, serving_nodes: int | None = None, num_gpus: in
         "        --head "
         "        --port=6379 "
         f"       {ports} && "
+        f"   {wait_for_ray_resources} "
         f"   {start_cmd} ; "
         "else "
         "    export RAY_raylet_start_wait_time_s=120 && "
@@ -285,7 +305,11 @@ def get_server_command(
             f"    {server_args} "
         )
         if num_nodes > 1:
-            server_start_cmd = get_ray_server_cmd(start_vllm_cmd)
+            server_start_cmd = get_ray_server_cmd(
+                start_vllm_cmd,
+                serving_nodes=num_nodes,
+                num_gpus=num_gpus,
+            )
         else:
             server_start_cmd = start_vllm_cmd
         num_tasks = 1


### PR DESCRIPTION
## Summary

- Update `dockerfiles/Dockerfile.vllm` to build from official `vllm/vllm-openai:v0.22.1` and install Ray for multi-node serving.
- Add a narrow build-time patch script for DeepSeek-V4-Pro CUDA 13 compatibility issues in the vLLM/CUTLASS stack.
- Wait for all expected Ray GPU resources before launching multi-node vLLM serving, avoiding startup races where vLLM only sees the head node.
- Document the vLLM image build command in `dockerfiles/README.md`.

## Validation

- Ran `python -m py_compile dockerfiles/patch_vllm_v0221_deepseekv4.py nemo_skills/pipeline/utils/server.py`.
- `pre-commit` hooks passed during commit: ruff check, ruff format, whitespace, private key scan, large file check.
- Tested the corresponding v0.22.1 patched container on DeepSeek-V4-Pro TP=4/DP=2 512k context stress runs; mns128/c512 recovered expected throughput compared with the v0.22.0 patched image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * vLLM Docker image bumped to v0.22.1 and now installs Ray for multi-node serving.
  * Added CUDA 13 compatibility safeguards for DeepSeek-V4-Pro during image build.
  * Multi-node deployments include Ray cluster readiness checks to ensure expected GPU resources before serving.

* **Documentation**
  * Added instructions for building the vLLM image and example build command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->