### PR TITLE
Add ntt-complex.format_ast benchmark scaffold

### DIFF
--- a/nemo_skills/dataset/ntt-complex/README.md
+++ b/nemo_skills/dataset/ntt-complex/README.md
@@ -1,0 +1,30 @@
+# NTT-COMPLEX
+
+`ntt-complex` is the umbrella benchmark for compositional NemotronTranscribe
+tasks. The bootstrap subtest is `ntt-complex.format_ast`, which evaluates audio
+speech translation with strict output formatting.
+
+The source data is expected to be prepared NeMo-Skills FLEURS and CoVoST2 AST/ST
+manifests, matching the canary-dev burst-eval path that prepares FLEURS and
+CoVoST2 as separate ASR and AST tasks. This checkout currently names those
+speech-translation subsets `fleurs.st` and `covost2.st`; canary-dev references
+them as `fleurs.ast` and `covost2.ast`. The prepare script accepts both layouts.
+
+Example:
+
+```bash
+ns prepare_data fleurs covost2 --data_dir <skills_data>
+NTT_COMPLEX_SOURCE_DATA_DIR=<skills_data> ns prepare_data ntt-complex --data_dir <skills_data>
+ns eval --benchmarks ntt-complex.format_ast --data_dir <skills_data> ...
+```
+
+`format_ast` renders each selected source row into several strict-output prompt
+variants:
+
+- `json_object`
+- `srt_single_cue`
+- `markdown_table`
+
+The evaluator extracts the translated text from the required structure, scores
+format validity, and then scores the extracted translation with the standard
+audio translation BLEU path.

