### PR TITLE
Speed up local vLLM ASR client requests

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -273,6 +273,79 @@ cs = hydra.core.config_store.ConfigStore.instance()
 cs.store(name="base_generation_config", node=GenerationTaskConfig)
 
 
+def _patch_httpcore_connection_pool_assignment() -> None:
+    """Patch httpcore's async connection assignment hot path.
+
+    httpcore 1.0.9 repeatedly materializes connection-state lists while
+    assigning queued requests to connections. At high OpenAI-compatible
+    concurrency this can dominate the client asyncio loop. Keep the same
+    request-assignment order, but use scalar checks/generators instead of
+    rebuilding lists on every pass.
+    """
+    try:
+        import httpcore._async.connection_pool as async_connection_pool
+    except ImportError:
+        LOG.debug("httpcore is not installed; skipping async connection-pool patch")
+        return
+
+    assign = async_connection_pool.AsyncConnectionPool._assign_requests_to_connections
+    if getattr(assign, "_nemo_skills_fast_assign", False):
+        return
+
+    def _fast_assign_requests_to_connections(self):
+        closing_connections = []
+
+        # First clean up closed/expired/surplus-idle connections. The original
+        # implementation builds an N-element list for every idle connection just
+        # to take its len(); len(self._connections) is behavior-equivalent.
+        for connection in list(self._connections):
+            if connection.is_closed():
+                self._connections.remove(connection)
+            elif connection.has_expired():
+                self._connections.remove(connection)
+                closing_connections.append(connection)
+            elif connection.is_idle() and len(self._connections) > self._max_keepalive_connections:
+                self._connections.remove(connection)
+                closing_connections.append(connection)
+
+        # Assign queued requests while preserving httpcore's first-match order.
+        queued_requests = [request for request in self._requests if request.is_queued()]
+        for pool_request in queued_requests:
+            origin = pool_request.request.url.origin
+            connection = next(
+                (
+                    connection
+                    for connection in self._connections
+                    if connection.can_handle_request(origin) and connection.is_available()
+                ),
+                None,
+            )
+
+            if connection is not None:
+                pool_request.assign_to_connection(connection)
+            elif len(self._connections) < self._max_connections:
+                connection = self.create_connection(origin)
+                self._connections.append(connection)
+                pool_request.assign_to_connection(connection)
+            else:
+                connection = next(
+                    (connection for connection in self._connections if connection.is_idle()),
+                    None,
+                )
+                if connection is not None:
+                    self._connections.remove(connection)
+                    closing_connections.append(connection)
+                    connection = self.create_connection(origin)
+                    self._connections.append(connection)
+                    pool_request.assign_to_connection(connection)
+
+        return closing_connections
+
+    _fast_assign_requests_to_connections._nemo_skills_fast_assign = True
+    async_connection_pool.AsyncConnectionPool._assign_requests_to_connections = _fast_assign_requests_to_connections
+    LOG.debug("Patched httpcore AsyncConnectionPool._assign_requests_to_connections")
+
+
 class GenerationTask:
     @classmethod
     def get_generation_default_args(cls) -> str:
@@ -862,6 +935,7 @@ class GenerationTask:
 
     async def async_loop(self, data):
         """Async loop to generate generations using asyncio."""
+        _patch_httpcore_connection_pool_assignment()
 
         # Initialize output lock for thread-safe writing
         if self.output_lock is None:

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -276,11 +276,18 @@ cs.store(name="base_generation_config", node=GenerationTaskConfig)
 def _patch_httpcore_connection_pool_assignment() -> None:
     """Patch httpcore's async connection assignment hot path.
 
-    httpcore 1.0.9 repeatedly materializes connection-state lists while
-    assigning queued requests to connections. At high OpenAI-compatible
-    concurrency this can dominate the client asyncio loop. Keep the same
-    request-assignment order, but use scalar checks/generators instead of
-    rebuilding lists on every pass.
+    httpcore 1.0.9's ``_assign_requests_to_connections`` is O(N^2 + N*M)
+    (N connections, M queued requests): it rebuilds connection-state lists for
+    every idle connection and again for every queued request. At high
+    OpenAI-compatible concurrency this dominates the client asyncio loop
+    (see encode/httpcore#1035, still unmerged as of 1.0.9).
+
+    This installs a single-pass O(N+M) rewrite ported from that PR: categorize
+    connections once, then assign queued requests from the available bucket
+    (popping so a connection is never handed to two requests in one pass) with
+    an early exit once nothing more can be serviced. HTTP/2 pools fall back to
+    the original because they need per-connection stream-capacity tracking that
+    this fast path omits.
     """
     try:
         import httpcore._async.connection_pool as async_connection_pool
