### PR TITLE
High-throughput async inference: native aiohttp fast-path, scalable async loop, and routing keys

### DIFF
--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -27,7 +27,7 @@ litellm[caching]==1.83.14
 math-verify[antlr4_9_3]
 mcp
 numpy
-openai
+openai[aiohttp]
 openpyxl>=3.1.0
 pandas>=2.0.0
 pyxlsb>=1.0.10

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -423,6 +423,11 @@ class GenerationTask:
 
         # output_lock will be initialized when async_loop is called
         self.output_lock = None
+        # Dedicated writer queue. Set when async_loop enters; tasks
+        # enqueue here instead of acquiring output_lock per
+        # completion. None when not in async_loop (the old path is
+        # used as fallback by other entrypoints like prover.py).
+        self._output_queue = None
 
     def setup_prompt(self):
         if self.cfg.prompt_config is None:
@@ -869,10 +874,24 @@ class GenerationTask:
         if self.should_run_evaluation and self.evaluator:
             output = await self.evaluate_single_datapoint({**data_point, **output})
 
-        # Thread-safe output writing
-        async with self.output_lock:
-            self.dump_outputs([output], [data_point], fout)
-            pbar.update(1)
+        # Hand the completion off to the writer task. This is a
+        # cheap asyncio.Queue.put -- no file I/O, no lock-protected
+        # critical section per task. Previously this was an
+        # output_lock + dump_outputs + pbar.update inside the lock,
+        # which serialized one fout.write + flush per completion.
+        # At line-buffered I/O (buffering=1, set on `open`) every
+        # write was a flush syscall, capping throughput at the lock-
+        # hold time (~12-16ms) regardless of concurrency. The new
+        # writer task batches and flushes periodically; per-completion
+        # cost on the hot path is a queue put.
+        if self._output_queue is not None:
+            await self._output_queue.put((output, data_point))
+        else:
+            # Fallback (e.g. async_loop wasn't entered through the
+            # writer-task path): old lock-protected write.
+            async with self.output_lock:
+                self.dump_outputs([output], [data_point], fout)
+                pbar.update(1)
 
     async def async_loop(self, data):
         """Async loop to generate generations using asyncio."""
@@ -895,7 +914,15 @@ class GenerationTask:
 
         pbar = tqdm(total=len(remaining_data_points), desc="Remaining generations")
 
-        with open(self.cfg.output_file + "-async", "at", encoding="utf-8", buffering=1) as fout:
+        # Default Python buffering (8KB on most platforms). The
+        # previous `buffering=1` forced a kernel flush on every
+        # newline -- combined with the per-completion output_lock,
+        # that flush became the throughput bottleneck (~60-80/sec
+        # cap regardless of client concurrency). The writer task
+        # below issues an explicit fout.flush() after every batch
+        # drained from the queue, so durability is preserved without
+        # paying for a syscall per record.
+        with open(self.cfg.output_file + "-async", "at", encoding="utf-8") as fout:
             # Dump prefilled data first
             if len(prefilled_data_points) > 0:
                 for output, data_point in zip(prefilled_outputs, prefilled_data_points):
@@ -906,6 +933,48 @@ class GenerationTask:
                         output = await self.evaluate_single_datapoint({**data_point, **output})
                 async with self.output_lock:
                     self.dump_outputs(prefilled_outputs, prefilled_data_points, fout)
+
+            # Dedicated writer coroutine. Drains completed records
+            # from self._output_queue, writes them to fout (one
+            # json.dumps per record), and flushes after each batch.
+            # The per-task hot path is now a single
+            # asyncio.Queue.put -- no lock contention, no per-record
+            # flush.
+            #
+            # The queue is sized comfortably above max_in_flight so
+            # producer puts never block in steady state. A `None`
+            # sentinel signals shutdown.
+            self._output_queue = asyncio.Queue(maxsize=max(self.cfg.max_concurrent_requests * 2, 1024))
+
+            async def _writer():
+                # Drain in batches: pull one item (blocking), then
+                # opportunistically drain any others already in the
+                # queue without blocking, write them all, and flush
+                # once at the end. Throughput scales with completion
+                # rate, not per-record syscall cost.
+                while True:
+                    item = await self._output_queue.get()
+                    if item is None:
+                        return
+                    batch = [item]
+                    # Drain anything that's already enqueued.
+                    while not self._output_queue.empty():
+                        nxt = self._output_queue.get_nowait()
+                        if nxt is None:
+                            # Sentinel mid-batch: write what we have
+                            # and exit after.
+                            for o, _dp in batch:
+                                fout.write(json.dumps(o) + "\n")
+                            pbar.update(len(batch))
+                            fout.flush()
+                            return
+                        batch.append(nxt)
+                    for o, _dp in batch:
+                        fout.write(json.dumps(o) + "\n")
+                    pbar.update(len(batch))
+                    fout.flush()
+
+            writer_task = asyncio.create_task(_writer())
 
             # Bounded worker pool. At most `max_in_flight` tasks
             # exist at any moment; as each one completes we spawn the
@@ -978,6 +1047,14 @@ class GenerationTask:
                     except StopIteration:
                         continue
                     in_flight.add(asyncio.create_task(_safe_one(dp)))
+
+            # Signal writer to drain remaining items and exit, then
+            # wait for it. The sentinel is consumed mid-batch by the
+            # writer's drain loop, which guarantees all already-
+            # enqueued items are flushed before return.
+            await self._output_queue.put(None)
+            await writer_task
+            self._output_queue = None
 
             pbar.close()
 

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -132,13 +132,22 @@ class GenerationTaskConfig:
     # simultaneously -- the kernel accept queue on the receiving end
     # (typically capped at net.core.somaxconn=4096) can briefly
     # overflow and SYN-drop the excess. Limiting the ramp rate so
-    # each ~250-connection burst is followed by a short pause keeps
-    # the accept queue draining cleanly.
+    # each ~ramp_rate/4-connection burst is followed by a short pause
+    # keeps the accept queue draining cleanly.
+    #
+    # Default 4000/sec accounts for ns generate's per-task pre-work
+    # (format_prompt, build litellm request, semaphore acquires) --
+    # the time from asyncio.create_task to "TCP request fired" is
+    # significant, so the configured task-creation rate has to be
+    # higher than the SYN rate you actually want at the kernel.
+    # Each burst is still ramp_rate/4 SYNs (1000 at default), well
+    # under net.core.somaxconn=4096.
+    #
     # Set to 0 (or negative) to disable ramping and prime
     # instantaneously. The transient-retry logic in
-    # BaseModel.generate_async would still cover the resulting SYN
+    # BaseModel.generate_async would still cover any resulting SYN
     # drops; the ramp just makes them not happen in the first place.
-    ramp_rate_per_sec: int = 1000
+    ramp_rate_per_sec: int = 4000
     # chunk the dataset into equal sized parts and index into them
     num_chunks: int | None = None  # if specified, will split the data into chunks and only generate for one chunk
     chunk_id: int | None = None  # if specified, will index the specified chunk only

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -15,11 +15,30 @@
 import asyncio
 import json
 import logging
+import os
 import random
 import shutil
 import subprocess
 import sys
 import time
+
+# uvloop is a drop-in replacement for asyncio's default event loop
+# that's ~2-4x faster on CPU-bound asyncio workloads. ns generate's
+# async_loop at high concurrency (5k+ lanes) becomes CPU-bound on
+# the event loop's per-task scheduling overhead -- not on actual
+# Python work in user code. Installing uvloop closes that gap so
+# the bounded pool can refill at the rate the upstream can sustain
+# instead of the rate one Python thread can scheduler-switch.
+#
+# Set NEMO_SKILLS_DISABLE_UVLOOP=1 to opt out (useful if a tool in
+# the stack assumes selector loop semantics; rare).
+if not os.environ.get("NEMO_SKILLS_DISABLE_UVLOOP"):
+    try:
+        import uvloop
+
+        uvloop.install()
+    except ImportError:
+        pass
 from copy import deepcopy
 from dataclasses import asdict, field, is_dataclass
 from pathlib import Path
