### PR TITLE
fix(ci): drop vedas pin — package deleted from PyPI, breaks every sandbox image build

### DIFF
--- a/requirements/sandbox.lock
+++ b/requirements/sandbox.lock
@@ -2403,8 +2403,6 @@ vcs-versioning==1.1.1
     # via setuptools-scm
 vdf==3.4
     # via steam
-vedas==0.0.1
-    # via -r requirements/stem.txt
 wasabi==1.1.3
     # via
     #   spacy

--- a/requirements/stem.txt
+++ b/requirements/stem.txt
@@ -189,7 +189,6 @@ transformers
 trimesh
 typ
 utils
-vedas
 wbdata
 webcolors
 wikidata


### PR DESCRIPTION
## What / Why

`vedas==0.0.1` has been **deleted from PyPI** (both `https://pypi.org/pypi/vedas/json` and `https://pypi.org/simple/vedas/` return 404). The sandbox image build (`Dockerfile.sandbox:82`, `uv pip install -r requirements/sandbox.lock`) therefore fails with:

```
× No solution found when resolving dependencies:
╰─▶ Because vedas was not found in the package registry and you require vedas==0.0.1,
    we can conclude that your requirements are unsatisfiable.
```

This reds the **CPU tests** workflow on every PR/branch right now (first seen on run [29051295001](https://github.com/NVIDIA-NeMo/Skills/actions/runs/29051295001) — the failure is in Build Images, before any test runs, and the failing lock line is identical on `main`).

## Fix

Remove the entry: nothing in the repo imports `vedas` (zero `import vedas` / `from vedas` hits); it was an unpinned line in `requirements/stem.txt` swept into `sandbox.lock`. 3 deleted lines total.

## Impact

Unblocks CI repo-wide, including the in-review #1479 and #1507.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the unused `vedas` package from the application’s dependency list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->