### PR TITLE
Add BBH (BIG-Bench Hard) benchmark

### DIFF
--- a/docs/evaluation/other-benchmarks.md
+++ b/docs/evaluation/other-benchmarks.md
@@ -4,6 +4,32 @@ More details are coming soon!
 
 ## Supported benchmarks
 
+### BBH (BIG-Bench Hard)
+
+- Benchmark is defined in [`nemo_skills/dataset/bbh/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/bbh/__init__.py)
+- Original benchmark source is [here](https://arxiv.org/abs/2210.09261) ([suzgun/BIG-Bench-Hard](https://github.com/suzgun/BIG-Bench-Hard)); data is pulled from the [`lukaemon/bbh`](https://huggingface.co/datasets/lukaemon/bbh) mirror.
+- 27 tasks, 6511 examples total. Answers are graded with exact match after extracting `\boxed{...}` (multiple-choice letters, True/False, yes/no, numbers and short strings are all handled by the `math` grader).
+- Per-task accuracy is reported via `subset_for_metrics` (the task name); the top-line metric is the average over all examples.
+- The default prompt is zero-shot boxed (`generic/general-boxed`), which follows NeMo-Skills' standardized boxed protocol rather than the original paper's 3-shot chain-of-thought exemplars.
+
+#### Data Preparation
+
+```bash
+ns prepare_data bbh
+```
+
+#### Running the Evaluation
+
+```bash
+ns eval \
+    --cluster=<CLUSTER_NAME> \
+    --model=<MODEL_PATH> \
+    --server_type=vllm \
+    --server_gpus=8 \
+    --benchmarks=bbh \
+    --output_dir=<OUTPUT_DIR>
+```
+
 ### arena-hard
 
 - Benchmark is defined in [`nemo_skills/dataset/arena-hard/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/arena-hard/__init__.py)

--- a/nemo_skills/dataset/bbh/__init__.py
+++ b/nemo_skills/dataset/bbh/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+# BBH answers are heterogeneous (multiple-choice letters, True/False, yes/no,
+# numbers, and short strings). We use the generic boxed prompt and the "math"
+# eval/metrics engine, which extracts \boxed{...} and grades letters, numbers and
+# string literals uniformly (see nemo_skills/evaluation/math_grader.py::math_equal).
+METRICS_TYPE = "math"
+GENERATION_ARGS = "++prompt_config=generic/general-boxed ++eval_type=math"

--- a/nemo_skills/dataset/bbh/prepare.py
+++ b/nemo_skills/dataset/bbh/prepare.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+# The 27 BIG-Bench Hard tasks (Suzgun et al., 2022 - https://arxiv.org/abs/2210.09261).
+TASKS = [
+    "boolean_expressions",
+    "causal_judgement",
+    "date_understanding",
+    "disambiguation_qa",
+    "dyck_languages",
+    "formal_fallacies",
+    "geometric_shapes",
+    "hyperbaton",
+    "logical_deduction_five_objects",
+    "logical_deduction_seven_objects",
+    "logical_deduction_three_objects",
+    "movie_recommendation",
+    "multistep_arithmetic_two",
+    "navigate",
+    "object_counting",
+    "penguins_in_a_table",
+    "reasoning_about_colored_objects",
+    "ruin_names",
+    "salient_translation_error_detection",
+    "snarks",
+    "sports_understanding",
+    "temporal_sequences",
+    "tracking_shuffled_objects_five_objects",
+    "tracking_shuffled_objects_seven_objects",
+    "tracking_shuffled_objects_three_objects",
+    "web_of_lies",
+    "word_sorting",
+]
+
+# Multiple-choice tasks encode the answer as a parenthesized letter, e.g. "(A)".
+# Strip the parentheses to the bare letter so the math grader's multiple-choice
+# path matches robustly whether the model boxes "A" or "(A)".
+MCQ_TARGET = re.compile(r"^\(([A-Z])\)$")
+
+
+def format_entry(entry: dict, task: str) -> dict:
+    target = str(entry["target"]).strip()
+    match = MCQ_TARGET.match(target)
+    expected_answer = match.group(1) if match else target
+    return {
+        "problem": entry["input"],
+        "expected_answer": expected_answer,
+        "subset_for_metrics": task,
+        "subtopic": task,
+    }
+
+
+def save_data(split: str):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+    output_file = data_dir / f"{split}.jsonl"
+
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for task in tqdm(TASKS, desc="Preparing BBH tasks"):
+            dataset = load_dataset("lukaemon/bbh", task)[split]
+            for entry in dataset:
+                fout.write(json.dumps(format_entry(entry, task)) + "\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=("test",),
+        help="BBH only provides a test split.",
+    )
+    args = parser.parse_args()
+
+    save_data(args.split)


