### PR TITLE
Fix installation_command with single quotes crashing job

### DIFF
--- a/nemo_skills/pipeline/utils/exp.py
+++ b/nemo_skills/pipeline/utils/exp.py
@@ -435,7 +435,7 @@ def install_packages_wrap(cmd, installation_command: str | None = None):
             f"if ! [ -f {lock_file} ]; then "
             f"echo 'Starting package installation with UUID: {job_uuid}'; "
             f"touch {lock_file}; "
-            f"echo 'Installing packages: {installation_command}'; "
+            f"echo {shlex.quote('Installing packages: ' + installation_command)}; "
             f"if {installation_command}; then "
             f"echo 'Package installation completed successfully'; "
             f"echo 'done' > {lock_file}; "


### PR DESCRIPTION
Fixes a bug where installation commands containing single quotes caused a crash due to a string substitution issue. Minimal example:
```
ns run_cmd \
  --cluster=... \
  --partition=... \
  --expname=test-installation-command-quote-bug \
  --installation_command="python -c 'print(123)'" \
  --command="python -c 'print(456)'"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal handling of package installation command logging for improved robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->