@@ -288,62 +295,103 @@ def _patch_httpcore_connection_pool_assignment() -> None:
         LOG.debug("httpcore is not installed; skipping async connection-pool patch")
         return
 
-    assign = async_connection_pool.AsyncConnectionPool._assign_requests_to_connections
-    if getattr(assign, "_nemo_skills_fast_assign", False):
+    original_assign = async_connection_pool.AsyncConnectionPool._assign_requests_to_connections
+    if getattr(original_assign, "_nemo_skills_fast_assign", False):
         return
 
-    def _fast_assign_requests_to_connections(self):
-        closing_connections = []
+    def _single_pass_assign_requests_to_connections(self):
+        # HTTP/2 multiplexing needs per-connection stream-capacity bookkeeping
+        # that this fast path intentionally omits, so defer to the original.
+        if getattr(self, "_http2", False):
+            return original_assign(self)
 
-        # First clean up closed/expired/surplus-idle connections. The original
-        # implementation builds an N-element list for every idle connection just
-        # to take its len(); len(self._connections) is behavior-equivalent.
-        for connection in list(self._connections):
+        closing_conns = []
+        available_conns = []
+        occupied_conns = []
+
+        # Phase 1: categorize every connection in a single O(N) pass.
+        for connection in self._connections:
             if connection.is_closed():
-                self._connections.remove(connection)
+                continue
             elif connection.has_expired():
-                self._connections.remove(connection)
-                closing_connections.append(connection)
-            elif connection.is_idle() and len(self._connections) > self._max_keepalive_connections:
-                self._connections.remove(connection)
-                closing_connections.append(connection)
-
-        # Assign queued requests while preserving httpcore's first-match order.
-        queued_requests = [request for request in self._requests if request.is_queued()]
-        for pool_request in queued_requests:
-            origin = pool_request.request.url.origin
-            connection = next(
-                (
-                    connection
-                    for connection in self._connections
-                    if connection.can_handle_request(origin) and connection.is_available()
-                ),
-                None,
-            )
-
-            if connection is not None:
-                pool_request.assign_to_connection(connection)
-            elif len(self._connections) < self._max_connections:
-                connection = self.create_connection(origin)
-                self._connections.append(connection)
-                pool_request.assign_to_connection(connection)
+                closing_conns.append(connection)
+            elif connection.is_available():
+                available_conns.append(connection)
+            elif connection.is_idle():
+                # Idle but not available should not happen; close defensively.
+                closing_conns.append(connection)
             else:
-                connection = next(
-                    (connection for connection in self._connections if connection.is_idle()),
-                    None,
-                )
-                if connection is not None:
-                    self._connections.remove(connection)
-                    closing_connections.append(connection)
-                    connection = self.create_connection(origin)
-                    self._connections.append(connection)
+                occupied_conns.append(connection)
+
+        total_existing = len(available_conns) + len(occupied_conns) + len(closing_conns)
+        new_conns_remaining = self._max_connections - total_existing
+
+        # Phase 2: assign queued requests. Reuse an available connection
+        # (popping so it is never handed to two requests in one pass), else
+        # create a new connection, else evict an idle one as a last resort.
+        # Stop as soon as a request cannot be serviced (early exit).
+        for pool_request in self._requests:
+            if not pool_request.is_queued():
+                continue
+            origin = pool_request.request.url.origin
+
+            assigned = False
+            # Iterate in reverse so popping the chosen connection is O(1).
+            for i in range(len(available_conns) - 1, -1, -1):
+                connection = available_conns[i]
+                if connection.can_handle_request(origin):
                     pool_request.assign_to_connection(connection)