@@ -148,6 +167,24 @@ class GenerationTaskConfig:
     # BaseModel.generate_async would still cover any resulting SYN
     # drops; the ramp just makes them not happen in the first place.
     ramp_rate_per_sec: int = 4000
+    # Number of background coroutines that postprocess + (optionally)
+    # evaluate completed datapoints. The async loop's bounded worker
+    # pool used to keep each lane "alive" (occupying a slot) until
+    # postprocess + evaluate + queue.put all completed -- which
+    # serialized those steps with the next HTTP refill. For
+    # reasoning-heavy workloads the per-lane post-HTTP work is small
+    # in absolute terms (~ms per record) but multiplied across
+    # thousands of lanes it can keep the bounded-pool slot occupied
+    # while real HTTP capacity sits idle. Moving postprocess + eval
+    # to a separate processor pool lets the lane exit the moment
+    # generate_async returns, so the bounded pool refills with the
+    # next datapoint immediately.
+    #
+    # Default 16 is enough headroom for synchronous postprocess (no
+    # eval) at >3k records/sec. If you enable an LLM-judge evaluator
+    # inside generate, raise this to match the eval concurrency you
+    # want.
+    postprocess_workers: int = 16
     # chunk the dataset into equal sized parts and index into them
     num_chunks: int | None = None  # if specified, will split the data into chunks and only generate for one chunk
     chunk_id: int | None = None  # if specified, will index the specified chunk only
@@ -432,10 +469,13 @@ class GenerationTask:
 
         # output_lock will be initialized when async_loop is called
         self.output_lock = None
-        # Dedicated writer queue. Set when async_loop enters; tasks
-        # enqueue here instead of acquiring output_lock per
-        # completion. None when not in async_loop (the old path is
-        # used as fallback by other entrypoints like prover.py).
+        # Three-stage pipeline queues (set by async_loop):
+        #   _raw_queue:    lanes -> processors  (un-postprocessed outputs)
+        #   _output_queue: processors -> writer (ready-to-write records)
+        # None outside of async_loop; _generate_and_save_datapoint
+        # falls back to inline postprocess + locked write in that
+        # case (used by entrypoints like prover.py).
+        self._raw_queue = None
         self._output_queue = None
 
     def setup_prompt(self):
@@ -877,27 +917,20 @@ class GenerationTask:
             output["generation_end_time"] = end_time
             output["generation_time"] = end_time - start_time
 
-        await self.postprocess_single_output(output, data_point)
-
-        # evaluate single-data point if requested and evaluator supports that
-        if self.should_run_evaluation and self.evaluator:
-            output = await self.evaluate_single_datapoint({**data_point, **output})
-
-        # Hand the completion off to the writer task. This is a
-        # cheap asyncio.Queue.put -- no file I/O, no lock-protected
-        # critical section per task. Previously this was an
-        # output_lock + dump_outputs + pbar.update inside the lock,
-        # which serialized one fout.write + flush per completion.
-        # At line-buffered I/O (buffering=1, set on `open`) every
-        # write was a flush syscall, capping throughput at the lock-
-        # hold time (~12-16ms) regardless of concurrency. The new
-        # writer task batches and flushes periodically; per-completion
-        # cost on the hot path is a queue put.
-        if self._output_queue is not None:
-            await self._output_queue.put((output, data_point))
+        # Hand the raw (un-postprocessed) completion off to the
+        # processor pool. The bounded-pool slot in async_loop frees
+        # the moment this coroutine returns, so the next datapoint
+        # can begin its HTTP request immediately. Postprocess +
+        # evaluate run in the processor pool; the writer task drains
+        # processed records to disk in batches.
+        if self._raw_queue is not None:
+            await self._raw_queue.put((output, data_point))
         else:
-            # Fallback (e.g. async_loop wasn't entered through the
-            # writer-task path): old lock-protected write.
+            # Fallback path (async_loop not entered through the
+            # processor/writer split). Run synchronously inline.
+            await self.postprocess_single_output(output, data_point)
+            if self.should_run_evaluation and self.evaluator:
+                output = await self.evaluate_single_datapoint({**data_point, **output})
             async with self.output_lock:
                 self.dump_outputs([output], [data_point], fout)
                 pbar.update(1)
@@ -943,17 +976,48 @@ class GenerationTask:
                 async with self.output_lock:
                     self.dump_outputs(prefilled_outputs, prefilled_data_points, fout)
 
-            # Dedicated writer coroutine. Drains completed records
-            # from self._output_queue, writes them to fout (one
-            # json.dumps per record), and flushes after each batch.
-            # The per-task hot path is now a single
-            # asyncio.Queue.put -- no lock contention, no per-record
-            # flush.
+            # Three-stage pipeline:
             #
-            # The queue is sized comfortably above max_in_flight so
-            # producer puts never block in steady state. A `None`
-            # sentinel signals shutdown.
-            self._output_queue = asyncio.Queue(maxsize=max(self.cfg.max_concurrent_requests * 2, 1024))
+            #   lanes ── raw_queue ──> processors ── write_queue ──> writer
+            #
+            # `lanes` are the bounded-pool tasks below; each one does
+            # one HTTP call and exits the instant the response is
+            # parsed. `processors` is a small pool of background
+            # coroutines that run postprocess_single_output and
+            # (optionally) evaluate_single_datapoint -- both of which
+            # used to run INSIDE the lane, holding its bounded-pool
+            # slot for ~5-10ms past the HTTP return for postprocess
+            # alone, and seconds or more if an LLM-judge evaluator
+            # was attached. Decoupling them lets the lane refill
+            # instantly. `writer` batches processed records and
+            # flushes once per batch.
+            #
+            # Queue sizes are picked so producer puts never block in
+            # steady state. A `None` sentinel propagates through each
+            # stage on shutdown.
+            queue_cap = max(self.cfg.max_concurrent_requests * 2, 1024)
+            self._raw_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_cap)
+            self._output_queue = asyncio.Queue(maxsize=queue_cap)
+            num_processors = max(1, int(self.cfg.postprocess_workers))
+
+            async def _processor():
+                # Drain raw_queue, postprocess (+ evaluate), forward
+                # to output_queue. A `None` sentinel terminates this
+                # worker; the dispatcher below pushes one sentinel
+                # per worker.
+                while True:
+                    item = await self._raw_queue.get()
+                    if item is None:
+                        return
+                    output, data_point = item
+                    try:
+                        await self.postprocess_single_output(output, data_point)
+                        if self.should_run_evaluation and self.evaluator:
+                            output = await self.evaluate_single_datapoint({**data_point, **output})
+                    except Exception:
+                        pos = data_point.get(self.cfg.async_position_key, "?")
+                        LOG.exception("postprocess/evaluate failed for async_pos=%s", pos)
+                    await self._output_queue.put((output, data_point))
 
             async def _writer():
                 # Drain in batches: pull one item (blocking), then
@@ -970,8 +1034,6 @@ class GenerationTask:
                     while not self._output_queue.empty():
                         nxt = self._output_queue.get_nowait()
                         if nxt is None:
-                            # Sentinel mid-batch: write what we have
-                            # and exit after.
                             for o, _dp in batch:
                                 fout.write(json.dumps(o) + "\n")
                             pbar.update(len(batch))
@@ -983,6 +1045,7 @@ class GenerationTask:
                     pbar.update(len(batch))
                     fout.flush()
 
+            processor_tasks = [asyncio.create_task(_processor()) for _ in range(num_processors)]
             writer_task = asyncio.create_task(_writer())
 
             # Bounded worker pool. At most `max_in_flight` tasks
@@ -1057,12 +1120,20 @@ class GenerationTask:
                         continue
                     in_flight.add(asyncio.create_task(_safe_one(dp)))
 
-            # Signal writer to drain remaining items and exit, then
-            # wait for it. The sentinel is consumed mid-batch by the
-            # writer's drain loop, which guarantees all already-
-            # enqueued items are flushed before return.
+            # Shutdown sequence: cascade sentinels through the
+            # pipeline so every in-flight record is flushed.
+            #   1. Put one None on raw_queue per processor -- each
+            #      processor exits after seeing its sentinel.
+            #   2. Wait for all processors. Any record put on
+            #      output_queue by a processor is already there.
+            #   3. Put one None on output_queue -- writer drains
+            #      whatever's queued ahead of it, then exits.
+            for _ in range(num_processors):
+                await self._raw_queue.put(None)
+            await asyncio.gather(*processor_tasks)
             await self._output_queue.put(None)
             await writer_task
