### PR TITLE
Add page-precise URL exclusion to Tavily search tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.json
 !greptile.json
 !tests/data/dummy_external_benchmark/benchmark_map.json
+!nemo_skills/mcp/servers/exclude_domains_hle_opus.json
 *.tar.gz
 *.tar
 *.npy

--- a/nemo_skills/mcp/servers/exclude_domains_hle_opus.json
+++ b/nemo_skills/mcp/servers/exclude_domains_hle_opus.json
@@ -1,0 +1,52 @@
+{
+  "_comment": "Got from the Opus tech report (Claude Opus 4.8 System Card): https://www-cdn.anthropic.com/0f0c97ad20d8005706296bd92aa1c27c6b2f4f61/Claude%20Opus%204.8%20System%20Card.pdf -- HLE answer-leak blocklist for the Tavily DirectTavily* tools via exclude_domains_config. type=domain -> hostname ban (exact or subdomain, also passed to Tavily's exclude_domains). type=url_substring -> page-precise: the URL is normalized (drop '/', lowercase) then substring-matched, so a single arxiv id / repo path / article is banned WITHOUT banning the whole domain (github.com, nature.com, x.com, openreview.net, researchgate.net, medium.com, news.ycombinator.com stay usable). The two scale.com entries are anchored ('://scale.com' = apex, '.scale.com' = subdomains) so descale.com is not caught.",
+  "notices": [
+    {
+      "properties": [
+        {"type": "domain", "value": "huggingface.co"},
+        {"type": "domain", "value": "hf.co"},
+        {"type": "domain", "value": "promptfoo.dev"},
+        {"type": "domain", "value": "lastexam.ai"},
+        {"type": "domain", "value": "agi.safe.ai"},
+        {"type": "domain", "value": "askfilo.com"},
+        {"type": "domain", "value": "studocu.com"},
+        {"type": "domain", "value": "coursehero.com"},
+        {"type": "domain", "value": "qiita.com"},
+
+        {"type": "url_substring", "value": "://scale.com"},
+        {"type": "url_substring", "value": ".scale.com"},
+        {"type": "url_substring", "value": "last-exam"},
+        {"type": "url_substring", "value": "hle-exam"},
+
+        {"type": "url_substring", "value": "2501.14249"},
+        {"type": "url_substring", "value": "2507.05241"},
+        {"type": "url_substring", "value": "2508.10173"},
+        {"type": "url_substring", "value": "2510.08959"},
+
+        {"type": "url_substring", "value": "nature.com/articles/s41586-025-09962-4"},
+        {"type": "url_substring", "value": "openreview.net/pdf?id=46UGfq8kMI"},
+        {"type": "url_substring", "value": "openreview.net/pdf/a94b1a66a55ab89d0e45eb8ed891b115db8bf760.pdf"},
+        {"type": "url_substring", "value": "researchgate.net/publication/394488269_Benchmark-Driven_Selection_of_AI_Evidence_from_DeepSeek-R1"},
+        {"type": "url_substring", "value": "researchgate.net/scientific-contributions/Petr-Spelda-2170307851"},
+        {"type": "url_substring", "value": "scribd.com/document/866099862"},
+        {"type": "url_substring", "value": "x.com/tbenst/status/1951089655191122204"},
+        {"type": "url_substring", "value": "x.com/andrewwhite01/status/1948056183115493745"},
+        {"type": "url_substring", "value": "news.ycombinator.com/item?id=44694191"},
+        {"type": "url_substring", "value": "github.com/supaihq/hle"},
+        {"type": "url_substring", "value": "github.com/centerforaisafety/hle"},
+        {"type": "url_substring", "value": "github.com/deepwriter-ai/hle-gemini-3-0"},
+        {"type": "url_substring", "value": "github.com/RUC-NLPIR/WebThinker/blob/main/data/HLE"},
+        {"type": "url_substring", "value": "github.com/hanjanghoon/DEER"},
+        {"type": "url_substring", "value": "github.com/repos/hanjanghoon/DEER"},
+        {"type": "url_substring", "value": "mveteanu/HLE_PDF"},
+        {"type": "url_substring", "value": "medium.com/@82deutschmark/o3-quiet-breakthrough-1bf9f0fobafc84"},
+        {"type": "url_substring", "value": "rahulpowar.medium.com/deepseek-triggers-1-trillion-slump-but-paves-a-bigger-future-for-ai"},
+        {"type": "url_substring", "value": "bincial.com/news/tzTechnology/421026"},
+        {"type": "url_substring", "value": "36kr.com/p/3481854274280581"},
+        {"type": "url_substring", "value": "jb243.github.io/pages/1438"},
+        {"type": "url_substring", "value": "xiaowenz.com/episodes/humanity-last-exam-and-agi"},
+        {"type": "url_substring", "value": "research-collection.ethz.ch/server/api/core/bitstreams/1902b5a9-4209-4529-b278-c258aad557ba/content"}
+      ]
+    }
+  ]
+}