+                    available_conns.pop(i)
+                    occupied_conns.append(connection)
+                    assigned = True
+                    break
+            if assigned:
+                continue
 
-        return closing_connections
+            if new_conns_remaining > 0:
+                connection = self.create_connection(origin)
+                pool_request.assign_to_connection(connection)
+                occupied_conns.append(connection)
+                new_conns_remaining -= 1
+                continue
 
-    _fast_assign_requests_to_connections._nemo_skills_fast_assign = True
-    async_connection_pool.AsyncConnectionPool._assign_requests_to_connections = _fast_assign_requests_to_connections
-    LOG.debug("Patched httpcore AsyncConnectionPool._assign_requests_to_connections")
+            for i in range(len(available_conns) - 1, -1, -1):
+                connection = available_conns[i]
+                if connection.is_idle():
+                    closing_conns.append(available_conns.pop(i))
+                    connection = self.create_connection(origin)
+                    pool_request.assign_to_connection(connection)
+                    occupied_conns.append(connection)
+                    assigned = True
+                    break
+
+            if not assigned:
+                break
+
+        # Phase 3: enforce max_keepalive_connections by closing surplus idle
+        # connections (idle connections are a subset of available ones).
+        if len(available_conns) > self._max_keepalive_connections:
+            kept = []
+            n_idle_kept = 0
+            for connection in available_conns:
+                if connection.is_idle():
+                    if n_idle_kept >= self._max_keepalive_connections:
+                        closing_conns.append(connection)
+                    else:
+                        kept.append(connection)
+                        n_idle_kept += 1
+                else:
+                    kept.append(connection)
+            available_conns = kept
+
+        self._connections = available_conns + occupied_conns
+        return closing_conns
+
+    _single_pass_assign_requests_to_connections._nemo_skills_fast_assign = True
+    async_connection_pool.AsyncConnectionPool._assign_requests_to_connections = (
+        _single_pass_assign_requests_to_connections
+    )
+    LOG.debug("Patched httpcore AsyncConnectionPool._assign_requests_to_connections (single-pass O(N+M))")
 
 
 class GenerationTask:

--- a/nemo_skills/inference/model/__init__.py
+++ b/nemo_skills/inference/model/__init__.py
@@ -26,6 +26,7 @@ from .audio_utils import (
     chunk_audio,
     load_audio_file,
     make_audio_content_block,
+    make_audio_url_content_block,
     save_audio_chunk_to_base64,
 )
 from .azure import AzureOpenAIModel

--- a/nemo_skills/inference/model/audio_utils.py
+++ b/nemo_skills/inference/model/audio_utils.py
@@ -150,3 +150,8 @@ def make_audio_content_block(base64_audio: str, audio_format: str = "audio_url")
         return {"type": "audio_url", "audio_url": {"url": f"data:audio/wav;base64,{base64_audio}"}}
     else:
         raise ValueError(f"Unsupported audio_format '{audio_format}'. Use 'audio_url' or 'input_audio'.")
+
+
+def make_audio_url_content_block(audio_url: str) -> dict:
+    """Create an audio_url content block from a URL."""
+    return {"type": "audio_url", "audio_url": {"url": audio_url}}

--- a/nemo_skills/inference/model/vllm_multimodal.py
+++ b/nemo_skills/inference/model/vllm_multimodal.py
@@ -34,6 +34,7 @@ from .audio_utils import (
     chunk_audio,
     load_audio_file,
     make_audio_content_block,
+    make_audio_url_content_block,
     save_audio_chunk_to_base64,
 )
 from .vllm import VLLMModel
@@ -77,6 +78,7 @@ class VLLMMultimodalModel(VLLMModel):
         audio_chunk_task_types: list[str] | None = None,
         chunk_audio_threshold_sec: int = 30,
         audio_format: str | None = None,