+            self._raw_queue = None
             self._output_queue = None
 
             pbar.close()

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -125,6 +125,20 @@ class GenerationTaskConfig:
     # maximum number of concurrent requests to the server for the async loop
     # if sync loop is used, this is the batch size
     max_concurrent_requests: int = 512
+    # Rate at which the async loop opens NEW HTTP connections during
+    # initial prime (target connections per second). The bounded
+    # worker pool would otherwise spawn `max_concurrent_requests`
+    # tasks in a tight loop, each opening a TCP connection nearly
+    # simultaneously -- the kernel accept queue on the receiving end
+    # (typically capped at net.core.somaxconn=4096) can briefly
+    # overflow and SYN-drop the excess. Limiting the ramp rate so
+    # each ~250-connection burst is followed by a short pause keeps
+    # the accept queue draining cleanly.
+    # Set to 0 (or negative) to disable ramping and prime
+    # instantaneously. The transient-retry logic in
+    # BaseModel.generate_async would still cover the resulting SYN
+    # drops; the ramp just makes them not happen in the first place.
+    ramp_rate_per_sec: int = 1000
     # chunk the dataset into equal sized parts and index into them
     num_chunks: int | None = None  # if specified, will split the data into chunks and only generate for one chunk
     chunk_id: int | None = None  # if specified, will index the specified chunk only
@@ -924,11 +938,30 @@ class GenerationTask:
             data_iter = iter(remaining_data_points)
             in_flight: set = set()
 
-            # Prime the pool up to the concurrency cap.
+            # Prime the pool up to the concurrency cap, with rate-
+            # limited ramp so we don't open all max_in_flight TCP
+            # connections in a microsecond burst.
+            ramp_rate = self.cfg.ramp_rate_per_sec
+            if ramp_rate > 0:
+                # Spawn in batches sized so the implied pause is
+                # ~250ms -- short enough not to extend wall-time
+                # noticeably (target_depth=20k at 1000/s = 20s
+                # ramp), long enough for the kernel accept queue
+                # to drain between bursts.
+                ramp_batch = max(50, ramp_rate // 4)
+                ramp_interval = ramp_batch / ramp_rate
+            else:
+                ramp_batch = max_in_flight  # instant prime
+                ramp_interval = 0.0
+
+            primed = 0
             for dp in data_iter:
                 in_flight.add(asyncio.create_task(_safe_one(dp)))
-                if len(in_flight) >= max_in_flight:
+                primed += 1
+                if primed >= max_in_flight:
                     break
+                if ramp_interval > 0 and primed % ramp_batch == 0:
+                    await asyncio.sleep(ramp_interval)
 
             # Refill as tasks complete. asyncio.wait with
             # FIRST_COMPLETED returns as soon as ANY task finishes,

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -893,15 +893,58 @@ class GenerationTask:
                 async with self.output_lock:
                     self.dump_outputs(prefilled_outputs, prefilled_data_points, fout)
 
-            # Create tasks for all remaining data points
-            tasks = []
-            for data_point in remaining_data_points:
-                task = asyncio.create_task(self._generate_and_save_datapoint(data_point, data, fout, pbar))
-                tasks.append(task)
+            # Bounded worker pool. At most `max_in_flight` tasks
+            # exist at any moment; as each one completes we spawn the
+            # next datapoint's task. Memory is O(in_flight), not
+            # O(total inputs), so the loop runs cleanly on 100k/1M+
+            # input files without preallocating a coroutine frame
+            # for each.
+            #
+            # Was: tasks = [asyncio.create_task(...) for dp in data]
+            # That created ALL coroutines upfront. At a 100k input
+            # file and ~1-5 KB per coroutine frame (closure + Task
+            # bookkeeping) the upfront allocation was 100-500 MB --
+            # avoidable memory pressure when co-located with other
+            # services. The outer semaphore inside each task bounded
+            # in-flight requests but didn't help that upfront cost.
+            #
+            # Each task is wrapped in a try/except so a single
+            # exception doesn't crash the whole gather (the old
+            # default behavior was first-exception-wins, killing
+            # all other in-flight datapoints).
+            max_in_flight = self.cfg.max_concurrent_requests
 
-            # Wait for all tasks to complete
-            if tasks:
-                await asyncio.gather(*tasks)
+            async def _safe_one(dp):
+                try:
+                    await self._generate_and_save_datapoint(dp, data, fout, pbar)
+                except Exception:
+                    pos = dp.get(self.cfg.async_position_key, "?")
+                    LOG.exception("datapoint async_pos=%s crashed", pos)
+
+            data_iter = iter(remaining_data_points)
+            in_flight: set = set()
+
+            # Prime the pool up to the concurrency cap.
+            for dp in data_iter:
+                in_flight.add(asyncio.create_task(_safe_one(dp)))
+                if len(in_flight) >= max_in_flight:
+                    break
+
+            # Refill as tasks complete. asyncio.wait with
+            # FIRST_COMPLETED returns as soon as ANY task finishes,
+            # which lets us start a fresh task immediately rather
+            # than waiting for the whole batch.
+            while in_flight:
+                done, in_flight = await asyncio.wait(
+                    in_flight,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for _ in done:
+                    try:
+                        dp = next(data_iter)
+                    except StopIteration:
+                        continue
+                    in_flight.add(asyncio.create_task(_safe_one(dp)))
 
             pbar.close()
 

--- a/nemo_skills/inference/model/azure.py
+++ b/nemo_skills/inference/model/azure.py
@@ -19,6 +19,9 @@ from .openai import OpenAIModel
 
 class AzureOpenAIModel(OpenAIModel):
     MODEL_PROVIDER = "azure"
+    # Azure uses a different endpoint layout + api-version/api-key auth that a
+    # plain AsyncOpenAI client can't target; keep it on litellm.
+    SUPPORTS_NATIVE_OPENAI = False
 
     def __init__(
         self,

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -399,6 +399,24 @@ class BaseModel:
         if hasattr(choice.message, "reasoning_content") and choice.message.reasoning_content:
             result["reasoning_content"] = choice.message.reasoning_content
 
+        # Dump the full usage object verbatim into the output. Keeping
+        # None-valued fields (rather than excluding them) preserves the
+        # distinction between "server explicitly sent null" and "field
+        # was absent" — both can be meaningful (e.g. some providers
+        # send prompt_tokens_details=null when there's no cache hit).
+        try:
+            result["usage"] = response.usage.model_dump()
+        except AttributeError:
+            # Older or non-pydantic usage objects: fall back to dict().
+            try:
+                result["usage"] = dict(response.usage)
+            except Exception:
+                result["usage"] = {
+                    "prompt_tokens": getattr(response.usage, "prompt_tokens", None),
+                    "completion_tokens": getattr(response.usage, "completion_tokens", None),
+                    "total_tokens": getattr(response.usage, "total_tokens", None),
+                }
+
         # Extract detailed token breakdown for reasoning models if available
         if hasattr(response.usage, "completion_tokens_details") and response.usage.completion_tokens_details:
             details = response.usage.completion_tokens_details

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -95,6 +95,17 @@ class BaseModel:
         output_dir: str | None = None,
         # Request tokenizer initialization independent of soft_fail
         require_tokenizer: bool = False,
+        # Max in-flight HTTP requests gated by an internal semaphore.
+        # The semaphore was originally added because earlier
+        # combinations of httpx + litellm would hang under truly
+        # unbounded concurrency. Modern httpx (>=0.27) handles this
+        # fine, so the default is now high enough to effectively be
+        # "no internal limit" -- the script-level concurrency knob
+        # (generate.py `max_concurrent_requests`) is the single
+        # user-facing cap. Override via $NEMO_SKILLS_MODEL_CONCURRENCY
+        # only if you have a specific reason to throttle BELOW the
+        # script-level cap.
+        concurrent_requests_limit: int = int(os.environ.get("NEMO_SKILLS_MODEL_CONCURRENCY", "65536")),
     ):
         self._tunnel = None
         self.model_name_or_path = model
@@ -169,7 +180,7 @@ class BaseModel:
         litellm.aclient_session = httpx.AsyncClient(limits=httpx_limits)
         # Controlling concurrent requests using semaphore since large
         # concurrent requests result into httpx hanging
-        self.concurrent_semaphore = asyncio.Semaphore(2048)
+        self.concurrent_semaphore = asyncio.Semaphore(concurrent_requests_limit)
 
     def _get_api_key(self, api_key: str | None, api_key_env_var: str | None, base_url: str) -> str | None:
         if api_key:  # explicit cmd argument always takes precedence
@@ -289,9 +300,23 @@ class BaseModel:
             "response_format": response_format,
         }
 
-        # TODO: remove this after we no longer use gpt-oss or it's fixed in vllm
+        # Two separate retry budgets:
+        # - bad_request_count is for the gpt-oss "output messages"
+        #   bug; small, app-level. Kept as-is until we drop that
+        #   model (or vLLM fixes it upstream).
+        # - transient_count handles socket-level failures that the
+        #   raw HTTP path can hit under burst load (kernel SYN-drops
+        #   when the accept queue overflows, brief upstream
+        #   unavailability during worker turnover, etc). litellm's
+        #   own max_retries covers HTTP 429/5xx but NOT these
+        #   connection-class exceptions, so a single ramp-up burst
+        #   into the upstream could otherwise hard-fail individual
+        #   datapoints. Retries here turn those into invisible
+        #   ~50-200ms re-tries.
         max_retries = 2
         retry_count = 0
+        max_transient_retries = int(os.environ.get("NEMO_SKILLS_TRANSIENT_RETRIES", "3"))
+        transient_count = 0
 
         async with self.concurrent_semaphore:
             while retry_count <= max_retries:
@@ -348,6 +373,41 @@ class BaseModel:
                         }
                     else:
                         raise e
