### PR TITLE
fix: honor skip_special_tokens from extra_body on the vLLM completion path

### DIFF
--- a/nemo_skills/inference/model/vllm.py
+++ b/nemo_skills/inference/model/vllm.py
@@ -150,6 +150,7 @@ class VLLMModel(BaseModel):
         assert reasoning_effort is None, "reasoning_effort is not supported for text completion requests"
         assert tools is None, "tools are not supported for text completion requests"
         assert response_format is None, "response_format is not supported for text completion requests"
+        request_extra_body = self._build_request_body(top_k, min_p, repetition_penalty, extra_body=extra_body)
         return {
             "prompt": prompt,
             "max_tokens": tokens_to_generate,
@@ -160,13 +161,16 @@ class VLLMModel(BaseModel):
             "logprobs": top_logprobs,
             "stream": stream,
             "echo": False,
-            "skip_special_tokens": False,
+            # Single source for skip_special_tokens: honor a value passed via
+            # inference.extra_body (default False = keep), instead of hardcoding it
+            # here while also leaving it in extra_body, which would duplicate the field.
+            "skip_special_tokens": request_extra_body.pop("skip_special_tokens", False),
             "n": 1,
             "logit_bias": None,
             "frequency_penalty": frequency_penalty,
             "presence_penalty": presence_penalty,
             "timeout": timeout,
-            "extra_body": self._build_request_body(top_k, min_p, repetition_penalty, extra_body=extra_body),
+            "extra_body": request_extra_body,
         }
 
     def _build_chat_request_params(

--- a/tests/test_vllm_completion.py
+++ b/tests/test_vllm_completion.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for VLLMModel text-completion request building."""
+
+from unittest.mock import patch
+
+from nemo_skills.inference.model.vllm import VLLMModel
+
+
+def _completion_request(**extra_body):
+    """Build a text-completion request dict without a live server."""
+    with patch.object(VLLMModel, "__init__", lambda self, **kwargs: None):
+        model = VLLMModel()
+    model._tunnel = None  # avoid __del__ touching an unset attribute at GC time
+    return model._build_completion_request_params(
+        prompt="hello",
+        tokens_to_generate=8,
+        extra_body=extra_body or None,
+    )
+
+
+def test_completion_skip_special_tokens_defaults_to_false():
+    """With no override, skip_special_tokens stays False and is absent from extra_body."""
+    request = _completion_request()
+    assert request["skip_special_tokens"] is False
+    assert "skip_special_tokens" not in request["extra_body"]
+
+
+def test_completion_skip_special_tokens_honored_from_extra_body():
+    """A value passed via extra_body is lifted to the single top-level field, not duplicated."""
+    request = _completion_request(skip_special_tokens=True)
+    assert request["skip_special_tokens"] is True
+    assert "skip_special_tokens" not in request["extra_body"]


### PR DESCRIPTION
> Recreated from an in-repo branch so CI can run on it (fork PRs do not receive CI secrets). Replaces #1478.

## What

The vLLM **text-completion** request builder hardcoded `skip_special_tokens: False` at the top level, while `_build_request_body` could simultaneously carry a user-supplied `skip_special_tokens` inside `extra_body`. The field was sourced twice, so any `extra_body.skip_special_tokens` was silently dropped on the completion path.

This pops `skip_special_tokens` out of `extra_body` into the single top-level field (default `False`), so `inference.extra_body.skip_special_tokens` is honored on the completion path — matching how the chat path already behaves.

## Why

`skip_special_tokens=false` keeps special tokens (e.g. speaker tags) in the decoded output, which multispeaker ASR needs. The chat endpoint already respects this via `extra_body`; this makes the completion endpoint consistent, without adding any new config surface.

Usage (just `extra_body`, no new options):

```
++inference.extra_body.skip_special_tokens=false
```

## Test

`tests/test_vllm_completion.py`:
- default → top-level `skip_special_tokens=False`, absent from `extra_body`
- `extra_body.skip_special_tokens=True` → lifted to the single top-level field, not duplicated



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `skip_special_tokens` parameter in inference requests is now configurable via request options, providing greater control over token processing behavior.

* **Tests**
  * Added tests to validate `skip_special_tokens` parameter handling and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->