+        audio_as_path: bool | None = None,
         **kwargs,
     ):
         """Initialize VLLMMultimodalModel with audio I/O and external API support.
@@ -88,6 +90,8 @@ class VLLMMultimodalModel(VLLMModel):
             audio_chunk_task_types: If None, chunk all task types; if specified, only chunk these.
             chunk_audio_threshold_sec: Audio duration threshold for chunking (in seconds).
             audio_format: Format for audio content ("audio_url" or "input_audio"). If None, select by mode.
+            audio_as_path: If True, send local audio paths as file:// URLs instead of inlining base64.
+                If None, defaults to True for local vLLM audio_url mode and False for external APIs.
             **kwargs: Other parameters passed to VLLMModel/BaseModel.
         """
         super().__init__(model=model, base_url=base_url, **kwargs)
@@ -105,6 +109,11 @@ class VLLMMultimodalModel(VLLMModel):
         if audio_format not in ("audio_url", "input_audio"):
             raise ValueError(f"Unsupported audio_format '{audio_format}'. Use 'audio_url' or 'input_audio'.")
         self.audio_format = audio_format
+        if audio_as_path is None:
+            audio_as_path = not self._external_api_mode and self.audio_format == "audio_url"
+        if audio_as_path and (self._external_api_mode or self.audio_format != "audio_url"):
+            raise ValueError("audio_as_path is only supported for local vLLM audio_url requests.")
+        self.audio_as_path = audio_as_path
 
         # Audio OUTPUT config
         self.output_audio_dir = None
@@ -301,7 +310,7 @@ class VLLMMultimodalModel(VLLMModel):
         """Convert message content with audio to proper list format.
 
         Handles 'audio' or 'audios' keys in messages and converts them to
-        base64-encoded input_audio content items.
+        audio content items.
 
         CRITICAL: Audio must come BEFORE text for models to process correctly.
 
@@ -329,18 +338,24 @@ class VLLMMultimodalModel(VLLMModel):
         if "audio" in result:
             audio = result.pop("audio")
             audio_path = os.path.join(self.data_dir, audio["path"])
-            base64_audio = audio_file_to_base64(audio_path)
-            audio_items.append(make_audio_content_block(base64_audio, self.audio_format))
+            audio_items.append(self._make_audio_input_block(audio_path))
         elif "audios" in result:
             for audio in result.pop("audios"):
                 audio_path = os.path.join(self.data_dir, audio["path"])
-                base64_audio = audio_file_to_base64(audio_path)
-                audio_items.append(make_audio_content_block(base64_audio, self.audio_format))
+                audio_items.append(self._make_audio_input_block(audio_path))
 
         if audio_items:
             result["content"] = audio_items + result["content"]
 
         return result
+
+    def _make_audio_input_block(self, audio_path: str) -> dict:
+        """Create an audio input block for a local file path."""
+        if self.audio_as_path:
+            return make_audio_url_content_block(f"file://{os.path.abspath(audio_path)}")
+
+        base64_audio = audio_file_to_base64(audio_path)
+        return make_audio_content_block(base64_audio, self.audio_format)
 
     def _needs_audio_chunking(self, messages: list[dict], task_type: str = None) -> tuple[bool, str, float]:
         """Check if audio in messages needs chunking.

--- a/tests/test_vllm_audio.py
+++ b/tests/test_vllm_audio.py
@@ -45,7 +45,8 @@ def test_audio_file_to_base64():
 def _is_valid_audio_content(content_item: dict) -> bool:
     """Check if content item is a valid audio block (either format)."""
     if content_item.get("type") == "audio_url":
-        return content_item.get("audio_url", {}).get("url", "").startswith("data:audio/wav;base64,")
+        url = content_item.get("audio_url", {}).get("url", "")
+        return url.startswith("data:audio/wav;base64,") or url.startswith("file://")
     elif content_item.get("type") == "input_audio":
         return "data" in content_item.get("input_audio", {})
     return False