+                except (
+                    httpx.ConnectError,
+                    httpx.ReadError,
+                    httpx.RemoteProtocolError,
+                    httpx.PoolTimeout,
+                    httpx.NetworkError,
+                    openai.APIConnectionError,
+                    ConnectionError,
+                    ConnectionResetError,
+                ) as e:
+                    # Transient socket-level failure. Common cause at
+                    # high concurrency: kernel SYN-drop during ramp-up
+                    # when the upstream accept queue briefly overflows.
+                    # Backoff doubles each retry (50ms, 100ms, 200ms)
+                    # to let the accept queue drain.
+                    if transient_count < max_transient_retries:
+                        transient_count += 1
+                        backoff = 0.05 * (2 ** (transient_count - 1))
+                        LOG.warning(
+                            "transient connect error, retry %d/%d after %.0fms: %s: %s",
+                            transient_count,
+                            max_transient_retries,
+                            backoff * 1000,
+                            type(e).__name__,
+                            e,
+                        )
+                        await asyncio.sleep(backoff)
+                        continue
+                    LOG.error(
+                        "transient connect error after %d retries, propagating: %s: %s",
+                        max_transient_retries,
+                        type(e).__name__,
+                        e,
+                    )
+                    raise
 
         return result
 

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -74,6 +74,14 @@ class BaseModel:
     # Litellm provider name
     MODEL_PROVIDER = "openai"
 
+    # Whether this model may use the native AsyncOpenAI + aiohttp fast-path
+    # (see __init__). Only OpenAI-compatible endpoints that speak the plain
+    # /v1/chat/completions schema at self.base_url can opt in. Subclasses that
+    # talk to a non-OpenAI server (megatron), a differently-authed endpoint
+    # (azure), a non-OpenAI provider (gemini), or need litellm's request
+    # rewriting (multimodal audio) leave this False and stay on litellm.
+    SUPPORTS_NATIVE_OPENAI = False
+
     def __init__(
         self,
         model: str,
@@ -183,23 +191,26 @@ class BaseModel:
         # concurrent requests result into httpx hanging
         self.concurrent_semaphore = asyncio.Semaphore(concurrent_requests_limit)
 
-        # Optional aiohttp fast-path. The default litellm.acompletion
-        # path goes through httpx, which is a pure-Python HTTP
-        # implementation -- at 5k+ concurrent connections it becomes
-        # the GIL-bound bottleneck (~95% of single-core CPU in the
-        # async loop, per py-spy). The OpenAI SDK natively supports
-        # an aiohttp transport via DefaultAioHttpClient. aiohttp's
-        # request/response parsing is C-extension backed, so the
-        # same workload runs at <5% CPU on the same hardware.
+        # Native aiohttp fast-path (DEFAULT for OpenAI-compatible
+        # providers). The litellm.acompletion path goes through httpx,
+        # a pure-Python HTTP implementation -- at 5k+ concurrent
+        # connections it becomes the GIL-bound bottleneck (~95% of
+        # single-core CPU in the async loop, per py-spy). The OpenAI
+        # SDK natively supports an aiohttp transport via
+        # DefaultAioHttpClient. aiohttp's request/response parsing is
+        # C-extension backed, so the same workload runs at <5% CPU on
+        # the same hardware.
         #
-        # Set NEMO_SKILLS_OPENAI_AIOHTTP=1 to enable. Only the
-        # non-streaming chat endpoint goes through this path; text
-        # completions, streaming, the responses API, and
-        # non-OpenAI-shaped providers (gemini, azure, etc.) still
-        # use litellm -- since this transport assumes an
-        # OpenAI-compatible HTTP API at self.base_url.
+        # Enabled by default for providers with SUPPORTS_NATIVE_OPENAI
+        # (openai, vllm, sglang). Both the non-streaming and streaming
+        # chat endpoints go through this path; text completions, the
+        # responses API, and non-OpenAI-shaped providers (gemini,
+        # azure, megatron, multimodal) still use litellm. Set
+        # NEMO_SKILLS_OPENAI_AIOHTTP=0 to force everything back onto
+        # litellm/httpx.
         self._async_openai_client = None
-        if os.environ.get("NEMO_SKILLS_OPENAI_AIOHTTP") == "1":
+        native_enabled = os.environ.get("NEMO_SKILLS_OPENAI_AIOHTTP", "1") != "0"
+        if native_enabled and self.SUPPORTS_NATIVE_OPENAI:
             try:
                 from openai import AsyncOpenAI, DefaultAioHttpClient
 
@@ -229,10 +240,18 @@ class BaseModel:
                     # rebuild the request and double-count
                     # concurrent_semaphore holds.
                 )
-            except ImportError:
+            except Exception as e:
+                # ImportError if openai[aiohttp] isn't installed, but the
+                # DefaultAioHttpClient constructor can also raise other errors
+                # when the aiohttp extra is only partially present. Degrade to
+                # litellm/httpx rather than failing model construction.
                 LOG.warning(
-                    "NEMO_SKILLS_OPENAI_AIOHTTP=1 but openai[aiohttp] is not installed; falling back to litellm/httpx."
+                    "Native AsyncOpenAI aiohttp fast-path unavailable (%s: %s); "
+                    "falling back to litellm/httpx. Install openai[aiohttp] to enable it.",
+                    type(e).__name__,
+                    e,
                 )
+                self._async_openai_client = None
 
     def _get_api_key(self, api_key: str | None, api_key_env_var: str | None, base_url: str) -> str | None:
         if api_key:  # explicit cmd argument always takes precedence
@@ -248,8 +267,11 @@ class BaseModel:
         return api_key
 
     def __del__(self):