### PR DESCRIPTION
## What does this PR do?

Adds **BBH (BIG-Bench Hard)** — the 27-task, 6511-example reasoning suite from [Suzgun et al., 2022](https://arxiv.org/abs/2210.09261) — to the benchmark suite. It's one of the most widely reported general-reasoning benchmarks and was not yet covered (BFCL is the closest existing benchmark, but targets tool-calling).

## Design

- **Data source:** the [`lukaemon/bbh`](https://huggingface.co/datasets/lukaemon/bbh) HF mirror of the official [suzgun/BIG-Bench-Hard](https://github.com/suzgun/BIG-Bench-Hard) repo (MIT). `prepare.py` pulls all 27 task configs and writes a single `test.jsonl`.
- **Heterogeneous answers, uniform grading:** BBH answers span multiple-choice letters, True/False, yes/no, integers and short strings. The benchmark uses the generic boxed prompt (`generic/general-boxed`) with `eval_type=math` / `METRICS_TYPE=math`, whose grader (`math_grader.py::math_equal`) already handles all of these — the single-letter MCQ path, the normalized-string fast path, and the symbolic/number path.
- **MCQ normalization:** multiple-choice targets are stored as bare letters (`"(A)" -> "A"`) so grading matches whether the model boxes `A` or `(A)`.
- **Per-task metrics:** `subset_for_metrics` is set to the task name, so per-task accuracy is reported alongside the overall average (same pattern as MMLU's subtopics).
- **Prompting protocol:** default is zero-shot boxed, consistent with NeMo-Skills' standardized boxed protocol (e.g. MMLU/GPQA) rather than the paper's 3-shot CoT exemplars. Few-shot can still be supplied via `examples_type` since `general-boxed` supports it.

## Validation (run locally on CPU)

- `prepare.py` runs end-to-end and produces **6511 examples across 27 tasks** with fields `problem`, `expected_answer`, `subset_for_metrics`, `subtopic`; no missing fields; all parenthesized MC targets normalized.
- End-to-end grading via `extract_answer` + `math_equal` scores representative cases correctly: MC (`\boxed{A}` and `\boxed{(A)}` both correct, wrong letter incorrect), booleans, yes/no, numbers, and word-sorting (exact vs. wrong order).
- `ruff check` passes; copyright headers match the current repo convention; `*.jsonl` is gitignored so no data is committed.

## Files

- `nemo_skills/dataset/bbh/__init__.py` — metrics/prompt defaults
- `nemo_skills/dataset/bbh/prepare.py` — data preparation
- `docs/evaluation/other-benchmarks.md` — benchmark entry

## Notes

- Reference accuracy numbers aren't included since I don't have a served model to run a full eval; happy to add a "Verifying Results" block if you can point me at a reference config, or a maintainer can run it.
- Docs placement (`other-benchmarks.md`) is easy to move if you'd prefer BBH under a different category.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the BBH (BIG-Bench Hard) benchmark, including dataset preparation and evaluation commands.
  * BBH data is now organized with default evaluation settings for exact-match grading and boxed-answer handling.

* **Documentation**
  * Expanded benchmark documentation with BBH details, including task coverage, source information, grading approach, and example commands for preparing data and running evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->