@@ -63,6 +64,7 @@ def mock_vllm_multimodal_model(tmp_path):
         model.audio_chunk_task_types = None
         model.chunk_audio_threshold_sec = 30
         model.audio_format = "audio_url"  # Test audio_url format (for vLLM/Qwen)
+        model.audio_as_path = True
         model._tunnel = None
         return model
 
@@ -79,6 +81,7 @@ def mock_vllm_multimodal_model_input_audio(tmp_path):
         model.audio_chunk_task_types = None
         model.chunk_audio_threshold_sec = 30
         model.audio_format = "input_audio"
+        model.audio_as_path = False
         model._tunnel = None
         return model
 
@@ -99,6 +102,22 @@ def test_content_text_to_list_with_audio(mock_vllm_multimodal_model, tmp_path):
     assert isinstance(result["content"], list)
     assert len(result["content"]) == 2
     assert _is_valid_audio_content(result["content"][0])
+    assert result["content"][0]["audio_url"]["url"] == f"file://{audio_path}"
+    assert result["content"][1]["type"] == "text"
+
+
+def test_content_text_to_list_with_audio_url_base64_fallback(mock_vllm_multimodal_model, tmp_path):
+    """Test that local vLLM audio_url mode can still inline base64 when requested."""
+    mock_vllm_multimodal_model.audio_as_path = False
+    audio_path = tmp_path / "test.wav"
+    with open(audio_path, "wb") as f:
+        f.write(b"RIFF" + b"\x00" * 100)
+
+    message = {"role": "user", "content": "Describe this audio", "audio": {"path": "test.wav"}}
+    result = mock_vllm_multimodal_model.content_text_to_list(message)
+
+    assert result["content"][0]["type"] == "audio_url"
+    assert result["content"][0]["audio_url"]["url"].startswith("data:audio/wav;base64,")
     assert result["content"][1]["type"] == "text"
 
 

--- a/tests/test_vllm_audio.py
+++ b/tests/test_vllm_audio.py
@@ -15,6 +15,7 @@
 """Tests for audio utilities and VLLMMultimodalModel audio input handling."""
 
 import base64
+import contextlib
 import os
 import tempfile
 from unittest.mock import patch
@@ -22,6 +23,7 @@ from unittest.mock import patch
 import pytest
 
 from nemo_skills.inference.model.audio_utils import audio_file_to_base64
+from nemo_skills.inference.model.vllm import VLLMModel
 from nemo_skills.inference.model.vllm_multimodal import VLLMMultimodalModel
 
 
@@ -215,3 +217,78 @@ def test_needs_audio_chunking_task_type_filter(mock_vllm_multimodal_model):
     # Task type in filter but file doesn't exist - should return False gracefully
     needs_chunking, _, _ = mock_vllm_multimodal_model._needs_audio_chunking(messages, task_type="transcription")
     assert needs_chunking is False