-        if self._tunnel:
-            self._tunnel.stop()
+        # getattr guard: __del__ can fire on an instance whose __init__ raised
+        # (or never ran), before _tunnel was set.
+        tunnel = getattr(self, "_tunnel", None)
+        if tunnel:
+            tunnel.stop()
 
     def _maybe_apply_stop_phrase_removal(
         self, result: dict, remove_stop_phrases: bool, stop_phrases: list[str] | None
@@ -404,15 +426,14 @@ class BaseModel:
                         request_params = self._build_chat_request_params(messages=prompt, stream=stream, **kwargs)
                         self._apply_routing_keys(request_params, cache_key)
                         # Fast path: native AsyncOpenAI + aiohttp transport,
-                        # set up in __init__ when NEMO_SKILLS_OPENAI_AIOHTTP=1.
-                        # Skips litellm's httpx-based dispatch which is the
-                        # dominant single-core CPU consumer at high
-                        # concurrency. Only the non-streaming chat endpoint
-                        # is routed here; everything else falls through to
-                        # litellm so we don't have to reimplement the full
-                        # transport surface for streaming, responses API,
-                        # text completions, or non-OpenAI providers.
-                        use_native = self._async_openai_client is not None and not stream
+                        # set up in __init__ for OpenAI-compatible providers
+                        # (disable with NEMO_SKILLS_OPENAI_AIOHTTP=0). Skips
+                        # litellm's httpx-based dispatch which is the dominant
+                        # single-core CPU consumer at high concurrency. Both
+                        # streaming and non-streaming chat are routed here; the
+                        # responses API, text completions, and non-OpenAI
+                        # providers still fall through to litellm.
+                        use_native = self._async_openai_client is not None
                         if use_native:
                             native_params = {
                                 k: v
@@ -556,6 +577,23 @@ class BaseModel:
 
         return result
 
+    @staticmethod
+    def _extract_reasoning(message_or_delta) -> str | None:
+        """Return reasoning text from an OpenAI chat message or streaming delta,
+        tolerating both field names.
+
+        vLLM historically exposed reasoning as `reasoning_content`; newer vLLM
+        versions expose it as `reasoning`. litellm normalizes these to
+        `reasoning_content` for us, but the native AsyncOpenAI fast-path sees
+        vLLM's raw field unchanged -- so we accept either here. Prefers
+        `reasoning_content` when both are present.
+        """
+        for attr in ("reasoning_content", "reasoning"):
+            value = getattr(message_or_delta, attr, None)
+            if value:
+                return value
+        return None
+
     def _parse_chat_completion_response(self, response, include_response: bool = False, **kwargs) -> dict:
         choice = response.choices[0]
         output = choice.message.content
@@ -567,9 +605,10 @@ class BaseModel:
         elif getattr(response.usage, "input_tokens", None) is not None:
             result["num_input_tokens"] = response.usage.input_tokens
 
-        # Add reasoning_content if available
-        if hasattr(choice.message, "reasoning_content") and choice.message.reasoning_content:
-            result["reasoning_content"] = choice.message.reasoning_content
+        # Add reasoning_content if available (accepts .reasoning or .reasoning_content)
+        reasoning = self._extract_reasoning(choice.message)
+        if reasoning:
+            result["reasoning_content"] = reasoning
 
         # Dump the full usage object verbatim into the output. Keeping
         # None-valued fields (rather than excluding them) preserves the
@@ -653,12 +692,8 @@ class BaseModel:
         """Process a single chat chunk and return data to yield."""
         if hasattr(chunk.choices[0], "delta"):
             cur_delta = chunk.choices[0].delta.content
-            # Check for reasoning_content in delta
-            reasoning_delta = (
-                getattr(chunk.choices[0].delta, "reasoning_content", None)
-                if hasattr(chunk.choices[0].delta, "reasoning_content")
-                else None
-            )
+            # Check for reasoning in delta (accepts .reasoning or .reasoning_content)
+            reasoning_delta = self._extract_reasoning(chunk.choices[0].delta)
             tool_calls_delta = getattr(chunk.choices[0].delta, "tool_calls", None)
         else:
             cur_delta = chunk.choices[0].text
@@ -751,6 +786,12 @@ class BaseModel:
 
     async def _stream_chat_chunks_async(self, response):
         async for chunk in response:
+            # Some servers emit chunks with no choices (e.g. a trailing
+            # usage-only chunk when stream_options.include_usage is set, or
+            # keepalive chunks). They carry no delta -- skip them so
+            # _process_chat_chunk's choices[0] access stays safe.
+            if not getattr(chunk, "choices", None):
+                continue
             results = self._process_chat_chunk(chunk)
             for result in results:
                 yield result

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -15,6 +15,7 @@ import abc
 import asyncio
 import logging
 import os
+import uuid
 from enum import Enum
 from typing import Union
 
@@ -301,6 +302,31 @@ class BaseModel:
     def _build_responses_request_params(self, **kwargs) -> dict:
         raise NotImplementedError("Responses completion is not not supported or implemented for this model.")
 
+    @staticmethod
+    def _apply_routing_keys(request_params: dict, cache_key: str | None) -> None:
+        """Attach the nmux pull-queue routing keys. No-op semantics elsewhere —
+        a plain OpenAI/vLLM/gemini endpoint just ignores (or echoes) them.
+
+          * `X-Request-Id` (extra_headers) = per-request IDEMPOTENCY. If a retry
+            resends the same id the nmux gateway re-attaches to the in-flight job
+            instead of duplicating it. The OpenAI SDK reuses request options across
+            its internal retry loop, so one id per logical call stays stable across
+            those attempts; distinct calls (incl. parallel samples) get distinct
+            ids → distinct jobs.
+          * `prompt_cache_key` (opt-in via `cache_key`) = prefix-cache AFFINITY.
+            Requests sharing a cache_key route to the SAME replica to reuse its KV
+            cache (multi-turn conversations, or single-turn requests sharing a long
+            prefix). Omitted when cache_key is None — the gateway then infers
+            affinity for multi-turn and lets unique single requests spread.
+
+        Decoupled on purpose: prompt_cache_key is meant to be SHARED across distinct
+        requests, so it must NOT double as the idempotency key (that made branches
+        re-attach to a sibling's job). See multiplexer docs/plans/MULTI_TURN_AFFINITY.md.
+        """
+        request_params.setdefault("extra_headers", {}).setdefault("X-Request-Id", str(uuid.uuid4()))
+        if cache_key is not None:
+            request_params["prompt_cache_key"] = cache_key
+
     @with_context_retry
     async def generate_async(
         self,
@@ -323,6 +349,7 @@ class BaseModel:
         include_response: bool = False,
         extra_body: dict = None,
         response_format=None,
+        cache_key: str | None = None,
     ) -> dict:
         if endpoint_type is None:
             # Infering completion type from prompt
@@ -375,6 +402,7 @@ class BaseModel:
                     if endpoint_type == EndpointType.chat:
                         assert isinstance(prompt, list), "Chat completion requests must be a list of messages."
                         request_params = self._build_chat_request_params(messages=prompt, stream=stream, **kwargs)
+                        self._apply_routing_keys(request_params, cache_key)
                         # Fast path: native AsyncOpenAI + aiohttp transport,
                         # set up in __init__ when NEMO_SKILLS_OPENAI_AIOHTTP=1.
                         # Skips litellm's httpx-based dispatch which is the
@@ -416,6 +444,7 @@ class BaseModel:
                     elif endpoint_type == EndpointType.text:
                         assert isinstance(prompt, str), "Text completion requests must be a string."
                         request_params = self._build_completion_request_params(prompt=prompt, stream=stream, **kwargs)
+                        self._apply_routing_keys(request_params, cache_key)
                         response = await litellm.atext_completion(**request_params, **self.litellm_kwargs)
                         if stream:
                             result = self._stream_completion_chunks_async(response)
@@ -426,6 +455,7 @@ class BaseModel:
                     elif endpoint_type == EndpointType.responses:
                         assert isinstance(prompt, list), "Responses completion requests must be a list."
                         request_params = self._build_responses_request_params(input=prompt, stream=stream, **kwargs)
+                        self._apply_routing_keys(request_params, cache_key)
                         response = await litellm.aresponses(**request_params, **self.litellm_kwargs)
                         if stream:
                             raise NotImplementedError("Streaming responses is not supported yet.")

--- a/nemo_skills/inference/model/base.py
+++ b/nemo_skills/inference/model/base.py
@@ -182,6 +182,57 @@ class BaseModel:
         # concurrent requests result into httpx hanging
         self.concurrent_semaphore = asyncio.Semaphore(concurrent_requests_limit)
 
+        # Optional aiohttp fast-path. The default litellm.acompletion
+        # path goes through httpx, which is a pure-Python HTTP
+        # implementation -- at 5k+ concurrent connections it becomes
+        # the GIL-bound bottleneck (~95% of single-core CPU in the
+        # async loop, per py-spy). The OpenAI SDK natively supports
+        # an aiohttp transport via DefaultAioHttpClient. aiohttp's
+        # request/response parsing is C-extension backed, so the
+        # same workload runs at <5% CPU on the same hardware.
+        #
+        # Set NEMO_SKILLS_OPENAI_AIOHTTP=1 to enable. Only the
+        # non-streaming chat endpoint goes through this path; text
+        # completions, streaming, the responses API, and
+        # non-OpenAI-shaped providers (gemini, azure, etc.) still
+        # use litellm -- since this transport assumes an
+        # OpenAI-compatible HTTP API at self.base_url.
+        self._async_openai_client = None
+        if os.environ.get("NEMO_SKILLS_OPENAI_AIOHTTP") == "1":
+            try:
+                from openai import AsyncOpenAI, DefaultAioHttpClient
+
+                # openai SDK defaults the aiohttp connector to
+                # max_connections=1000, max_keepalive_connections=100,
+                # which silently caps the lane count at high
+                # concurrency (8k lanes see only ~1000 open TCP
+                # connections; the rest stall in the aiohttp connector
+                # queue). Also, httpx-aiohttp's transport translates
+                # httpx.Limits(max_connections=None) to "omit the
+                # `limit` kwarg," which makes aiohttp fall back to ITS
+                # default of 100 -- worse than the openai SDK
+                # default. We therefore pass an explicit large
+                # integer (NEMO_SKILLS_OPENAI_AIOHTTP_LIMIT, default
+                # 65536) instead of None.
+                aiohttp_limit = int(os.environ.get("NEMO_SKILLS_OPENAI_AIOHTTP_LIMIT", "65536"))
+                self._async_openai_client = AsyncOpenAI(
+                    api_key=api_key,
+                    base_url=self.base_url,
+                    http_client=DefaultAioHttpClient(
+                        limits=httpx.Limits(
+                            max_connections=aiohttp_limit,
+                            max_keepalive_connections=aiohttp_limit,
+                        ),
+                    ),
+                    max_retries=0,  # we own retries; SDK's retry would
+                    # rebuild the request and double-count
+                    # concurrent_semaphore holds.
+                )
+            except ImportError:
+                LOG.warning(
+                    "NEMO_SKILLS_OPENAI_AIOHTTP=1 but openai[aiohttp] is not installed; falling back to litellm/httpx."
+                )
+
     def _get_api_key(self, api_key: str | None, api_key_env_var: str | None, base_url: str) -> str | None:
         if api_key:  # explicit cmd argument always takes precedence
             return api_key
@@ -324,7 +375,38 @@ class BaseModel:
                     if endpoint_type == EndpointType.chat:
                         assert isinstance(prompt, list), "Chat completion requests must be a list of messages."
                         request_params = self._build_chat_request_params(messages=prompt, stream=stream, **kwargs)
-                        response = await litellm.acompletion(**request_params, **self.litellm_kwargs)
+                        # Fast path: native AsyncOpenAI + aiohttp transport,
+                        # set up in __init__ when NEMO_SKILLS_OPENAI_AIOHTTP=1.
+                        # Skips litellm's httpx-based dispatch which is the
+                        # dominant single-core CPU consumer at high
+                        # concurrency. Only the non-streaming chat endpoint
+                        # is routed here; everything else falls through to
+                        # litellm so we don't have to reimplement the full
+                        # transport surface for streaming, responses API,
+                        # text completions, or non-OpenAI providers.
+                        use_native = self._async_openai_client is not None and not stream
+                        if use_native:
+                            native_params = {
+                                k: v
+                                for k, v in request_params.items()
+                                # litellm-only knobs we strip before
+                                # handing the body to AsyncOpenAI. The
+                                # SDK validates against the OpenAI
+                                # schema and rejects unknown top-level
+                                # fields.
+                                if k not in ("allowed_openai_params",)
+                            }
+                            # AsyncOpenAI needs `model` as a top-level
+                            # kwarg; litellm consumes it via
+                            # self.litellm_kwargs (with the `openai/`
+                            # provider prefix). Use the raw model name
+                            # here.
+                            native_params.setdefault("model", self.model_name_or_path)
+                            response = await self._async_openai_client.chat.completions.create(
+                                **native_params,
+                            )
+                        else:
+                            response = await litellm.acompletion(**request_params, **self.litellm_kwargs)
                         if stream:
                             result = self._stream_chat_chunks_async(response)
                         else:

--- a/nemo_skills/inference/model/openai.py
+++ b/nemo_skills/inference/model/openai.py
@@ -15,7 +15,6 @@
 import copy
 import os
 import re
-import uuid
 
 from .base import BaseModel
 
@@ -130,15 +129,12 @@ class OpenAIModel(BaseModel):
             "stream": stream,
             "tools": tools,
             "response_format": response_format,
-            # Per-call idempotency hint. The OpenAI SDK reuses the same
-            # request body across its internal retry loop, so this UUID
-            # stays stable across attempts of one logical request.
-            # Downstream services that dedup by prompt_cache_key see the
-            # same value across SDK-internal retries and can re-attach
-            # to the in-flight request instead of starting a duplicate.
-            # On real OpenAI this is just a prompt-cache lookup hint —
-            # a unique UUID means no cache hit, a minor perf cost.
-            "prompt_cache_key": str(uuid.uuid4()),
+            # NOTE: idempotency (X-Request-Id) and prefix-cache affinity
+            # (prompt_cache_key, opt-in via generate_async(cache_key=...)) are
+            # attached centrally in BaseModel._apply_routing_keys. We deliberately
+            # do NOT set a per-request-UUID prompt_cache_key here: that would give
+            # every request a unique affinity key and defeat cross-request prefix
+            # caching. See multiplexer docs/plans/MULTI_TURN_AFFINITY.md.
         }
 
         if self._is_reasoning_model(self.model):

--- a/nemo_skills/inference/model/openai.py
+++ b/nemo_skills/inference/model/openai.py
@@ -15,6 +15,7 @@
 import copy
 import os
 import re
+import uuid
 
 from .base import BaseModel
 
@@ -129,6 +130,15 @@ class OpenAIModel(BaseModel):
             "stream": stream,
             "tools": tools,
             "response_format": response_format,
+            # Per-call idempotency hint. The OpenAI SDK reuses the same
+            # request body across its internal retry loop, so this UUID
+            # stays stable across attempts of one logical request.
+            # Downstream services that dedup by prompt_cache_key see the
+            # same value across SDK-internal retries and can re-attach
+            # to the in-flight request instead of starting a duplicate.
+            # On real OpenAI this is just a prompt-cache lookup hint —
+            # a unique UUID means no cache hit, a minor perf cost.
+            "prompt_cache_key": str(uuid.uuid4()),
         }
 
         if self._is_reasoning_model(self.model):