--- a/nemo_skills/dataset/ntt-complex/__init__.py
+++ b/nemo_skills/dataset/ntt-complex/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NTT-COMPLEX: compositional NemotronTranscribe evaluation tasks.
+
+The initial benchmark group intentionally contains one bootstrap subtest:
+
+- ``ntt-complex.format_ast``: audio speech translation plus strict output
+  formatting.
+"""
+
+REQUIRES_DATA_DIR = True
+IS_BENCHMARK_GROUP = True
+SCORE_MODULE = "nemo_skills.dataset.ntt-complex.ntt_complex_metrics"
+
+BENCHMARKS = {
+    "ntt-complex.format_ast": {},
+}

--- a/nemo_skills/dataset/ntt-complex/format_ast/__init__.py
+++ b/nemo_skills/dataset/ntt-complex/format_ast/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+METRICS_TYPE = "nemo_skills.dataset.ntt-complex.ntt_complex_metrics::NTTComplexMetrics"
+EVAL_ARGS = (
+    "++eval_type=nemo_skills.dataset.ntt-complex.ntt_complex_eval::NTTComplexEvaluator "
+    "++eval_config.normalization_mode=multilingual "
+    "++eval_config.strip_helpful_prefixes=true"
+)
+GENERATION_ARGS = "++prompt_format=openai ++enable_audio=true"

--- a/nemo_skills/dataset/ntt-complex/ntt_complex_eval.py
+++ b/nemo_skills/dataset/ntt-complex/ntt_complex_eval.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Evaluator for NTT-COMPLEX subtests."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import fields
+from typing import Any
+
+from nemo_skills.evaluation.evaluator.audio import AudioEvaluatorConfig, evaluate_translation
+from nemo_skills.evaluation.evaluator.base import BaseEvaluator
+
+
+def _audio_config(config: dict[str, Any]) -> AudioEvaluatorConfig:
+    field_names = {field.name for field in fields(AudioEvaluatorConfig)}
+    return AudioEvaluatorConfig(**{key: value for key, value in config.items() if key in field_names})
+
+
+def _clean_generation(generation: str, config: AudioEvaluatorConfig) -> str:
+    # ASR prefix stripping can corrupt structured outputs, e.g. extracting the
+    # first quoted string from JSON. Format-AST validates the raw structure.
+    return str(generation).strip()
+
+
+def _balanced_json_object(text: str) -> str | None:
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    in_string = False
+    escape = False
+    for idx, char in enumerate(text[start:], start=start):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : idx + 1]
+    return None
+
+
+def _extract_json_translation(generation: str) -> tuple[bool, str, str | None]:
+    payload = _balanced_json_object(generation)
+    if payload is None:
+        return False, generation.strip(), "missing_json_object"
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        return False, generation.strip(), f"invalid_json:{exc.msg}"
+    required = {"source_language", "target_language", "translation"}
+    keys = set(parsed)
+    if keys != required:
+        return False, str(parsed.get("translation", "")).strip(), "json_keys_mismatch"
+    translation = parsed.get("translation")
+    if not isinstance(translation, str) or not translation.strip():
+        return False, "", "missing_translation"
+    return True, translation.strip(), None
+
+
+def _extract_srt_translation(generation: str) -> tuple[bool, str, str | None]:
+    lines = [line.strip() for line in generation.strip().splitlines() if line.strip()]
+    if len(lines) < 3:
+        return False, generation.strip(), "too_few_srt_lines"
+    if lines[0] != "1":
+        return False, " ".join(lines[2:]).strip(), "missing_srt_index"
+    timestamp = r"^\d{2}:\d{2}:\d{2},\d{3}\s+-->\s+\d{2}:\d{2}:\d{2},\d{3}$"
+    if re.match(timestamp, lines[1]) is None:
+        return False, " ".join(lines[2:]).strip(), "invalid_srt_timestamp"
+    translation = " ".join(lines[2:]).strip()
+    if not translation:
+        return False, "", "missing_translation"
+    return True, translation, None
+
+
+def _split_markdown_row(line: str) -> list[str]:
+    line = line.strip()
+    if line.startswith("|"):
+        line = line[1:]
+    if line.endswith("|"):
+        line = line[:-1]
+    return [cell.strip() for cell in line.split("|")]
+
+
+def _extract_markdown_translation(generation: str) -> tuple[bool, str, str | None]:
+    rows = [line.strip() for line in generation.strip().splitlines() if line.strip()]
+    table_rows = [line for line in rows if "|" in line]
+    if len(table_rows) < 3:
+        return False, generation.strip(), "too_few_markdown_rows"
+    header = [cell.lower() for cell in _split_markdown_row(table_rows[0])]
+    expected = ["source_language", "target_language", "translation"]
+    if header != expected:
+        return False, generation.strip(), "markdown_header_mismatch"
+    separator = _split_markdown_row(table_rows[1])
+    if len(separator) != 3 or not all(re.fullmatch(r":?-{3,}:?", cell) for cell in separator):
+        return False, generation.strip(), "markdown_separator_mismatch"
+    data = _split_markdown_row(table_rows[2])
+    if len(data) != 3:
+        return False, generation.strip(), "markdown_data_mismatch"
+    translation = data[2].strip()
+    if not translation:
+        return False, "", "missing_translation"
+    return True, translation, None
+
+
+def extract_formatted_translation(format_id: str, generation: str) -> tuple[bool, str, str | None]:
+    if format_id == "json_object":
+        return _extract_json_translation(generation)
+    if format_id == "srt_single_cue":
+        return _extract_srt_translation(generation)
+    if format_id == "markdown_table":
+        return _extract_markdown_translation(generation)
+    return False, generation.strip(), f"unknown_format:{format_id}"
+
+
+class NTTComplexEvaluator(BaseEvaluator):
+    """Mixed evaluator for NTT-COMPLEX.
+
+    `Format-AST` first validates and extracts the required structure, then
+    scores the extracted translation with the standard audio translation path.
+    """
+
+    def __init__(self, config: dict[str, Any], num_parallel_requests=10):
+        super().__init__(config, num_parallel_requests)
+        self.audio_config = _audio_config(config)
+
+    async def eval_single(self, data_point: dict[str, Any]) -> dict[str, Any]:
+        task_type = data_point.get("task_type")
+        if task_type != "Format-AST":
+            raise ValueError(f"Unsupported NTT-COMPLEX task_type: {task_type}")
+
+        generation = _clean_generation(data_point.get("generation", ""), self.audio_config)
+        format_id = str(data_point.get("format_id", ""))
+        format_valid, extracted, format_error = extract_formatted_translation(format_id, generation)
+
+        extra_fields = data_point.get("extra_fields") or {}
+        tgt_lang = extra_fields.get("tgt_lang")
+        translation_metrics = evaluate_translation(data_point.get("expected_answer", ""), extracted, tgt_lang)
+        translation_ok = bool(translation_metrics.get("is_correct"))
+        translation_metrics["is_correct"] = bool(format_valid and translation_ok)
+        translation_metrics.update(
+            {
+                "format_valid": bool(format_valid),
+                "format_score": 1.0 if format_valid else 0.0,
+                "format_error": format_error,
+                "formatted_generation": generation,
+                "extracted_translation": extracted,
+                "predicted_answer": extracted,
+                "format_ast_is_correct": bool(format_valid and translation_ok),
+            }
+        )
+        return translation_metrics

--- a/nemo_skills/dataset/ntt-complex/ntt_complex_metrics.py
+++ b/nemo_skills/dataset/ntt-complex/ntt_complex_metrics.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Metrics and group scoring for NTT-COMPLEX."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from nemo_skills.evaluation.metrics.audio_metrics import AudioMetrics
+from nemo_skills.evaluation.metrics.base import as_percentage
+
+
+class NTTComplexMetrics(AudioMetrics):
+    """AudioMetrics extension with strict-format success signals."""
+
+    def __init__(self, compute_no_answer: bool = True, max_k: int = 1):
+        super().__init__(compute_no_answer=compute_no_answer, max_k=max_k)
+        self.format_valid = 0
+        self.format_total = 0
+        self.format_ast_correct = 0
+        self.by_format: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    def update(self, predictions):
+        for pred in predictions:
+            if "format_valid" in pred:
+                self.format_total += 1
+                self.format_valid += int(bool(pred["format_valid"]))
+                self.format_ast_correct += int(bool(pred.get("format_ast_is_correct")))
+                self.by_format[str(pred.get("format_id", "unknown"))].append(pred)
+        super().update(predictions)
+
+    def _format_metrics(self) -> dict[str, float]:
+        if self.format_total <= 0:
+            return {}
+        metrics: dict[str, float] = {
+            "format_valid_rate": round(100.0 * self.format_valid / self.format_total, 2),
+            "format_ast_success_rate": round(100.0 * self.format_ast_correct / self.format_total, 2),
+        }
+        for format_id, rows in sorted(self.by_format.items()):
+            if rows:
+                valid = sum(int(bool(row.get("format_valid"))) for row in rows)
+                metrics[f"format_valid_rate/{format_id}"] = round(100.0 * valid / len(rows), 2)
+        return metrics
+
+    def get_metrics(self):
+        metrics_dict = super().get_metrics()
+        for _agg_mode, agg_metrics in metrics_dict.items():
+            agg_metrics.update(self._format_metrics())
+        return metrics_dict
+
+    def metrics_to_print(self):
+        metrics = super().metrics_to_print()
+        if self.format_total > 0:
+            metrics["format_valid_rate"] = as_percentage
+            metrics["format_ast_success_rate"] = as_percentage
+        return metrics
+
+
+def _metrics_for_eval_mode(benchmark_metrics: dict[str, Any], eval_mode: str) -> dict[str, Any] | None:
+    if eval_mode in benchmark_metrics:
+        return benchmark_metrics[eval_mode]
+    all_metrics = benchmark_metrics.get("_all_")
+    if isinstance(all_metrics, dict):
+        return all_metrics.get(eval_mode)
+    return None
+
+
+def compute_score(combined_metrics: dict) -> dict:
+    """Aggregate NTT-COMPLEX subtest results."""
+    benchmarks = {key: value for key, value in combined_metrics.items() if key == "ntt-complex.format_ast"}
+    if not benchmarks:
+        return {}
+
+    eval_modes = set()
+    for benchmark_metrics in benchmarks.values():
+        if "_all_" in benchmark_metrics:
+            eval_modes.update(benchmark_metrics["_all_"].keys())
+        else:
+            eval_modes.update(benchmark_metrics.keys())
+
+    aggregated = {}
+    for eval_mode in sorted(eval_modes):
+        total_entries = 0
+        weighted: dict[str, float] = defaultdict(float)
+        for benchmark_metrics in benchmarks.values():
+            metrics = _metrics_for_eval_mode(benchmark_metrics, eval_mode)
+            if not metrics:
+                continue
+            entries = int(metrics.get("num_entries") or 0)
+            if entries <= 0:
+                continue
+            total_entries += entries
+            for key, value in metrics.items():
+                if key == "num_entries" or not isinstance(value, (int, float)):
+                    continue
+                weighted[key] += float(value) * entries
+        if total_entries <= 0:
+            continue
+        aggregated[eval_mode] = {"num_entries": total_entries}
+        for key, value in weighted.items():
+            aggregated[eval_mode][key] = round(value / total_entries, 2)
+    return aggregated

--- a/nemo_skills/dataset/ntt-complex/prepare.py
+++ b/nemo_skills/dataset/ntt-complex/prepare.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prepare NTT-COMPLEX manifests from already-prepared NeMo-Skills data."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterable
+
+SYSTEM_MESSAGE = "You are a helpful assistant. /no_think"
+DEFAULT_SOURCE_DATA_DIR = (
+    "/home/vmendelev/.cache/saferun/cluster-sshfs/oci_iad/lustre/fs12/portfolios/llmservice/users/"
+    "pzelasko/results/speechlm-2026h1/skills_data"
+)
+
+FORMAT_SPECS = {
+    "json_object": {
+        "name": "JSON object",
+        "prompt": (
+            "Translate the speech to {target_language}. Respond with only a valid JSON object "
+            'with exactly these keys: "source_language", "target_language", "translation". '
+            'Set "translation" to the translated speech.'
+        ),
+    },
+    "srt_single_cue": {
+        "name": "single-cue SRT",
+        "prompt": (
+            "Translate the speech to {target_language}. Respond with only one SRT subtitle cue: "
+            "line 1 must be the cue number 1, line 2 must be "
+            "00:00:00,000 --> 00:00:05,000, and the remaining line must be the translation."
+        ),
+    },
+    "markdown_table": {
+        "name": "Markdown table",
+        "prompt": (
+            "Translate the speech to {target_language}. Respond with only a Markdown table "
+            "with columns source_language, target_language, translation, and exactly one data row."
+        ),
+    },
+}
+
+SOURCE_MANIFEST_CANDIDATES = {
+    "fleurs": ("st/test.jsonl", "ast/test.jsonl"),
+    "covost2": ("st/test.jsonl", "ast/test.jsonl"),
+}
+
+
+def _stable_key(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows = []
+    with open(path, encoding="utf-8") as fin:
+        for line in fin:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def _write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with open(path, "w", encoding="utf-8") as fout:
+        for row in rows:
+            fout.write(json.dumps(row, ensure_ascii=False) + "\n")
+            count += 1
+    return count
+
+
+def _sample(rows: list[dict[str, Any]], count: int, salt: str) -> list[dict[str, Any]]:
+    if count <= 0:
+        return []
+    keyed = sorted(rows, key=lambda row: _stable_key([salt, row.get("id"), row.get("audio_path"), row]))
+    return keyed[: min(count, len(keyed))]
+
+
+def _origin_id(row: dict[str, Any]) -> str:
+    for key in ("id", "sample_id", "uniq_id", "key"):
+        if row.get(key) is not None:
+            return str(row[key])
+    audio_path = row.get("audio_path") or row.get("audio_filepath")
+    if isinstance(audio_path, str):
+        return Path(audio_path).stem
+    return _stable_key(row)[:16]
+
+
+def _source_language(row: dict[str, Any]) -> str:
+    extra_fields = row.get("extra_fields") or {}
+    return str(extra_fields.get("src_lang_name") or extra_fields.get("src_lang") or row.get("language") or "unknown")
+
+
+def _target_language(row: dict[str, Any]) -> str:
+    extra_fields = row.get("extra_fields") or {}
+    return str(extra_fields.get("tgt_lang_name") or extra_fields.get("tgt_lang") or "target language")
+
+
+def _target_lang_code(row: dict[str, Any]) -> str | None:
+    extra_fields = row.get("extra_fields") or {}
+    value = extra_fields.get("tgt_lang")
+    return str(value) if value is not None else None
+
+
+def _reference(row: dict[str, Any]) -> str:
+    return str(row.get("reference") or row.get("expected_answer") or "")
+
+
+def _with_audio_prompt(row: dict[str, Any], prompt: str) -> list[dict[str, Any]]:
+    messages = copy.deepcopy(row.get("messages") or [])
+    if not any(message.get("role") == "system" for message in messages):
+        messages.insert(0, {"role": "system", "content": SYSTEM_MESSAGE})
+
+    audio_meta = None
+    for message in messages:
+        if message.get("role") == "user" and isinstance(message.get("audio"), dict):
+            audio_meta = copy.deepcopy(message["audio"])
+            break
+    if audio_meta is None:
+        audio_path = row.get("audio_path") or row.get("audio_filepath")
+        audio_meta = {"path": audio_path}
+        if row.get("duration") is not None:
+            audio_meta["duration"] = row["duration"]
+
+    for idx, message in enumerate(messages):
+        if message.get("role") == "user":
+            messages[idx] = {"role": "user", "content": prompt, "audio": audio_meta}
+            break
+    else:
+        messages.append({"role": "user", "content": prompt, "audio": audio_meta})
+    return messages
+
+
+def _render_row(row: dict[str, Any], source_dataset: str, origin_manifest: str, format_id: str) -> dict[str, Any]:
+    format_spec = FORMAT_SPECS[format_id]
+    source_language = _source_language(row)
+    target_language = _target_language(row)
+    prompt = format_spec["prompt"].format(target_language=target_language)
+    extra_fields = copy.deepcopy(row.get("extra_fields") or {})
+    extra_fields.setdefault("src_lang_name", source_language)
+    extra_fields.setdefault("tgt_lang_name", target_language)
+    if _target_lang_code(row) is not None:
+        extra_fields.setdefault("tgt_lang", _target_lang_code(row))
+
+    out = copy.deepcopy(row)
+    out.update(
+        {
+            "task_type": "Format-AST",
+            "expected_answer": _reference(row),
+            "reference": _reference(row),
+            "source": row.get("source"),
+            "messages": _with_audio_prompt(row, prompt),
+            "subset_for_metrics": f"format_ast.{format_id}",
+            "ntt_complex_subtest": "format_ast",
+            "format_id": format_id,
+            "format_name": format_spec["name"],
+            "origin_dataset": source_dataset,
+            "origin_manifest": f"{source_dataset}/{origin_manifest}",
+            "origin_id": _origin_id(row),
+            "extra_fields": extra_fields,
+        }
+    )
+    return out
+
+
+def _load_source_rows(source_root: Path, source_dataset: str) -> tuple[str, list[dict[str, Any]]]:
+    for rel_path in SOURCE_MANIFEST_CANDIDATES[source_dataset]:
+        rows = _read_jsonl(source_root / source_dataset / rel_path)
+        if rows:
+            return rel_path, rows
+    return SOURCE_MANIFEST_CANDIDATES[source_dataset][0], []
+
+
+def build_format_ast_rows(source_root: Path, samples_per_source: int, sources: list[str]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for source_dataset in sources:
+        origin_manifest, source_rows = _load_source_rows(source_root, source_dataset)
+        selected = _sample(source_rows, samples_per_source, f"format_ast:{source_dataset}")
+        for source_row in selected:
+            for format_id in FORMAT_SPECS:
+                rows.append(_render_row(source_row, source_dataset, origin_manifest, format_id))
+    return sorted(rows, key=lambda row: _stable_key([row["origin_dataset"], row["origin_id"], row["format_id"]]))
+
+
+def prepare_ntt_complex(
+    data_dir: Path,
+    source_data_dir: Path,
+    samples_per_source: int,
+    sources: list[str],
+) -> None:
+    rows = build_format_ast_rows(source_data_dir, samples_per_source, sources)
+    count = _write_jsonl(data_dir / "format_ast" / "test.jsonl", rows)
+    _write_jsonl(
+        data_dir / "manifest_summary.jsonl",
+        [
+            {
+                "ntt_complex_summary": {
+                    "format_ast": {
+                        "num_entries": count,
+                        "source_data_dir": str(source_data_dir),
+                        "sources": sources,
+                        "formats": list(FORMAT_SPECS),
+                    }
+                }
+            }
+        ],
+    )
+    print(f"Wrote ntt-complex.format_ast: {count} samples")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare NTT-COMPLEX manifests")
+    parser.add_argument(
+        "--source-data-dir",
+        default=os.getenv("NTT_COMPLEX_SOURCE_DATA_DIR") or os.getenv("NEMO_SKILLS_DATA_DIR") or DEFAULT_SOURCE_DATA_DIR,
+        help="Prepared source benchmark root containing fleurs and covost2.",
+    )
+    parser.add_argument("--samples-per-source", type=int, default=200, help="Samples to draw from each source dataset.")
+    parser.add_argument(
+        "--sources",
+        default="fleurs,covost2",
+        help="Comma-separated prepared source datasets to use. Supported: fleurs,covost2.",
+    )
+    parser.add_argument("--output-dir", default=None, help="Override output directory. Defaults to this package directory.")
+    args = parser.parse_args()
+
+    sources = [source.strip() for source in args.sources.split(",") if source.strip()]
+    unknown_sources = sorted(set(sources) - set(SOURCE_MANIFEST_CANDIDATES))
+    if unknown_sources:
+        raise ValueError(f"Unsupported source dataset(s): {', '.join(unknown_sources)}")
+
+    source_data_dir = Path(args.source_data_dir)
+    if not source_data_dir.exists():
+        raise FileNotFoundError(f"Source data root does not exist: {source_data_dir}")
+
+    data_dir = Path(args.output_dir) if args.output_dir else Path(__file__).parent
+    prepare_ntt_complex(
+        data_dir=data_dir,
+        source_data_dir=source_data_dir,
+        samples_per_source=args.samples_per_source,
+        sources=sources,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ntt_complex_format_ast.py
+++ b/tests/test_ntt_complex_format_ast.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module(name: str, rel_path: str):
+    module_path = Path(__file__).parents[1] / rel_path
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_jsonl(path: Path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fout:
+        for row in rows:
+            fout.write(json.dumps(row) + "\n")
+
+
+def _ast_row(row_id: str, dataset: str, src_lang: str, tgt_lang: str):
+    return {
+        "id": row_id,
+        "task_type": "Multilingual-AST",
+        "expected_answer": "hola mundo",
+        "source": "hello world",
+        "reference": "hola mundo",
+        "audio_path": f"/dataset/{dataset}/audio/{row_id}.wav",
+        "duration": 1.0,
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant. /no_think"},
+            {
+                "role": "user",
+                "content": "Please translate the given speech to Spanish.",
+                "audio": {"path": f"/dataset/{dataset}/audio/{row_id}.wav", "duration": 1.0},
+            },
+        ],
+        "subset_for_metrics": f"{src_lang}->{tgt_lang}",
+        "extra_fields": {
+            "src_lang": src_lang,
+            "tgt_lang": tgt_lang,
+            "src_lang_name": "English",
+            "tgt_lang_name": "Spanish",
+        },
+    }
+
+
+def test_prepare_format_ast_manifest(tmp_path):
+    prepare = _load_module("ntt_complex_prepare", "nemo_skills/dataset/ntt-complex/prepare.py")
+    source_root = tmp_path / "source"
+    output_root = tmp_path / "out"
+    _write_jsonl(source_root / "fleurs" / "st" / "test.jsonl", [_ast_row("fleurs-1", "fleurs", "en_us", "es_419")])
+    _write_jsonl(source_root / "covost2" / "ast" / "test.jsonl", [_ast_row("covost2-1", "covost2", "en", "es")])
+
+    prepare.prepare_ntt_complex(
+        data_dir=output_root,
+        source_data_dir=source_root,
+        samples_per_source=1,
+        sources=["fleurs", "covost2"],
+    )
+
+    rows = [
+        json.loads(line)
+        for line in (output_root / "format_ast" / "test.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(rows) == 6
+    assert {row["format_id"] for row in rows} == {"json_object", "srt_single_cue", "markdown_table"}
+    assert {row["origin_dataset"] for row in rows} == {"fleurs", "covost2"}
+    assert all(row["task_type"] == "Format-AST" for row in rows)
+    assert all(row["ntt_complex_subtest"] == "format_ast" for row in rows)
+    assert all(row["messages"][-1]["audio"]["path"].startswith("/dataset/") for row in rows)
+
+
+def test_format_ast_evaluator_extracts_and_scores():
+    eval_mod = _load_module("ntt_complex_eval", "nemo_skills/dataset/ntt-complex/ntt_complex_eval.py")
+    evaluator = eval_mod.NTTComplexEvaluator({"strip_helpful_prefixes": True}, num_parallel_requests=1)
+    sample = _ast_row("sample-1", "fleurs", "en_us", "es_419")
+    sample.update(
+        {
+            "task_type": "Format-AST",
+            "format_id": "json_object",
+            "generation": json.dumps(
+                {
+                    "source_language": "English",
+                    "target_language": "Spanish",
+                    "translation": "hola mundo",
+                }
+            ),
+        }
+    )
+
+    result = asyncio.run(evaluator.eval_single(sample))
+
+    assert result["format_valid"] is True
+    assert result["format_ast_is_correct"] is True
+    assert result["extracted_translation"] == "hola mundo"
+    assert result["pred_text"] == "hola mundo"
+
+
+def test_format_ast_evaluator_flags_invalid_format():
+    eval_mod = _load_module("ntt_complex_eval_invalid", "nemo_skills/dataset/ntt-complex/ntt_complex_eval.py")
+    evaluator = eval_mod.NTTComplexEvaluator({}, num_parallel_requests=1)
+    sample = _ast_row("sample-2", "covost2", "en", "es")
+    sample.update(
+        {
+            "task_type": "Format-AST",
+            "format_id": "markdown_table",
+            "generation": "hola mundo",
+        }
+    )
+
+    result = asyncio.run(evaluator.eval_single(sample))
+
+    assert result["format_valid"] is False
+    assert result["format_ast_is_correct"] is False
+    assert result["format_error"] == "too_few_markdown_rows"


### PR DESCRIPTION
# Add ntt-complex.format_ast benchmark scaffold

## Summary

This PR adds the bootstrap `ntt-complex` benchmark group and its first subtest, `ntt-complex.format_ast`.

`format_ast` evaluates a complex2 task: audio speech translation plus strict output formatting. It renders existing FLEURS and CoVoST2 AST/ST examples into three required output formats:

- `json_object`
- `srt_single_cue`
- `markdown_table`

The evaluator validates the requested structure, extracts the translated text, and scores the extracted translation with the standard audio translation BLEU path.

## Implementation

Added:

- `nemo_skills/dataset/ntt-complex/prepare.py`
- `nemo_skills/dataset/ntt-complex/ntt_complex_eval.py`
- `nemo_skills/dataset/ntt-complex/ntt_complex_metrics.py`
- `nemo_skills/dataset/ntt-complex/README.md`
- `tests/test_ntt_complex_format_ast.py`

The prepare script accepts source manifests from both naming layouts used across the current code and canary-dev references:

- `fleurs/st/test.jsonl` or `fleurs/ast/test.jsonl`
- `covost2/st/test.jsonl` or `covost2/ast/test.jsonl`

## Validation

Local tests on branch `codex/ntt-complex-format-ast`:

```bash
python -m compileall nemo_skills/dataset/ntt-complex tests/test_ntt_complex_format_ast.py
python -m pytest -s tests/test_ntt_complex_format_ast.py
```

Result:

- `3 passed`

Draco/IAD data preflight:

- Workflow: `ntt-complex-format-ast-prepare-preflight-v4-20260618`
- Slurm id: `10226192`
- Config override: `/home/vmendelev/.cache/saferun/runner-packages/runner-cluster-configs/cluster_configs/v0.7.1`
- Generated manifest: `/lustre/fsw/portfolios/llmservice/users/vmendelev/workspace/code/nemo-run/ntt-complex-eval/eval-format-ast/skills_data/ntt-complex/format_ast/test.jsonl`
- Rows: `1200`
- Source balance: `fleurs=600`, `covost2=600`
- Format balance: `json_object=400`, `markdown_table=400`, `srt_single_cue=400`

## Runtime Evaluation Status

Target checkpoint:

```text
/lustre/fs12/portfolios/llmservice/users/pzelasko/results/speechlm-2026h1/0615-h50-r3-thd-id-riva20-ast-suno-cbias10-iad-resumable-buckfix-4node/eval-step-7200
```

The latest successful startup eval was:

- Workflow: `ntt-complex-format-ast-piotr-step7200-eval-v25-open-asr-startup-20260618`
- Slurm app: `10228227`
- Image: `/lustre/fs12/portfolios/llmservice/users/pzelasko/containers/open-asr-nemotron-omni.sqsh`
- Scope: one node, one GPU, `++max_samples=8`
- State: Runner success, `exit_code=0`
- Result: 8 rows generated; `format_valid=0/8`; `format_ast_is_correct=0/8`

The full eval completed successfully:

- Workflow: `ntt-complex-format-ast-piotr-step7200-eval-v26-full-20260618`
- Slurm app: `10228387`
- Output: `/lustre/fsw/portfolios/llmservice/users/vmendelev/workspace/code/nemo-run/ntt-complex-eval/eval-format-ast/evals/piotr_step7200_format_ast_v26_full/eval-results/ntt-complex.format_ast/output.jsonl`
- Result: 1200 rows generated; `format_valid=0/1200`; `format_ast_is_correct=0/1200`; average BLEU `0.2322`
- By format: `json_object` 0/400 valid (`missing_json_object`), `markdown_table` 0/400 valid (`too_few_markdown_rows`), `srt_single_cue` 0/400 valid (`too_few_srt_lines`)
- By source dataset: `covost2` 0/600 valid, average BLEU `0.2450`; `fleurs` 0/600 valid, average BLEU `0.2194`

`latest/iad.yaml` must not be used for this work because it is an unfilled template. The active workflows use the rendered `v0.7.1` config override above.

Hosted Nemotron Omni comparison:

- Probe workflow v2: `ntt-complex-format-ast-hosted-nemotron-omni-api-probe-v2-20260618`
- Probe Slurm app: `10228637`
- Backend/model: hosted NVIDIA Inference API, `nvidia/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`
- Probe result: 6 rows generated; `errors=0`; `format_valid=6/6`; `format_ast_is_correct=2/6`; average BLEU `0.1997`
- Full workflow: `ntt-complex-format-ast-hosted-nemotron-omni-api-full-v1-20260618`
- Full Slurm app: `10228702`
- Full output: `/lustre/fsw/portfolios/llmservice/users/vmendelev/workspace/code/nemo-run/ntt-complex-eval/eval-format-ast/evals/hosted_nemotron_omni_format_ast_full_v1/eval-results/ntt-complex.format_ast/output.jsonl`
- Full result: 1200 rows generated; `errors=0`; `format_valid=1124/1200`; `format_ast_is_correct=120/1200`; average BLEU `0.1118`
- By format: `json_object` 392/400 valid and 44/400 correct; `markdown_table` 332/400 valid and 33/400 correct; `srt_single_cue` 400/400 valid and 43/400 correct.

## PR Handoff

Suggested base:

```text
NVIDIA-NeMo/Skills:codex/ntt-smoke
```

Suggested head:

```text
NVIDIA-NeMo/Skills:codex/ntt-complex-format-ast
```

Branch commit:

```text
e3ce0839a17fa53ab20bb77d63e9a1d7daf2d0bb
```

Browser PR URL:

```text
https://github.com/NVIDIA-NeMo/Skills/pull/1491
```

Qwen Omni comparison status:

- Hosted API probe: `ntt-complex-format-ast-hosted-qwen-omni-model-probe-v1-20260618`, Slurm app `10228800`
- Candidate ids tested: `Qwen/Qwen3-Omni-30B-A3B-Instruct`, `qwen/qwen3-omni-30b-a3b-instruct`, `Qwen/Qwen3-Omni-30B-A3B-Thinking`, `qwen/qwen3-omni-30b-a3b-thinking`
- Result: all hosted candidates returned HTTP 401 `key_model_access_denied` with the available runner key.
- Self-host discovery: internal docs identify `Qwen/Qwen3-Omni-30B-A3B-Instruct` and `vllm_omni.OmniLLM`, but bounded Draco/IAD cache checks did not find the documented Granary chain script, a Qwen3-Omni HF snapshot, or a usable `vllm_omni` runtime/package.
- Required next input: an authorized hosted key or a concrete Draco/IAD self-host runtime path.