+
+
+@contextlib.contextmanager
+def _stub_vllm_base():
+    """Run the real ``VLLMMultimodalModel.__init__`` while stubbing the heavy
+    ``VLLMModel`` base so no server / tokenizer / network setup is needed.
+
+    The base only needs to provide the attributes the audio-config logic reads
+    (``base_url`` and ``output_dir``); everything the assertions cover lives in
+    ``VLLMMultimodalModel.__init__`` itself.
+    """
+
+    def _init(self, model=None, base_url=None, **kwargs):
+        self.base_url = base_url
+        self.output_dir = kwargs.get("output_dir")
+        self._tunnel = None  # consumed by BaseModel.__del__
+
+    with patch.object(VLLMModel, "__init__", _init):
+        yield
+
+
+def test_audio_as_path_defaults_local_default_url():
+    """Local vLLM (no base_url) defaults to audio_url + audio_as_path=True."""
+    with _stub_vllm_base():
+        model = VLLMMultimodalModel(base_url=None)
+    assert model._external_api_mode is False
+    assert model.audio_format == "audio_url"
+    assert model.audio_as_path is True
+
+
+def test_audio_as_path_defaults_local_explicit_localhost():
+    """Explicit local URL is still treated as local (path default on)."""
+    with _stub_vllm_base():
+        model = VLLMMultimodalModel(base_url="http://127.0.0.1:5000/v1")
+    assert model._external_api_mode is False
+    assert model.audio_format == "audio_url"
+    assert model.audio_as_path is True
+
+
+def test_audio_as_path_defaults_external_api():
+    """External API defaults to input_audio + audio_as_path=False."""
+    with _stub_vllm_base():
+        model = VLLMMultimodalModel(base_url="https://inference-api.nvidia.com/v1")
+    assert model._external_api_mode is True
+    assert model.audio_format == "input_audio"
+    assert model.audio_as_path is False
+
+
+def test_audio_as_path_local_base64_opt_out():
+    """audio_as_path=False is allowed for local audio_url (base64 fallback)."""
+    with _stub_vllm_base():
+        model = VLLMMultimodalModel(base_url=None, audio_as_path=False)
+    assert model.audio_format == "audio_url"
+    assert model.audio_as_path is False
+
+
+def test_audio_as_path_rejected_for_external_api():
+    """audio_as_path=True against an external API must raise."""
+    with _stub_vllm_base():
+        with pytest.raises(ValueError, match="audio_as_path is only supported"):
+            VLLMMultimodalModel(base_url="https://inference-api.nvidia.com/v1", audio_as_path=True)
+
+
+def test_audio_as_path_rejected_for_input_audio_format():
+    """audio_as_path=True with input_audio format must raise even when local."""
+    with _stub_vllm_base():
+        with pytest.raises(ValueError, match="audio_as_path is only supported"):
+            VLLMMultimodalModel(base_url=None, audio_format="input_audio", audio_as_path=True)
+
+
+def test_unsupported_audio_format_raises():
+    """An unknown audio_format is rejected."""
+    with _stub_vllm_base():
+        with pytest.raises(ValueError, match="Unsupported audio_format"):
+            VLLMMultimodalModel(base_url=None, audio_format="bogus")


### PR DESCRIPTION
## Summary
- Replace httpcore's async connection-pool assignment hot path (httpcore 1.0.9 is O(N²+N·M)) with a single-pass O(N+M) rewrite ported from encode/httpcore#1035; HTTP/2 pools fall back to the original implementation. This also fixes the two logic bugs that PR documents: the `max_keepalive_connections` idle-count miscount, and the HTTP/1.1 double-assign that can raise `ConnectionNotAvailable`.
- Send local vLLM multimodal audio as `file://` audio URLs by default for local `audio_url` requests, avoiding inline base64 payloads (base64 retained for external APIs and as an explicit fallback).
- Add a shared `make_audio_url_content_block` helper and expand vLLM audio tests (file:// vs base64 content, plus direct `VLLMMultimodalModel.__init__` tests for `audio_as_path` defaulting/validation).

## Test plan
- `python3 -m py_compile nemo_skills/inference/generate.py nemo_skills/inference/model/vllm_multimodal.py nemo_skills/inference/model/audio_utils.py`
- `pytest tests/test_vllm_audio.py` → 16 passed; `ruff check` + `ruff format --check` clean.
- httpcore rewrite validated for assignment-decision equivalence + liveness across 20k randomized pool states (vs the original 1.0.9 implementation).
- Full 8-chunk ASR leaderboard end-to-end: WER (%) 6.21, no throughput regression; controlled traced runs show the patch applied (`max_queued=1`, `max_conn=512`). Residual wall-clock variance traces to server-startup / chunk-start skew, not the request path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audio_as_path option to multimodal models to represent local audio as file:// URLs instead of inline base64.
  * Added support for producing audio URL content blocks for URL-based audio inputs.
  * Improved async connection pooling to make request assignment more efficient.

* **Tests**
  * Expanded tests to cover audio_as_path defaults, fallback to base64, validation for file:// and data:audio values, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
