### PR TITLE
Add apex_2025 benchmark

### DIFF
--- a/nemo_skills/dataset/apex_2025/__init__.py
+++ b/nemo_skills/dataset/apex_2025/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+METRICS_TYPE = "math"
+GENERATION_ARGS = "++prompt_config=generic/math ++eval_type=math"

--- a/nemo_skills/dataset/apex_2025/prepare.py
+++ b/nemo_skills/dataset/apex_2025/prepare.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+HF_REPO_ID = "MathArena/apex_2025"
+
+
+def format_entry(entry):
+    return {
+        "problem_idx": entry["problem_idx"],
+        "source": entry["source"],
+        "problem": entry["problem"],
+        "expected_answer": str(entry["answer"]),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout, ensure_ascii=False)
+            fout.write("\n")
+
+
+def main(args):
+    dataset = load_dataset(HF_REPO_ID, split="train")
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+    output_file = data_dir / f"{args.split}.jsonl"
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--split", default="test", choices=("test",), help="Dataset split to process.")
+    args = parser.parse_args()
+    main(args)

--- a/nemo_skills/dataset/apex_2025/prepare.py
+++ b/nemo_skills/dataset/apex_2025/prepare.py
@@ -32,9 +32,11 @@ def format_entry(entry):
 
 
 def write_data_to_file(output_file, data):
+    formatted_entries = [format_entry(entry) for entry in tqdm(data, desc=f"Formatting {output_file.name}")]
+
     with open(output_file, "wt", encoding="utf-8") as fout:
-        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
-            json.dump(format_entry(entry), fout, ensure_ascii=False)
+        for entry in tqdm(formatted_entries, desc=f"Writing {output_file.name}"):
+            json.dump(entry, fout, ensure_ascii=False)
             fout.write("\n")
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -15,6 +15,7 @@
 # tuple of dataset name, available splits and prepared sft files
 DATASETS = [
     ("aime25", ["test"]),
+    ("apex_2025", ["test"]),
     ("math-500", ["test"]),
     ("aime24", ["test"]),
     ("amc23", ["test"]),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `apex_2025` dataset, including math-oriented default settings.
  * Introduced a dataset preparation utility that loads the dataset, formats records into a UTF-8 JSONL file, and supports a configurable output split.
* **Tests**
  * Expanded dataset test coverage to include `apex_2025` for the supported split.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->