--- a/nemo_skills/mcp/servers/tavily_search_tool.py
+++ b/nemo_skills/mcp/servers/tavily_search_tool.py
@@ -837,7 +837,9 @@ class DirectTavilyGymTool(_DirectTavilyBase):
         if results.get("error"):
             return results["error"]
         results["results"] = [
-            r for r in (results.get("results") or []) if isinstance(r.get("url"), str) and not self._is_url_blocked(r["url"])
+            r
+            for r in (results.get("results") or [])
+            if isinstance(r.get("url"), str) and not self._is_url_blocked(r["url"])
         ]
         return "".join(_postprocess_gym_search_results(results, int(self._config["max_result_chars"])))
 

--- a/nemo_skills/mcp/servers/tavily_search_tool.py
+++ b/nemo_skills/mcp/servers/tavily_search_tool.py
@@ -29,14 +29,20 @@ Configuration:
 
         ++tool_overrides.DirectTavilyBrowserTool.exclude_domains_config=/path/to/exclude_domains.json
 
-    The config file is expected to contain domain-valued notice properties:
+    The config file contains notice properties of two types:
+      - "domain": matched against the URL hostname (exact or subdomain) and also passed to
+        Tavily's API ``exclude_domains``.
+      - "url_substring": matched as a normalized substring of the full URL (drop "/", lowercase).
+        This enables page-precise blocking (e.g. a single arxiv id or repo path) without banning
+        the whole domain. Search results, find_in_page, scroll_page and open/extract all respect it.
 
         {
           "notices": [
             {
               "properties": [
                 {"type": "domain", "value": "example.com"},
-                {"type": "domain", "value": "restricted.example.org"}
+                {"type": "url_substring", "value": "2501.14249"},
+                {"type": "url_substring", "value": "github.com/owner/leak-repo"}
               ]
             }
           ]
@@ -182,7 +188,7 @@ def _parse_exclude_domains(exclude_config: dict[str, Any]) -> list[str]:
     notices = exclude_config["notices"]
     for notice in notices:
         for prop in notice["properties"]:
-            if prop.get("type") == "domain":
+            if prop["type"] == "domain":
                 exclude_domains.append(prop["value"])
     return exclude_domains
 
@@ -191,6 +197,24 @@ def _load_exclude_domains_from_file(path: str) -> list[str]:
     with open(path, "r", encoding="utf-8") as f:
         exclude_config = json.load(f)
     return _parse_exclude_domains(exclude_config)
+
+
+def _parse_exclude_url_substrings(exclude_config: dict[str, Any]) -> list[str]:
+    # Same notice/property structure as domains, but with type "url_substring". These are matched
+    # as substrings against normalized URLs (see _is_url_substring_blocked), which lets a blocklist
+    # target a single page/paper (e.g. one arxiv id) without banning the whole domain.
+    substrings = []
+    for notice in exclude_config["notices"]:
+        for prop in notice["properties"]:
+            if prop["type"] == "url_substring":
+                substrings.append(prop["value"])
+    return substrings
+
+
+def _load_exclude_url_substrings_from_file(path: str) -> list[str]:
+    with open(path, "r", encoding="utf-8") as f:
+        exclude_config = json.load(f)
+    return _parse_exclude_url_substrings(exclude_config)
 
 
 def _normalize_api_keys(value: str | list[str] | tuple[str, ...] | None) -> list[str]:
@@ -282,6 +306,19 @@ def _extract_domain(url: str) -> str:
 def _is_url_excluded(url: str, exclude_domains: list[str]) -> bool:
     hostname = urlparse(url).hostname or ""
     return any(hostname == domain or hostname.endswith("." + domain) for domain in exclude_domains)
+
+
+def _normalize_url_for_substring(value: str) -> str:
+    # Normalization used by the substring blocklist: drop "/" and lowercase, then substring-match.
+    # Mirrors the HLE blocklist methodology so anchored patterns like "://scale.com" behave as intended.
+    return value.replace("/", "").lower()
+
+
+def _is_url_substring_blocked(url: str, exclude_url_substrings: list[str]) -> bool:
+    if not exclude_url_substrings:
+        return False
+    normalized_url = _normalize_url_for_substring(url)
+    return any(_normalize_url_for_substring(pattern) in normalized_url for pattern in exclude_url_substrings)
 
 
 def _cache_key_for_url(url: str) -> str:
@@ -396,6 +433,7 @@ class _DirectTavilyBase(Tool):
             "tavily_api_key": None,
             "api_base_url": DEFAULT_API_BASE_URL,
             "exclude_domains": [],
+            "exclude_url_substrings": [],
             "timeout_s": DEFAULT_HTTP_TIMEOUT_S,
             "max_retries": DEFAULT_MAX_RETRIES,
             "retry_backoff_s": DEFAULT_RETRY_BACKOFF_S,
@@ -405,6 +443,7 @@ class _DirectTavilyBase(Tool):
         self._api_keys: list[str] = []
         self._num_requests = 0
         self._exclude_domains: list[str] = []
+        self._exclude_url_substrings: list[str] = []
         self._sanitize_keys: dict[str, set[str]] = {}
         self.requests_to_metrics: dict[str, TavilySearchMetrics] = defaultdict(TavilySearchMetrics)
 
@@ -428,7 +467,17 @@ class _DirectTavilyBase(Tool):
         self._exclude_domains = list(cfg.get("exclude_domains") or [])
         self._exclude_domains.extend(_load_exclude_domains_from_file(cfg["exclude_domains_config"]))
         self._exclude_domains = sorted(set(self._exclude_domains))
+        self._exclude_url_substrings = list(cfg.get("exclude_url_substrings") or [])
+        self._exclude_url_substrings.extend(_load_exclude_url_substrings_from_file(cfg["exclude_domains_config"]))
+        self._exclude_url_substrings = sorted(set(self._exclude_url_substrings))
         self._sanitize_keys = {tool: set(keys) for tool, keys in cfg.get("hide_args", {}).items()}
+
+    def _is_url_blocked(self, url: str) -> bool:
+        # Blocked if the hostname is in exclude_domains OR the normalized URL contains any
+        # exclude_url_substrings pattern (page-precise blocklist, e.g. a single arxiv id).
+        return _is_url_excluded(url, self._exclude_domains) or _is_url_substring_blocked(
+            url, self._exclude_url_substrings
+        )
 
     async def list_tools(self) -> list[dict[str, Any]]:
         raise NotImplementedError
@@ -784,6 +833,9 @@ class DirectTavilyGymTool(_DirectTavilyBase):
         results = await self._tracked_post_json("/search", payload, request_id=request_id, function="search")
         if results.get("error"):
             return results["error"]
+        results["results"] = [
+            r for r in (results.get("results") or []) if isinstance(r.get("url"), str) and not self._is_url_blocked(r["url"])
+        ]
         return "".join(_postprocess_gym_search_results(results, int(self._config["max_result_chars"])))
 
     async def _find_in_page(self, arguments: dict[str, Any], *, request_id: str | None) -> str:
@@ -795,7 +847,7 @@ class DirectTavilyGymTool(_DirectTavilyBase):
             return "Query is none"
         if not isinstance(url, str) or not isinstance(query, str):
             return "URL and query must be strings"
-        if _is_url_excluded(url, self._exclude_domains):
+        if self._is_url_blocked(url):
             return "URL is in excluded domains"
 
         payload = {
@@ -826,7 +878,7 @@ class DirectTavilyGymTool(_DirectTavilyBase):
             return "URL is none"
         if not isinstance(url, str):
             return "URL must be a string"
-        if _is_url_excluded(url, self._exclude_domains):
+        if self._is_url_blocked(url):
             return "URL is in excluded domains"
 
         start_index, error = _coerce_int_arg(arguments.get("start_index"), 0, "start_index")
@@ -1020,7 +1072,7 @@ class DirectTavilyBrowserTool(DirectTavilyGymTool):
         entries: list[TavilyBrowserSearchMemoryItem] = []
         for result in results.get("results") or []:
             url = result.get("url")
-            if not isinstance(url, str) or not url or _is_url_excluded(url, self._exclude_domains):
+            if not isinstance(url, str) or not url or self._is_url_blocked(url):
                 continue
             snippet = _clean_text(str(result.get("content") or ""))
             snippet, _ = _truncate_text(snippet, max_result_chars)
@@ -1099,7 +1151,7 @@ class DirectTavilyBrowserTool(DirectTavilyGymTool):
     async def _extract_page(
         self, url: str, *, request_id: str | None
     ) -> tuple[TavilyBrowserCachedPage | None, str | None]:
-        if _is_url_excluded(url, self._exclude_domains):
+        if self._is_url_blocked(url):
             self._increment_stat(request_id, "tool_errors")
             self._increment_stat(request_id, "excluded_url_attempts")
             return None, "URL is in excluded domains"

--- a/nemo_skills/mcp/servers/tavily_search_tool.py
+++ b/nemo_skills/mcp/servers/tavily_search_tool.py
@@ -48,6 +48,9 @@ Configuration:
           ]
         }
 
