### PR TITLE
Add MGSM (Multilingual Grade School Math) benchmark

### DIFF
--- a/docs/evaluation/multilingual.md
+++ b/docs/evaluation/multilingual.md
@@ -7,6 +7,20 @@ Once prepared, the `ns eval` command will run on all languages prepared, and the
 
 ## Supported benchmarks
 
+### MGSM
+
+- Benchmark is defined in [`nemo_skills/dataset/mgsm/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/mgsm/__init__.py)
+- Original benchmark source is [here](https://arxiv.org/abs/2210.03057); data is pulled from the [`juletxara/mgsm`](https://huggingface.co/datasets/juletxara/mgsm) mirror.
+- 250 GSM8K test problems translated into 10 languages plus English (11 total: `en`, `es`, `fr`, `de`, `ru`, `zh`, `ja`, `th`, `sw`, `bn`, `te`).
+- Answers are integers, graded by exact match after extracting `\boxed{...}`. Per-language accuracy is reported via `subset_for_metrics`.
+- Uses a single English boxed instruction (en-CoT setting) by default. `target_language` is populated on every example, so switching `METRICS_TYPE` to `math_multilingual` (to additionally score native-language reasoning) works without changing data preparation.
+
+```bash
+ns prepare_data mgsm --languages <lang1> <lang2> ...
+```
+
+Prepare all languages by omitting `--languages`.
+
 ### mmlu-prox
 
 - Benchmark is defined in [`nemo_skills/dataset/mmlu-prox/__init__.py`](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/dataset/mmlu-prox/__init__.py)

--- a/nemo_skills/dataset/mgsm/__init__.py
+++ b/nemo_skills/dataset/mgsm/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+# MGSM (Multilingual Grade School Math): GSM8K test problems translated into 10
+# languages plus English. Answers are integers, graded by exact match after
+# extracting \boxed{...}. Per-language accuracy is reported via subset_for_metrics.
+#
+# The default prompt uses a single English boxed instruction (en-CoT setting).
+# To score native-language reasoning as well, switch METRICS_TYPE to
+# "math_multilingual" (uses target_language, already populated below) and use a
+# target-language prompt.
+METRICS_TYPE = "math"
+GENERATION_ARGS = "++prompt_config=generic/general-boxed ++eval_type=math"

--- a/nemo_skills/dataset/mgsm/prepare.py
+++ b/nemo_skills/dataset/mgsm/prepare.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+# MGSM (Shi et al., 2022 - https://arxiv.org/abs/2210.03057): 250 GSM8K test
+# problems translated into 10 languages, plus the original English. Language codes
+# are ISO 639-1 (compatible with the "math_multilingual" metric's target_language).
+LANGUAGES = ["en", "es", "fr", "de", "ru", "zh", "ja", "th", "sw", "bn", "te"]
+
+
+def format_entry(entry: dict, lang: str) -> dict:
+    return {
+        "problem": entry["question"],
+        "expected_answer": entry["answer_number"],
+        "subset_for_metrics": lang,
+        "target_language": lang,
+    }
+
+
+def save_data(split: str, languages: list[str]):
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+    output_file = data_dir / f"{split}.jsonl"
+
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for lang in tqdm(languages, desc="Preparing MGSM languages"):
+            dataset = load_dataset("juletxara/mgsm", lang)[split]
+            for entry in dataset:
+                # Non-latin scripts must be preserved, so keep ensure_ascii=False.
+                fout.write(json.dumps(format_entry(entry, lang), ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--languages",
+        default=LANGUAGES,
+        nargs="+",
+        choices=LANGUAGES,
+        help="Which language(s) to prepare. Defaults to all 11 MGSM languages.",
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=("test", "train"),
+        help="MGSM provides a test split (250 problems/language) and a small train split of few-shot exemplars.",
+    )
+    args = parser.parse_args()
+
+    save_data(args.split, args.languages)


### PR DESCRIPTION
## What does this PR do?

Adds **MGSM (Multilingual Grade School Math)** — 250 GSM8K test problems translated into 10 languages plus English ([Shi et al., 2022](https://arxiv.org/abs/2210.03057)) — to the multilingual benchmark suite. MGSM is one of the most widely reported multilingual reasoning benchmarks and was not yet covered.

## Design

- **Data source:** the [`juletxara/mgsm`](https://huggingface.co/datasets/juletxara/mgsm) HF mirror. `prepare.py` supports the standard multilingual `--languages` selector (defaults to all 11: `en, es, fr, de, ru, zh, ja, th, sw, bn, te`) and writes a single `test.jsonl` (2750 examples).
- **Grading:** integer answers, graded by exact match after extracting `\boxed{...}` (`generic/general-boxed` prompt + `eval_type=math` / `METRICS_TYPE=math`). Per-language accuracy is reported via `subset_for_metrics` (same pattern as MMLU subtopics and the `-x` multilingual benchmarks).
- **Prompting:** default is a single English boxed instruction (en-CoT). Every example also carries `target_language`, so switching `METRICS_TYPE` to `math_multilingual` (to additionally score native-language reasoning, as `aime24-x` does) requires no changes to data preparation.
- Non-Latin scripts are preserved (`ensure_ascii=False`).

## Validation (run locally on CPU)

- `prepare.py` runs end-to-end → **2750 examples across 11 languages**, 250 each; fields `problem`, `expected_answer` (int), `subset_for_metrics`, `target_language`; non-Latin scripts (zh/bn/te) preserved; no missing fields.
- `--languages en zh` correctly produces only those two languages (500 examples).
- End-to-end grading via `extract_answer` + `math_equal` scores correctly: `\boxed{18}` correct, wrong number incorrect, boxed answer after non-English text correct, and `6` ≡ `6.0`.
- `ruff check` passes; copyright headers match the current repo convention; `*.jsonl` is gitignored so no data is committed.

## Files

- `nemo_skills/dataset/mgsm/__init__.py` — metrics/prompt defaults
- `nemo_skills/dataset/mgsm/prepare.py` — data preparation (with `--languages`)
- `docs/evaluation/multilingual.md` — benchmark entry

## Notes

- Reference accuracy numbers aren't included since I don't have a served model to run a full eval; happy to add them if you can point me at a reference config, or a maintainer can run it.
- I chose the plain `math` metric (per-language accuracy, the standard MGSM number) over `math_multilingual`; the latter adds a language-consistency requirement that's less meaningful in the default en-CoT setting. Since `target_language` is already populated, switching is a one-line change if you'd prefer consistency with `aime24-x`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the multilingual MGSM benchmark in the evaluation docs.
  * Documented how answers are graded, including native-language scoring for multilingual reasoning.
  * Added a command to prepare MGSM data for specific languages, with an option to generate all languages by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->