--- a/nemo_skills/inference/model/openai.py
+++ b/nemo_skills/inference/model/openai.py
@@ -20,6 +20,10 @@ from .base import BaseModel
 
 
 class OpenAIModel(BaseModel):
+    # OpenAI-compatible /v1/chat/completions endpoint -- eligible for the
+    # native AsyncOpenAI + aiohttp fast-path (see BaseModel.__init__).
+    SUPPORTS_NATIVE_OPENAI = True
+
     def __init__(
         self,
         host: str = "127.0.0.1",

--- a/nemo_skills/inference/model/vllm.py
+++ b/nemo_skills/inference/model/vllm.py
@@ -91,6 +91,11 @@ def process_image_content(content: list | str | None, data_dir: str = "") -> lis
 
 
 class VLLMModel(BaseModel):
+    # vLLM (and sglang, which subclasses this) serve an OpenAI-compatible
+    # /v1/chat/completions API -- eligible for the native AsyncOpenAI +
+    # aiohttp fast-path (see BaseModel.__init__).
+    SUPPORTS_NATIVE_OPENAI = True
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/nemo_skills/inference/model/vllm_multimodal.py
+++ b/nemo_skills/inference/model/vllm_multimodal.py
@@ -69,6 +69,11 @@ class VLLMMultimodalModel(VLLMModel):
         )
     """
 
+    # Audio/VLM request rewriting and response post-processing go through
+    # litellm; keep this off the native fast-path until it's verified for
+    # multimodal payloads. Overrides VLLMModel's True.
+    SUPPORTS_NATIVE_OPENAI = False
+
     def __init__(
         self,
         model: str | None = None,

--- a/nemo_skills/pipeline/utils/cluster.py
+++ b/nemo_skills/pipeline/utils/cluster.py
@@ -215,6 +215,16 @@ def get_env_variables(cluster_config):
         "HF_TOKEN",
         "NGC_API_KEY",
     }
+    # Auto-passthrough for NEMO_SKILLS_* runtime tuning vars set in
+    # the user's shell. Without this, opt-in env knobs like
+    # NEMO_SKILLS_OPENAI_AIOHTTP, NEMO_SKILLS_DISABLE_UVLOOP, and
+    # NEMO_SKILLS_TRANSIENT_RETRIES are stripped when the launcher
+    # spawns the inner python -- they only live in the wrapper
+    # shell. Scoping by prefix keeps the surface tight (no risk of
+    # accidentally exporting unrelated user env).
+    for name in os.environ:
+        if name.startswith("NEMO_SKILLS_") and name not in optional_env_vars_to_add:
+            optional_env_vars_to_add.add(name)
     default_factories = {
         "HF_TOKEN": lambda: str(token) if (token := get_token()) else "",
     }

--- a/tests/test_native_openai_path.py
+++ b/tests/test_native_openai_path.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the native AsyncOpenAI + aiohttp fast-path in BaseModel.
+
+Covers the three feature-completion items:
+  1. Native path is the DEFAULT for OpenAI-compatible providers and can be
+     disabled with NEMO_SKILLS_OPENAI_AIOHTTP=0; non-OpenAI providers never
+     use it.
+  2. Reasoning content is read from BOTH `.reasoning` and `.reasoning_content`
+     (litellm normalizes this for us; the native path sees vLLM's raw field).
+  3. Streaming is routed through the native path and tolerates chunks with no
+     choices.
+
+These are pure unit tests -- no server or network access.
+"""
+
+import asyncio
+import types
+
+import openai
+import pytest
+
+from nemo_skills.inference.model.azure import AzureOpenAIModel
+from nemo_skills.inference.model.base import BaseModel
+from nemo_skills.inference.model.gemini import GeminiModel
+from nemo_skills.inference.model.megatron import MegatronModel
+from nemo_skills.inference.model.openai import OpenAIModel
+from nemo_skills.inference.model.sglang import SGLangModel
+from nemo_skills.inference.model.vllm import VLLMModel
+from nemo_skills.inference.model.vllm_multimodal import VLLMMultimodalModel
+
+
+# ---------------------------------------------------------------------------
+# Item 2: reasoning extraction accepts both field names
+# ---------------------------------------------------------------------------
+def test_extract_reasoning_from_reasoning_content():
+    obj = types.SimpleNamespace(reasoning_content="thinking")
+    assert BaseModel._extract_reasoning(obj) == "thinking"
+
+
+def test_extract_reasoning_from_reasoning():
+    # New vLLM field name; only `.reasoning` present.
+    obj = types.SimpleNamespace(reasoning="thinking")
+    assert BaseModel._extract_reasoning(obj) == "thinking"
+
+
+def test_extract_reasoning_prefers_reasoning_content():
+    obj = types.SimpleNamespace(reasoning_content="primary", reasoning="secondary")
+    assert BaseModel._extract_reasoning(obj) == "primary"
+
+
+def test_extract_reasoning_absent_or_empty():
+    assert BaseModel._extract_reasoning(types.SimpleNamespace()) is None
+    assert BaseModel._extract_reasoning(types.SimpleNamespace(reasoning="", reasoning_content="")) is None
+
+
+class _FakeUsage:
+    completion_tokens = 5
+    prompt_tokens = 3
+
+    def model_dump(self):
+        return {"completion_tokens": 5, "prompt_tokens": 3, "total_tokens": 8}
+
+
+class _FakeChoice:
+    def __init__(self, message):
+        self.message = message
+        self.finish_reason = "stop"
+
+    def model_dump(self):
+        return {"message": {"role": "assistant", "content": self.message.content}}
+
+
+class _FakeResponse:
+    def __init__(self, message):
+        self.choices = [_FakeChoice(message)]
+        self.usage = _FakeUsage()
+
+
+def test_parse_chat_completion_reads_reasoning_field():
+    # A response carrying ONLY `.reasoning` (as newer vLLM emits over the raw
+    # OpenAI schema) must still populate reasoning_content in the result.
+    inst = BaseModel.__new__(BaseModel)
+    message = types.SimpleNamespace(content="the answer", reasoning="the thinking")
+    result = inst._parse_chat_completion_response(_FakeResponse(message))
+    assert result["generation"] == "the answer"
+    assert result["reasoning_content"] == "the thinking"
+    assert result["num_generated_tokens"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Item 3: streaming chunk parsing (reasoning + empty-choices guard)
+# ---------------------------------------------------------------------------
+def test_process_chat_chunk_reads_reasoning_field():
+    inst = BaseModel.__new__(BaseModel)
+    delta = types.SimpleNamespace(content="hi", reasoning="step")
+    chunk = types.SimpleNamespace(choices=[types.SimpleNamespace(delta=delta, finish_reason=None)])
+    [result] = inst._process_chat_chunk(chunk)
+    assert result["generation"] == "hi"
+    assert result["reasoning_content"] == "step"
+
+
+def test_stream_skips_empty_choices_chunk():
+    inst = BaseModel.__new__(BaseModel)
+
+    async def fake_stream():
+        # usage-only / keepalive chunk with no choices -- must be skipped
+        yield types.SimpleNamespace(choices=[])
+        yield types.SimpleNamespace(
+            choices=[types.SimpleNamespace(delta=types.SimpleNamespace(content="hello"), finish_reason=None)]
+        )
+
+    async def collect():
+        return [r async for r in inst._stream_chat_chunks_async(fake_stream())]
+
+    results = asyncio.run(collect())
+    assert results == [{"generation": "hello"}]
+
+
+# ---------------------------------------------------------------------------
+# Item 1: which providers are eligible for the native fast-path
+# ---------------------------------------------------------------------------
+def test_native_eligibility_by_provider():
+    assert BaseModel.SUPPORTS_NATIVE_OPENAI is False
+    # OpenAI-compatible endpoints opt in.
+    assert OpenAIModel.SUPPORTS_NATIVE_OPENAI is True
+    assert VLLMModel.SUPPORTS_NATIVE_OPENAI is True
+    assert SGLangModel.SUPPORTS_NATIVE_OPENAI is True
+    # Non-OpenAI-shaped endpoints stay on litellm.
+    assert AzureOpenAIModel.SUPPORTS_NATIVE_OPENAI is False
+    assert GeminiModel.SUPPORTS_NATIVE_OPENAI is False
+    assert MegatronModel.SUPPORTS_NATIVE_OPENAI is False
+    assert VLLMMultimodalModel.SUPPORTS_NATIVE_OPENAI is False
+
+
+class _DummyAioHttpClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class _DummyAsyncOpenAI:
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+
+
+@pytest.fixture
+def _mock_openai_client(monkeypatch):
+    # Avoid needing the real openai[aiohttp] transport / a live endpoint.
+    monkeypatch.setattr(openai, "AsyncOpenAI", _DummyAsyncOpenAI, raising=False)
+    monkeypatch.setattr(openai, "DefaultAioHttpClient", _DummyAioHttpClient, raising=False)
+
+
+def test_native_client_on_by_default(monkeypatch, _mock_openai_client):
+    monkeypatch.delenv("NEMO_SKILLS_OPENAI_AIOHTTP", raising=False)
+    model = VLLMModel(model="test-model", base_url="http://localhost:9999/v1")
+    assert isinstance(model._async_openai_client, _DummyAsyncOpenAI)
+
+
+def test_native_client_opt_out(monkeypatch, _mock_openai_client):
+    monkeypatch.setenv("NEMO_SKILLS_OPENAI_AIOHTTP", "0")
+    model = VLLMModel(model="test-model", base_url="http://localhost:9999/v1")
+    assert model._async_openai_client is None
+
+
+def test_native_client_off_for_ineligible_provider(monkeypatch, _mock_openai_client):
+    monkeypatch.delenv("NEMO_SKILLS_OPENAI_AIOHTTP", raising=False)
+
+    class _NoNative(VLLMModel):
+        SUPPORTS_NATIVE_OPENAI = False
+
+    model = _NoNative(model="test-model", base_url="http://localhost:9999/v1")
+    assert model._async_openai_client is None

--- a/tests/test_prompt_cache_routing.py
+++ b/tests/test_prompt_cache_routing.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the nmux pull-queue routing keys attached by BaseModel.
+
+Idempotency (X-Request-Id) and prefix-cache affinity (prompt_cache_key) are
+DECOUPLED: X-Request-Id is per-request (distinct jobs / safe retries),
+prompt_cache_key is opt-in and SHARED across requests that should co-locate.
+See multiplexer docs/plans/MULTI_TURN_AFFINITY.md.
+"""
+
+from nemo_skills.inference.model.base import BaseModel
+
+
+def test_idempotency_header_always_set_affinity_opt_in():
+    # No cache_key → X-Request-Id present (idempotency), prompt_cache_key OMITTED
+    # so the gateway infers affinity (multi-turn) / lets unique requests spread.
+    params = {}
+    BaseModel._apply_routing_keys(params, None)
+    assert "prompt_cache_key" not in params
+    xid = params["extra_headers"]["X-Request-Id"]
+    assert isinstance(xid, str) and len(xid) >= 16
+
+
+def test_cache_key_sets_prompt_cache_key():
+    params = {}
+    BaseModel._apply_routing_keys(params, "conv-1")
+    assert params["prompt_cache_key"] == "conv-1"
+    assert params["extra_headers"]["X-Request-Id"]
+
+
+def test_shared_affinity_distinct_request_ids():
+    # The branching/multi-sample invariant: same cache_key → co-locate (shared
+    # prefill), but each call gets a DISTINCT X-Request-Id → distinct jobs.
+    p1, p2 = {}, {}
+    BaseModel._apply_routing_keys(p1, "conv-1")
+    BaseModel._apply_routing_keys(p2, "conv-1")
+    assert p1["prompt_cache_key"] == p2["prompt_cache_key"] == "conv-1"
+    assert p1["extra_headers"]["X-Request-Id"] != p2["extra_headers"]["X-Request-Id"]
+
+
+def test_preserves_existing_headers_and_does_not_override_request_id():
+    # setdefault semantics: a caller-set X-Request-Id (e.g. for app-level retry
+    # idempotency) and other headers survive.
+    params = {"extra_headers": {"X-Custom": "v", "X-Request-Id": "preset"}}
+    BaseModel._apply_routing_keys(params, None)
+    assert params["extra_headers"]["X-Custom"] == "v"
+    assert params["extra_headers"]["X-Request-Id"] == "preset"


### PR DESCRIPTION
## Summary

Makes `ns generate` scale cleanly to high concurrency (5k+ in-flight requests) against OpenAI-compatible endpoints. At high concurrency the old litellm/httpx dispatch was the GIL-bound bottleneck (~95% of a single core in the async loop, per py-spy); this branch moves the hot path onto a C-extension-backed aiohttp transport and removes the per-completion write/postprocess serialization in the generate loop. It also adds optional, provider-agnostic request-routing keys that a proxy/gateway may use (a plain endpoint ignores them).

The fast path is the **default** and is correct for current vLLM (reasoning field rename) and streaming.

## What's included

**Native AsyncOpenAI + aiohttp fast-path** (`model/base.py`)
- Routes non-streaming **and** streaming chat through a native `AsyncOpenAI` client using the `DefaultAioHttpClient` (aiohttp) transport, bypassing litellm's httpx dispatch.
- **Default-on** for OpenAI-compatible providers, gated by a new `SUPPORTS_NATIVE_OPENAI` class attribute → enabled for `openai`/`vllm`/`sglang`; `azure`, `gemini`, `megatron`, and multimodal stay on litellm. Disable with `NEMO_SKILLS_OPENAI_AIOHTTP=0`.
- Reasoning content is read from **both** `.reasoning` (newer vLLM) and `.reasoning_content` (older) — litellm normalized this for us, but the native path sees vLLM's raw field.
- Transient socket-error retries with backoff; extended httpx client TTL patch to survive long high-concurrency runs.

**Scalable async loop** (`inference/generate.py`)
- Bounded worker pool (memory O(in_flight), not O(total inputs)) with a rate-limited connection ramp (`ramp_rate_per_sec`, default 4000) to avoid overflowing the kernel accept queue on prime.
- Dedicated batched **writer task** (flush per batch) instead of a per-completion `fout` lock.
- Separate **postprocess/eval processor pool** (`postprocess_workers`, default 16) so a lane frees its slot the instant the HTTP response returns.
- Installs `uvloop` when available (`NEMO_SKILLS_DISABLE_UVLOOP=1` to opt out).

**Request-routing keys** (`model/base.py`) — optional, provider-agnostic; a plain endpoint ignores them:
- `X-Request-Id`: a per-request id for idempotency/tracing, kept stable across the OpenAI SDK retry loop; distinct calls get distinct ids.
- `prompt_cache_key`: the standard OpenAI/vLLM prefix-cache hint, opt-in via `cache_key=`. Requests sharing a value hint a shared prompt prefix. Kept separate from `X-Request-Id` (shared vs per-request).

**Misc**
- Dumps the full `response.usage` dict + reasoning-token breakdown into the output.
- Auto-passthrough of `NEMO_SKILLS_*` env vars to the inner python launched by the pipeline (`pipeline/utils/cluster.py`).
- `core/requirements.txt`: `openai` → `openai[aiohttp]` so the transport is actually installed (per CONTRIBUTING, inference deps live here).

## Config / env knobs

| Knob | Default | Purpose |
|---|---|---|
| `NEMO_SKILLS_OPENAI_AIOHTTP` | `1` | Native fast-path; `0` forces litellm |
| `NEMO_SKILLS_OPENAI_AIOHTTP_LIMIT` | `65536` | aiohttp max connections |
| `NEMO_SKILLS_TRANSIENT_RETRIES` | `3` | Socket-level retry budget |
| `NEMO_SKILLS_DISABLE_UVLOOP` | unset | Opt out of uvloop |
| `max_concurrent_requests` (cfg) | `512` | Script-level concurrency cap |
| `ramp_rate_per_sec` (cfg) | `4000` | Connection ramp on prime |
| `postprocess_workers` (cfg) | `16` | Postprocess/eval pool size |

## Testing

**Unit** (`tests/test_prompt_cache_routing.py`, `tests/test_native_openai_path.py` — 15 tests): routing-key idempotency/affinity decoupling; reasoning extraction from both field names; stream + non-stream parsing; empty-`choices` chunk guard; per-provider native eligibility; env-var default/opt-out.

**Live parity** (real model on an OpenAI-compatible endpoint, `nvidia/nemotron-3-nano-30b-a3b`):
- native vs litellm (`AIOHTTP=0`), × non-stream × stream → **identical** final answer; `reasoning_content` captured on all four; native transport active only by default and off with `AIOHTTP=0`.
- Streaming yields well-formed chunks (`generation`/`reasoning_content`/`finish_reason`).
- Tool-calling stream via native path → `finish_reason=tool_calls`, reassembled `get_weather({"city":"Paris"})` (the exact chunk shape `ToolCallingWrapper._stream_single` consumes).

> Reviewer note: this touches the core inference loop — worth running the SLURM GPU CI (add the **run GPU tests** label).

## Known non-blocking notes
- Streaming `num_generated_tokens` is `None` on both native and litellm paths (unchanged; `ToolCallingWrapper` counts via tokenizer). I did not enable `stream_options.include_usage`, but added the empty-`choices` guard so it's safe to turn on later.
- The native aiohttp session isn't explicitly closed at process exit (same as litellm's existing `aclient_session`); harmless since the process exits after a run.