+    A ready-made HLE answer-leak blocklist (from the Claude Opus 4.8 System Card) ships at
+    ``nemo_skills/mcp/servers/exclude_domains_hle_opus.json``.
+
     If these tools are used for training data curation, use an
     organization-approved exclusion registry. This reduces the risk of collecting
     content from domains that must be excluded for legal, license, policy, or

--- a/tests/test_tavily_search_tool.py
+++ b/tests/test_tavily_search_tool.py
@@ -491,3 +491,117 @@ def test_direct_tavily_v3_name_remains_compatible():
 
     assert issubclass(DirectTavilyV3Tool, DirectTavilyBrowserTool)
     assert DirectTavilyV3Tool().__class__.__name__ == "DirectTavilyV3Tool"
+
+
+def test_is_url_substring_blocked_normalizes_and_is_page_precise():
+    from nemo_skills.mcp.servers.tavily_search_tool import _is_url_substring_blocked, _normalize_url_for_substring
+
+    assert _normalize_url_for_substring("GitHub.com/Foo/Bar") == "github.comfoobar"
+
+    # Page-precise: block the HLE paper / specific repo, but NOT the rest of arxiv / github.
+    patterns = ["2501.14249", "github.com/centerforaisafety/hle", "://scale.com", ".scale.com", "last-exam"]
+    assert _is_url_substring_blocked("https://arxiv.org/abs/2501.14249", patterns)
+    assert not _is_url_substring_blocked("https://arxiv.org/abs/1706.03762", patterns)
+    assert _is_url_substring_blocked("https://github.com/centerforaisafety/hle", patterns)
+    assert not _is_url_substring_blocked("https://github.com/pytorch/pytorch", patterns)
+    # Anchored "://scale.com" matches scale.com but not descale.com.
+    assert _is_url_substring_blocked("https://scale.com/leaderboard", patterns)
+    assert not _is_url_substring_blocked("https://descale.com/page", patterns)
+    # Plain substring.
+    assert _is_url_substring_blocked("https://blog.example/the-last-exam-answers", patterns)
+    # No patterns -> nothing blocked.
+    assert not _is_url_substring_blocked("https://arxiv.org/abs/2501.14249", [])
+
+
+@pytest.fixture
+def exclude_url_substrings_config(tmp_path):
+    exclude_file = tmp_path / "exclude_substr.json"
+    exclude_file.write_text(
+        json.dumps(
+            {
+                "notices": [
+                    {
+                        "properties": [
+                            {"type": "domain", "value": "blocked.example"},
+                            {"type": "url_substring", "value": "2501.14249"},
+                            {"type": "url_substring", "value": "github.com/centerforaisafety/hle"},
+                        ]
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(exclude_file)
+
+
+def test_tool_loads_exclude_url_substrings_from_config(exclude_url_substrings_config):
+    from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilySearchTool
+
+    tool = DirectTavilySearchTool()
+    tool.configure({"tavily_api_key": "test-key", "exclude_domains_config": exclude_url_substrings_config})
+
+    assert tool._exclude_domains == ["blocked.example"]
+    assert tool._exclude_url_substrings == ["2501.14249", "github.com/centerforaisafety/hle"]
+    # Substring patterns and the (separate) domain list both feed _is_url_blocked.
+    assert tool._is_url_blocked("https://arxiv.org/abs/2501.14249")
+    assert tool._is_url_blocked("https://sub.blocked.example/x")
+    assert not tool._is_url_blocked("https://arxiv.org/abs/1706.03762")
+
+
+def test_browser_web_search_filters_url_substring_results(exclude_url_substrings_config):
+    async def run_test():
+        from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyBrowserTool
+
+        tool = DirectTavilyBrowserTool()
+        tool.configure({"tavily_api_key": "test-key", "exclude_domains_config": exclude_url_substrings_config})
+
+        async def fake_post_json(endpoint, payload):
+            return {
+                "results": [
+                    {"url": "https://arxiv.org/abs/2501.14249", "title": "HLE Paper", "content": "leak"},
+                    {"url": "https://arxiv.org/abs/1706.03762", "title": "Attention Is All You Need", "content": "ok"},
+                ]
+            }
+
+        tool._post_json = fake_post_json
+
+        result = await tool.execute("web_search", {"query": "humanity last exam"}, extra_args={"request_id": "req"})
+        assert "Attention Is All You Need" in result
+        assert "HLE Paper" not in result
+        assert "2501.14249" not in result
+
+        # Opening / extracting the blocked page is refused too.
+        blocked = await tool.execute(
+            "find_in_page",
+            {"url": "https://arxiv.org/abs/2501.14249", "query": "answer"},
+            extra_args={"request_id": "req"},
+        )
+        assert "excluded domains" in str(blocked)
+
+    asyncio.run(run_test())
+
+
+def test_gym_web_search_filters_url_substring_results(exclude_url_substrings_config):
+    async def run_test():
+        from nemo_skills.mcp.servers.tavily_search_tool import DirectTavilyGymTool
+
+        tool = DirectTavilyGymTool()
+        tool.configure({"tavily_api_key": "test-key", "exclude_domains_config": exclude_url_substrings_config})
+
+        async def fake_post_json(endpoint, payload):
+            return {
+                "results": [
+                    {"url": "https://github.com/centerforaisafety/hle", "title": "HLE repo", "content": "leak"},
+                    {"url": "https://example.com/ok", "title": "Allowed", "content": "fine"},
+                ]
+            }
+
+        tool._post_json = fake_post_json
+
+        result = await tool.execute("web_search", {"query": "hle"}, extra_args={"request_id": "req"})
+        assert "Allowed" in result
+        assert "HLE repo" not in result
+        assert "centerforaisafety" not in result
+
+    asyncio.run(run_test())


### PR DESCRIPTION
Lets a blocklist target a single page/paper (e.g. one arxiv id) without banning the whole domain. url_substring patterns load from the same exclude config as domains and apply to both search results and page access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL blocking by supporting both excluded domains and configurable URL substrings.
  * Made URL substring/domain matching more consistent via normalization, reducing accidental over-matching.
  * Applied the same blocking rules across search filtering and page open/extract/scroll flows.
* **Tests**
  * Added coverage for URL substring normalization, precise matching, and enforcement across tool paths.
* **Documentation / Chores**
  * Updated URL blocking documentation to describe substring semantics and added the HLE exclude/blocklist configuration (with updated ignore rules).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->